### PR TITLE
Fix the printed name of the ocis component

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,5 +1,5 @@
 name: ocis
-title: oCis Documentation
+title: oCIS Documentation
 version: 'next'
 start_page: ROOT:index.adoc
 nav:

--- a/site.yml
+++ b/site.yml
@@ -1,6 +1,6 @@
 # note that this site.yml file is for local building and testing only
 site:
-  title: ownCloud oCis Documentation
+  title: ownCloud oCIS Documentation
   url: https://doc.owncloud.com
   start_page: ocis::index.adoc
 


### PR DESCRIPTION
Fixes the printed name of the component `oCis` --> `oCIS`