### PR TITLE
Updated NFS documentation

### DIFF
--- a/modules/ROOT/pages/deployment/nfs.adoc
+++ b/modules/ROOT/pages/deployment/nfs.adoc
@@ -15,7 +15,6 @@
 :nmcli-url: https://manpages.ubuntu.com/manpages/focal/man1/nmcli.1.html
 :nmtui-url: https://manpages.ubuntu.com/manpages/focal/man1/nmtui.1.html
 :rpc-statd-url: https://linux.die.net/man/8/rpc.statd
-:man-nfs-ubuntu-url: http://manpages.ubuntu.com/manpages/focal/man5/nfs.5.html
 :innodb_flush_method-url: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_flush_method
 
 :description: ownCloud recommends using NFS for any scenario when accessing Unix-based remote servers or storages other than local storage. It has solid performance and is very stable. This guide covers the official ownCloud NFS (Network File System) deployment recommendations for oCIS.
@@ -82,7 +81,7 @@ To use NFS for oCIS, you must use *NFSv4* for various reasons.
 
 == NFS Mount Options
 
-See the {nfs-man-page-url}[man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitly set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
+See the {nfs-man-page-url}[Linux man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitly set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
 
 === Mount Options to Consider
 

--- a/modules/ROOT/pages/deployment/nfs.adoc
+++ b/modules/ROOT/pages/deployment/nfs.adoc
@@ -18,13 +18,13 @@
 :man-nfs-ubuntu-url: http://manpages.ubuntu.com/manpages/focal/man5/nfs.5.html
 :innodb_flush_method-url: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_flush_method
 
-:description: ownCloud recommends using NFS for any scenario when accessing Unix based remote servers or storages other than local storage. It has solid performance and is very stable. This guide covers the official ownCloud NFS (Network File System) deployment recommendations for oCIS.
+:description: ownCloud recommends using NFS for any scenario when accessing Unix-based remote servers or storages other than local storage. It has solid performance and is very stable. This guide covers the official ownCloud NFS (Network File System) deployment recommendations for oCIS.
 
 == Introduction
 
 {description}
 
-NOTE: This guide only covers the NFS client side where ownCloud runs. Follow the server or storage vendors recommendations to configure the NFS server (storage backend).
+NOTE: This guide only covers the NFS client side where ownCloud runs. Follow the server or storage vendors' recommendations to configure the NFS server (storage back end).
 
 == NFS Prerequisites
 
@@ -34,17 +34,17 @@ See the xref:prerequisites/index.adoc#nfs_notes_prerequisites[NFS Notes] in the 
 
 It is advised to use network storage like NFS only in un-routed, switched Gigabit or higher environments.
 
-Please consider that a network stack runs in ranges of µs while a storage backend usually runs in ranges of ms.
-Any tuning considerations should therefore, beside mounting options, first be attempted on the backend storage layout side, especially under high loads.
+Consider that a network stack runs in ranges of µs while a storage back end usually runs in ranges of ms.
+Any tuning considerations, beside mounting options, should therefore be attempted first on the back end storage layout side, especially under high loads.
 
 == NFSv4 Overview
 
 To use NFS for oCIS, you must use *NFSv4* for various reasons. 
 
-* Most important, starting with NFSv4, *Extended Attributes* can be provided by the NFS server, _if implemented_. See the xref:prerequisites/index.adoc#nfs_notes_prerequisites[NFS Notes] in the prerequisites documentation for more details.
+* Most importantly, starting with NFSv4, *Extended Attributes* can be provided by the NFS server, _if implemented_. See the xref:prerequisites/index.adoc#nfs_notes_prerequisites[NFS Notes] in the prerequisites documentation for more details.
 * *Improved Security:* It {nfs-strong-security-architecture-url}[mandates a strong security architecture]. It does not require {rpc-statd-url}[rpc.statd] or {lockd-url}[lockd]. As a result, it only uses port 2049.
-* *Improved Reliability:* Uses TCP by default.
-* *Improved Performance:* It uses Multi-Component Messages, which reduce network traffic. It is capable of using a 32KB page size, compared to the default, 1024 bytes.
+* *Improved Reliability:* It uses TCP by default.
+* *Improved Performance:* It uses multi-component messages, which reduce network traffic. It is capable of using a 32KB page size, compared to the default, 1024 bytes.
 * Use of {nfs-read-write-delegations-url}[Read/Write Delegations].
 
 [caption=]
@@ -62,18 +62,18 @@ To use NFS for oCIS, you must use *NFSv4* for various reasons.
 | A single protocol with the addition of OPEN and CLOSE for security auditing
 
 | Locking
-| Lease based locking in the same protocol
+| Lease-based locking in the same protocol
 
 | Security
-| Kerberos and ACL based
+| Kerberos and ACL-based
 
 | Communication
-| Multiple operations per RPC. (Improves performance)
+| Multiple operations per RPC (improves performance)
 
 | I18N
 | UTF-8
 
-| Scalable parallel access to files distributed among multiple servers
+| Scalable parallel access to files distributed between multiple servers
 | pNFS (with NFSv4.1)
 
 | Extended Attributes
@@ -88,7 +88,7 @@ See the {man-nfs-ubuntu-url}[Ubuntu 20.04 man pages] for a detailed description 
 
 ==== _netdev
 
-Use this option to ensure that the network is enabled, before NFS attempts to mount these filesystems. This setting is essential when other services depend on the availability of the NFS storage during the start process. A service may error or not start correctly, if the mount is not ready before attempting to access its data files.
+Use this option to ensure that the network is enabled before NFS attempts to mount these filesystems. This setting is essential when other services depend on the availability of the NFS storage during the start process. A service may fail or not start correctly if the mount is not ready before attempting to access its data files.
 
 TIP: You can also use {autofs-url}[autofs], to ensure that mounts are always available before attempting to access them.
 
@@ -98,7 +98,7 @@ Using `nofail` allows the boot sequence to continue even if the drive fails to m
 
 ==== bg
 
-ownCloud recommends using this option. Determines how the mount command behaves if an attempt to mount an export fails. If the bg option is specified, a timeout or failure triggers the mount command to fork a child, which will continue to attempt mounting the export. The parent immediately returns with a zero exit code. This is known as a "background" mount. This option is useful for continuous operation without manual intervention if the network connectivity is temporarily down or the storage backend must be rebooted.
+ownCloud recommends using this option. Determines how the mount command behaves if an attempt to mount an export fails. If the bg option is specified, a timeout or failure triggers the mount command to fork a child, which will continue to attempt mounting the export. The parent immediately returns with a zero exit code. This is known as a "background" mount. This option is useful for continuous operation without manual intervention if the network connectivity is temporarily down or the storage back end must be rebooted.
 
 ==== hard
 
@@ -118,15 +118,15 @@ With the default value of _async_, the NFS client may delay sending application 
 
 ==== tcp
 
-ownCloud recommends using this option. Force using TCP as transport protocol. Alternatively you can use _proto=tcp_.
+ownCloud recommends using this option forcing the use of TCP as transport protocol. Alternatively you can use _proto=tcp_.
 
 ==== Tune the Read and Write Block Sizes
 
-The allowed block sizes are the packet chunk sizes that NFS uses when reading and writing data. The smaller the size, the greater the number of packets need to be sent to send or receive a file. Conversely, the larger the size, the fewer the number of packets need to be sent to send or receive a file. With NFS Version 3 and 4, you can set the `rsize` and `wsize` values as high as 65536, when the network transport is TCP. The default value is 32768 and must be a multiple of 4096.
+The allowed block sizes are the packet chunk sizes that NFS uses when reading and writing data. The smaller the size, the greater the number of packets needed to transfer a file. Conversely, the larger the size, the fewer the number of packets that need to be sent to transfer a file. With NFS Version 3 and 4, you can set the `rsize` and `wsize` values as high as 65536 if the network transport protocol is TCP. The default value is 32768 and must be a multiple of 4096.
 
 NOTE: Read and write size must be identical on the NFS server and client.
 
-You can find the set values by working with the output of the `mount` command on a standard server, as in the example below.
+You can find the configured values in the output of the `mount` command on a standard server, as in the example below.
 
 [source,console]
 ----
@@ -168,10 +168,10 @@ bg,nfsvers=4,wsize=65536,rsize=65536,tcp,_netdev
 === MTU (Maximum Transmission Unit) Size
 
 The MTU size dictates the maximum amount of data that can be transferred in one Ethernet frame.
-If the MTU size is too small, then regardless of the read and write block sizes, the data must still be fragmented across multiple frames.
+If the MTU size is too small, the data must still be fragmented across multiple frames regardless of the read and write block sizes.
 Keep in mind that MTU = payload (`packetsize`) + 28.
 
-==== Get the Current Set MTU Size
+==== Get the Current MTU Size
 
 You can find the current MTU size for each interface using _netstat_, _ifconfig_, _ip_, and _cat_, as in the following examples:
 
@@ -230,7 +230,7 @@ ping <your-storage-backend> -c 3 -M do -s <packetsize>
 
 ==== Get the Optimal MTU Size
 
-To get the optimal MTU size, run following command:
+To get the optimal MTU size, run the following command:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/nfs.adoc
+++ b/modules/ROOT/pages/deployment/nfs.adoc
@@ -1,1 +1,271 @@
-include::{latest-server-version}@server:admin_manual:page$installation/deployment_recommendations/nfs.adoc[leveloffset=+2]
+= Network File System (NFS) Deployment Recommendations
+:toc: right
+:toclevels: 2
+
+:ea-ietf-url: https://datatracker.ietf.org/doc/html/rfc8276
+:autofs-url: https://help.ubuntu.com/community/Autofs
+:lockd-url: https://docs.oracle.com/cd/E19455-01/806-0916/rfsrefer-9/index.html
+:mount-man-page-url: http://man7.org/linux/man-pages/man8/mount.8.html
+:netplan-docs-url: https://netplan.io/reference
+:networkmanager-url: https://help.ubuntu.com/community/NetworkManager
+:networkworld-mtu-size-issues-url: https://www.networkworld.com/article/2224654/mtu-size-issues.html
+:nfs-man-page-url: https://linux.die.net/man/5/nfs
+:nfs-read-write-delegations-url: https://tools.ietf.org/html/rfc7530#section-1.4.6
+:nfs-strong-security-architecture-url: https://tools.ietf.org/html/rfc7530#section-3 
+:nmcli-url: https://manpages.ubuntu.com/manpages/focal/man1/nmcli.1.html
+:nmtui-url: https://manpages.ubuntu.com/manpages/focal/man1/nmtui.1.html
+:rpc-statd-url: https://linux.die.net/man/8/rpc.statd
+:man-nfs-ubuntu-url: http://manpages.ubuntu.com/manpages/focal/man5/nfs.5.html
+:innodb_flush_method-url: https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_flush_method
+
+:description: ownCloud recommends using NFS for any scenario when accessing Unix based remote servers or storages other than local storage. It has solid performance and is very stable. This guide covers the official ownCloud NFS (Network File System) deployment recommendations for oCIS.
+
+== Introduction
+
+{description}
+
+NOTE: This guide only covers the NFS client side where ownCloud runs. Follow the server or storage vendors recommendations to configure the NFS server (storage backend).
+
+== NFS Prerequisites
+
+See the xref:prerequisites/index.adoc#nfs_notes_prerequisites[NFS Notes] in the prerequisites documentation for important details.
+
+== General Performance Considerations
+
+It is advised to use network storage like NFS only in un-routed, switched Gigabit or higher environments.
+
+Please consider that a network stack runs in ranges of µs while a storage backend usually runs in ranges of ms.
+Any tuning considerations should therefore, beside mounting options, first be attempted on the backend storage layout side, especially under high loads.
+
+== NFSv4 Overview
+
+To use NFS for oCIS, you must use *NFSv4* for various reasons. 
+
+* Most important, starting with NFSv4, *Extended Attributes* can be provided by the NFS server, _if implemented_. See the xref:prerequisites/index.adoc#nfs_notes_prerequisites[NFS Notes] in the prerequisites documentation for more details.
+* *Improved Security:* It {nfs-strong-security-architecture-url}[mandates a strong security architecture]. It does not require {rpc-statd-url}[rpc.statd] or {lockd-url}[lockd]. As a result, it only uses port 2049.
+* *Improved Reliability:* Uses TCP by default.
+* *Improved Performance:* It uses Multi-Component Messages, which reduce network traffic. It is capable of using a 32KB page size, compared to the default, 1024 bytes.
+* Use of {nfs-read-write-delegations-url}[Read/Write Delegations].
+
+[caption=]
+.NFSv4 Key Value Overview
+[width="100%",cols="30%,70%",options="header",]
+|===
+
+| NFSv4
+| Explanation
+
+| Exports
+| All exports can be mounted together in a directory tree structure as part of a pseudo-filesystem
+
+| Protocol
+| A single protocol with the addition of OPEN and CLOSE for security auditing
+
+| Locking
+| Lease based locking in the same protocol
+
+| Security
+| Kerberos and ACL based
+
+| Communication
+| Multiple operations per RPC. (Improves performance)
+
+| I18N
+| UTF-8
+
+| Scalable parallel access to files distributed among multiple servers
+| pNFS (with NFSv4.1)
+
+| Extended Attributes
+| Introduced by {ea-ietf-url}[IETF, December 2017]
+|===
+
+== NFS Mount Options
+
+See the {man-nfs-ubuntu-url}[Ubuntu 20.04 man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitly set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
+
+=== Mount Options to Consider
+
+==== _netdev
+
+Use this option to ensure that the network is enabled, before NFS attempts to mount these filesystems. This setting is essential when other services depend on the availability of the NFS storage during the start process. A service may error or not start correctly, if the mount is not ready before attempting to access its data files.
+
+TIP: You can also use {autofs-url}[autofs], to ensure that mounts are always available before attempting to access them.
+
+==== nofail
+
+Using `nofail` allows the boot sequence to continue even if the drive fails to mount. This can happen if the NFS server accessed is down. The boot process will continue after the mount reaches timeout. The default device timeout is 90 seconds. If the option is not set, the boot process will wait until the NFS server is available but can be manually set using the option `x-systemd.mount-timeout=<value in seconds>`.
+
+==== bg
+
+ownCloud recommends using this option. Determines how the mount command behaves if an attempt to mount an export fails. If the bg option is specified, a timeout or failure triggers the mount command to fork a child, which will continue to attempt mounting the export. The parent immediately returns with a zero exit code. This is known as a "background" mount. This option is useful for continuous operation without manual intervention if the network connectivity is temporarily down or the storage backend must be rebooted.
+
+==== hard
+
+Default value is _hard_. For business-critical NFS exports, ownCloud recommends using _hard_ mounts. ownCloud strongly discourages the use of _soft_ mounts.
+
+==== retrans
+
+Default value is 3. This option can be tuned when using option _soft_.
+
+==== timeo
+
+Default value is 600 (60 seconds). This option can be tuned when using option _soft_.
+
+==== sync/async
+
+With the default value of _async_, the NFS client may delay sending application writes to the NFS server. In other words, under normal circumstances, data written by an application may not immediately appear on the server that hosts the file. The **sync** mount option provides greater data cache coherence among clients, but at a **significant performance cost**. You may consider further tuning when using clustered server environments.
+
+==== tcp
+
+ownCloud recommends using this option. Force using TCP as transport protocol. Alternatively you can use _proto=tcp_.
+
+==== Tune the Read and Write Block Sizes
+
+The allowed block sizes are the packet chunk sizes that NFS uses when reading and writing data. The smaller the size, the greater the number of packets need to be sent to send or receive a file. Conversely, the larger the size, the fewer the number of packets need to be sent to send or receive a file. With NFS Version 3 and 4, you can set the `rsize` and `wsize` values as high as 65536, when the network transport is TCP. The default value is 32768 and must be a multiple of 4096.
+
+NOTE: Read and write size must be identical on the NFS server and client.
+
+You can find the set values by working with the output of the `mount` command on a standard server, as in the example below.
+
+[source,console]
+----
+root@server:~# mount | egrep -o rsize=[0-9]*
+----
+
+[source,plaintext]
+----
+rsize=65536
+----
+
+[source,console]
+----
+root@server:~# mount | egrep -o wsize=[0-9]*
+----
+
+[source,plaintext]
+----
+wsize=65536
+----
+
+The information can also be retrieved using the command set of your dedicated storage backend.
+Once you've determined the best sizes, set them permanently by passing the (`rsize` and `wsize`) options when mounting the share or in the share's mount configuration.
+
+.Specifying the read and write block sizes when calling mount
+[source,bash]
+----
+mount 192.168.0.104:/data /mnt -o rsize=65536,wsize=65536
+----
+
+.Example for a set of NFS mount options:
+[source,plaintext]
+----
+bg,nfsvers=4,wsize=65536,rsize=65536,tcp,_netdev
+----
+
+== Ethernet Configuration Options
+ 
+=== MTU (Maximum Transmission Unit) Size
+
+The MTU size dictates the maximum amount of data that can be transferred in one Ethernet frame.
+If the MTU size is too small, then regardless of the read and write block sizes, the data must still be fragmented across multiple frames.
+Keep in mind that MTU = payload (`packetsize`) + 28.
+
+==== Get the Current Set MTU Size
+
+You can find the current MTU size for each interface using _netstat_, _ifconfig_, _ip_, and _cat_, as in the following examples:
+
+.Retrieve interface MTU size with netstat
+[source,bash]
+----
+netstat -i
+----
+
+[source,plaintext]
+----
+Kernel Interface table
+Iface      MTU    RX-OK RX-ERR RX-DRP RX-OVR    TX-OK TX-ERR TX-DRP TX-OVR Flg
+lo       65536   363183      0      0 0        363183      0      0      0 LRU
+eth0      1500  3138292      0      0 0       2049155      0      0      0 BMR
+----
+
+.Retrieve interface MTU size with ifconfig
+[source,bash]
+----
+ifconfig| grep -i MTU
+----
+
+[source,plaintext]
+----
+lo: flags=73<UP,LOOPBACK,RUNNING>  mtu 65536
+eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
+----
+
+.Retrieve interface MTU size with ip
+[source,bash]
+----
+ip addr | grep mtu
+----
+
+[source,plaintext]
+----
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+----
+
+.Retrieve interface MTU size with cat
+[source,bash]
+----
+cat /sys/class/net/<interface>/mtu
+----
+
+==== Check for MTU Fragmentation
+
+To check if a particular packet size will be fragmented on the way to the target, run the following command:
+
+[source,bash]
+----
+ping <your-storage-backend> -c 3 -M do -s <packetsize>
+----
+
+==== Get the Optimal MTU Size
+
+To get the optimal MTU size, run following command:
+
+[source,bash]
+----
+tracepath <your-storage-backend>
+----
+
+You can expect to see output like the following:
+
+[source,console]
+----
+ 1?: [LOCALHOST]                      pmtu 1500 <1>
+ 1:  <your-storage-backend>                              0.263ms reached <2>
+ 1:  <your-storage-backend>                              0.224ms reached <3>
+     Resume: pmtu 1500 hops 1 back 1
+----
+<1> The first line with localhost shows the given MTS size.
+<2> The last line shows the optimal MTU size.
+<3> If both are identical, nothing needs to be done.
+
+==== Change Your MTU Value
+
+In case you need or want to change the MTU size, under Ubuntu eg. to 1280:
+
+* If {networkmanager-url}[NetworkManager] is managing all devices on the system, then you can use {nmtui-url}[nmtui] or {nmcli-url}[nmcli] to configure the MTU setting.
+* If NetworkManager is not managing all devices on the system, you can set the MTU to 1280 with Netplan, as in the following example.
++
+[source,yaml]
+----
+network:
+  version: 2
+  ethernets:
+    eth0:
+      mtu: 1280
+----
++
+Refer to {netplan-docs-url}[the Netplan documentation] for further information.
+
+TIP: NetworkWorld has {networkworld-mtu-size-issues-url}[an excellent overview of MTU size issues]. 

--- a/modules/ROOT/pages/deployment/nfs.adoc
+++ b/modules/ROOT/pages/deployment/nfs.adoc
@@ -82,7 +82,7 @@ To use NFS for oCIS, you must use *NFSv4* for various reasons.
 
 == NFS Mount Options
 
-See the {man-nfs-ubuntu-url}[Ubuntu 20.04 man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitly set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
+See the {nfs-man-page-url}[man pages] for a detailed description of the NFS mount options. The following options are default for NFS except if explicitly set differently when mounting: `rw`, `suid`, `dev`, `exec`, `auto`, `nouser`, and `async`.
 
 === Mount Options to Consider
 


### PR DESCRIPTION
This PR updates the NFS documentation.
It is more or less a rewrite because we cant reuse the linked version as it contains stuff that does not work or is not needed with oCIS.

Not pushed to staging