### PR TITLE
Itemize text for better readbility

### DIFF
--- a/modules/ROOT/pages/deployment/index.adoc
+++ b/modules/ROOT/pages/deployment/index.adoc
@@ -8,11 +8,10 @@
 
 {description}
 
-If you only want to play around and see what oCIS has to offer, we suggest the quick and easy
-xref:deployment/manual/manual-setup.adoc[Basic Setup].
+* If you only want to play around and see what oCIS has to offer, we suggest the quick and easy xref:deployment/manual/manual-setup.adoc[Manual Setup] section.
 
-In case you have already decided on a Docker instance with one or more containers, checkout the xref:deployment/docker/docker-setup.adoc[Setup with Docker] section.
+* In case you have already decided on a Docker instance with one or more containers, checkout the xref:deployment/docker/docker-setup.adoc[Setup with Docker] section.
 
-xref:deployment/security.adoc[Securing oCIS] should be a primary concern after you've set up your server.
+* xref:deployment/security.adoc[Securing oCIS] should be a primary concern after you've set up your server.
 
-The next steps will likely be setting up a xref:deployment/nfs.adoc[Network File System] and adding xref:extensions/index.adoc[Extensions].
+* The next steps will likely be setting up a xref:deployment/nfs.adoc[Network File System] and adding xref:extensions/index.adoc[Extensions].


### PR DESCRIPTION
Itemize the deployment overview for better readability.
Using Manual instaed of Basic setup to have the same word as it is used for the document name.