### PR TITLE
Add new document: General Info

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -1,0 +1,202 @@
+= General Info
+
+:toc: right
+
+:description: This document covers general aspects of oCIS like start modes, extensions, configuration ect. for a common understanding.
+
+== Introduction
+
+{description}
+
+The example commands shown need to be adopted depending if you are using the manual installation or a docker environment. See the xref:deployment/manual/manual-setup.adoc[Manual Setup] and the xref:deployment/docker/docker-setup.adoc[Docker Setup] for more details.  
+
+== Embedded Supervisor
+
+oCIS has an xref:architecture/index.adoc#ocis-microservice-runtime[embedded supervisor] for managing the runtime und reducing the memory footprint needed. In addition, this supervisor takes care that an extension will be restarted automatically in case it fails. When using an external supervisor like systemd, Kubernetes or others, this supervisor is not required.
+
+== Deciding the Startup Mode
+
+The following two mode types do not predefine a particular installation method like the manual or docker installation. When using Kubernetes as supervisor, the docker installation is mandatory.  
+
+Starting oCIS using the embedded supervisor::
+This mode can be used when scaling is not the primary focus and can be the case if you have a:
+* small productive environment or 
+* when you do testing and/or development
+
+Starting oCIS in unsupervised mode::
+This mode is used when _availability, scaling and the adoption to dynamically changing requirements_ have a xref:availability_scaling/index.adoc#deployment-evolution[high priority]. In this case, an external supervisor like Kubernetes is used to deploy and run oCIS with its extensions.
+
+== Start oCIS With All Predefined Extensions
+
+When you type `ocis server`, the embedded supervisor is automatically used and starts available predefined extensions automatically. The supervisor starts on port 9250 (by default) and listens for commands regarding the lifecycle of the supervised extensions.
+
+To list the started predefined extension type:
+
+[source,bash]
+----
+ocis list
+----
+
+This will print an output like:
+
+[source,plaintext]
+----
++------------------------+
+|       EXTENSION        |
++------------------------+
+| accounts               |
+| glauth                 |
+| graph                  |
+| graph-explorer         |
+| idp                    |
+| ocs                    |
+| onlyoffice             |
+| proxy                  |
+| settings               |
+| storage-authbasic      |
+| storage-authbearer     |
+| storage-frontend       |
+| storage-gateway        |
+| storage-groupsprovider |
+| storage-home           |
+| storage-metadata       |
+| storage-public-link    |
+| storage-sharing        |
+| storage-users          |
+| storage-users-provider |
+| store                  |
+| thumbnails             |
+| web                    |
+| webdav                 |
++------------------------+
+----
+
+== Managing Extensions
+
+=== List Available Extensions
+
+Type `ocis --help` to get a list of available extensions.
+
+=== Manage Instances of Extensions
+
+==== oCIS Supervised Extensions
+
+You can start, list or kill available extensions in supervised mode with the `ocis` command. _These extensions can not be instantinated and share the same PID_. To manage supervised extensions, you need to have a running `ocis server` first or an error will be thrown.
+
+NOTE: When an extension runs supervised, is killed and started again, the only way to provide / overwrite configuration values will be through an *extension config file*. This is due to the parent process has already started, and it already has its own environment.
+
+List running extensions::
+[source,bash]
+----
+ocis list
+----
+
+Kill a running extension::
+[source,bash]
+----
+ocis kill [extension name]
+----
+
+Start a extension::
+[source,bash]
+----
+ocis run [extension name]
+----
+
+==== Non Supervised Extensions
+
+You can create at any time non oCIS supervised instances of an extension with `ocis [extension name]` like `ocis proxy`. _These extensions are independent of extensions in supervised mode and have their own PID_. The Instances are managed with classical OS methods or e.g. via Kubernetes.
+
+Creating multiple instances of an extensions is used for scaling. Note that you may need configuration for and access to the instantinated extensions like with a load balancer when you scale.
+
+== Configuration of oCIS
+
+// taken from: https://owncloud.dev/ocis/config/
+
+oCIS uses a hierachical structure for its configuration, *where each element overwrites its precedent*. These are:
+
+. Environment variables
+. Extension configuration file
+. oCIS configuration file
+
+The expected loading locations are:
+
+. `$HOME/.ocis/config/`
+. `/etc/ocis/`
+. `.config/`
+
+You can define a non standard configuration file location on startup either with an:
+
+* command option (`--config-file value`) or with a
+* environment variable (`OCIS_CONFIG_FILE`)
+
+NOTE: Administrators must be aware of these sources and the order applied (the _configuration file arithmetics_). Mis-managing them can be a source of confusion leading to undesired results on the final configuration created and applied.
+
+=== Configuration File Naming
+
+The configuration files for oCIS are YAML based (a human-friendly data serialization language).
+
+The filename to define a config has following namespace:
+
+[source,plaintext]
+----
+ocis.yaml
+ or
+[extension name].yaml
+----
+
+You can list the possible extension names by typing:
+
+[source,bash]
+----
+ocis list
+----
+
+=== Starting oCIS With Environment Variables
+
+You can use environment variables to define or overwrite config parameters which will be used when starting oCIS like:
+
+[source,bash]
+----
+PROXY_HTTP_ADDR=localhost:5555 ocis server
+----
+
+or when using multiple environment variables like:
+
+[source,bash]
+----
+PROXY_HTTP_ADDR=localhost:5555 \
+PROXY_DEBUG_ADDR=localhost:6666 \
+ocis server
+----
+
+Remember the note in xref:ocis_supervised_extensions[oCIS Supervised Extensions] when killing/restarting extensions in superviced mode.
+
+=== Globally Shared Logging Values
+
+When running in supervised mode (`ocis server`), it is beneficial to have common values for logging so that the log output is correctly formatted or everything is piped to the same file without duplicating config keys and values all over the place. This is possible using the global log config key with following example:
+
+.ocis.yaml
+[source,yaml]
+----
+log:
+  level: error
+  color: true
+  pretty: true
+  file: /var/tmp/ocis_output.log
+----
+
+NOTE: In case of an extension overwriting its shared logging config that received from the main ocis.yaml file, you *MUST* specify all values.
+
+==== Log Config Keys
+
+This are the necessary log keys and the available values:
+
+[source,plaintext]
+----
+log:
+  level: [ error | warning | info | debug ]
+  color: [ true | false ]
+  pretty: [ true | false ]
+  file: [ path/to/log/file ] # MUST not be used with pretty = true
+----

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -2,17 +2,17 @@
 
 :toc: right
 
-:description: This document covers general aspects of oCIS like start modes, extensions, configuration ect. for a common understanding.
+:description: This document covers general aspects of oCIS like start modes, extensions, configuration etc. for a common understanding.
 
 == Introduction
 
 {description}
 
-The example commands shown need to be adopted depending if you are using the manual installation or a docker environment. See the xref:deployment/manual/manual-setup.adoc[Manual Setup] and the xref:deployment/docker/docker-setup.adoc[Docker Setup] for more details.  
+The example commands shown need to be adjusted depending on whether you are using the manual installation or a docker environment. See the xref:deployment/manual/manual-setup.adoc[Manual Setup] and the xref:deployment/docker/docker-setup.adoc[Docker Setup] for more details.  
 
 == Embedded Supervisor
 
-oCIS has an xref:architecture/index.adoc#ocis-microservice-runtime[embedded supervisor] for managing the runtime und reducing the memory footprint needed. In addition, this supervisor takes care that an extension will be restarted automatically in case it fails. When using an external supervisor like systemd, Kubernetes or others, this supervisor is not required.
+oCIS has an xref:architecture/index.adoc#ocis-microservice-runtime[embedded supervisor] for managing the runtime und reducing the memory footprint. In addition, this supervisor takes care that an extension will be restarted automatically if it fails. When using an external supervisor like systemd, Kubernetes or others, the embedded supervisor is not needed.
 
 == Deciding the Startup Mode
 
@@ -24,13 +24,13 @@ This mode can be used when scaling is not the primary focus and can be the case 
 * when you do testing and/or development
 
 Starting oCIS in unsupervised mode::
-This mode is used when _availability, scaling and the adoption to dynamically changing requirements_ have a xref:availability_scaling/index.adoc#deployment-evolution[high priority]. In this case, an external supervisor like Kubernetes is used to deploy and run oCIS with its extensions.
+This mode is used when _availability, scaling and the adjustment to dynamically changing requirements_ have a xref:availability_scaling/index.adoc#deployment-evolution[high priority]. In this case, an external supervisor like Kubernetes is used to deploy and run oCIS with its extensions.
 
 == Start oCIS With All Predefined Extensions
 
 When you type `ocis server`, the embedded supervisor is automatically used and starts available predefined extensions automatically. The supervisor starts on port 9250 (by default) and listens for commands regarding the lifecycle of the supervised extensions.
 
-To list the started predefined extension type:
+To list the started predefined extensions, type:
 
 [source,bash]
 ----
@@ -81,9 +81,9 @@ Type `ocis --help` to get a list of available extensions.
 
 ==== oCIS Supervised Extensions
 
-You can start, list or kill available extensions in supervised mode with the `ocis` command. _These extensions can not be instantinated and share the same PID_. To manage supervised extensions, you need to have a running `ocis server` first or an error will be thrown.
+You can start, list or kill available extensions in supervised mode with the `ocis` command. _These extensions share the same PID_. To manage supervised extensions, you need to run `ocis server` first or an error will be thrown.
 
-NOTE: When an extension runs supervised, is killed and started again, the only way to provide / overwrite configuration values will be through an *extension config file*. This is due to the parent process has already started, and it already has its own environment.
+NOTE: When an extension runs supervised, is killed and started again, the only way to provide or overwrite configuration values will be through an *extension config file*. This is due to the parent process having already started in its own environment.
 
 List running extensions::
 [source,bash]
@@ -97,17 +97,17 @@ Kill a running extension::
 ocis kill [extension name]
 ----
 
-Start a extension::
+Start an extension::
 [source,bash]
 ----
 ocis run [extension name]
 ----
 
-==== Non Supervised Extensions
+==== Unsupervised Extensions
 
-You can create at any time non oCIS supervised instances of an extension with `ocis [extension name]` like `ocis proxy`. _These extensions are independent of extensions in supervised mode and have their own PID_. The Instances are managed with classical OS methods or e.g. via Kubernetes.
+At any time, you can create unsupervised instances of an extension with `ocis [extension name]`, for example `ocis proxy`. _These extensions are independent of extensions in supervised mode and have their own PID_. The Instances are managed with classical OS methods or e.g. via Kubernetes.
 
-Creating multiple instances of an extensions is used for scaling. Note that you may need configuration for and access to the instantinated extensions like with a load balancer when you scale.
+Creating multiple instances of an extension is used for scaling. Note that you may need configuration for and access to the extension instances like with a load balancer when you scale.
 
 == Configuration of oCIS
 
@@ -119,22 +119,22 @@ oCIS uses a hierachical structure for its configuration, *where each element ove
 . Extension configuration file
 . oCIS configuration file
 
-The expected loading locations are:
+The expected locations are:
 
 . `$HOME/.ocis/config/`
 . `/etc/ocis/`
 . `.config/`
+// check in beta 1 if this is accurate
+You can define a nonstandard configuration file location on startup either with an:
 
-You can define a non standard configuration file location on startup either with an:
-
-* command option (`--config-file value`) or with a
+* command option (`--config-file value`) or with an
 * environment variable (`OCIS_CONFIG_FILE`)
 
-NOTE: Administrators must be aware of these sources and the order applied (the _configuration file arithmetics_). Mis-managing them can be a source of confusion leading to undesired results on the final configuration created and applied.
+NOTE: Administrators must be aware of these sources and the order applied (the _configuration file arithmetics_). Mismanaging them can be a source of confusion leading to undesired results on the final configuration created and applied.
 
 === Configuration File Naming
 
-The configuration files for oCIS are YAML based (a human-friendly data serialization language).
+The configuration files for oCIS are YAML-based (a human-friendly data serialization language).
 
 The filename to define a config has following namespace:
 
@@ -170,11 +170,11 @@ PROXY_DEBUG_ADDR=localhost:6666 \
 ocis server
 ----
 
-Remember the note in xref:ocis_supervised_extensions[oCIS Supervised Extensions] when killing/restarting extensions in superviced mode.
+Remember the note in xref:ocis_supervised_extensions[oCIS Supervised Extensions] when killing/restarting extensions in supervised mode.
 
 === Globally Shared Logging Values
 
-When running in supervised mode (`ocis server`), it is beneficial to have common values for logging so that the log output is correctly formatted or everything is piped to the same file without duplicating config keys and values all over the place. This is possible using the global log config key with following example:
+When running in supervised mode (`ocis server`), it is beneficial to have common values for logging so that the log output is correctly formatted or everything is piped to the same file without duplicating config keys and values all over the place. This is possible using the global log config key with the following example:
 
 .ocis.yaml
 [source,yaml]
@@ -186,11 +186,11 @@ log:
   file: /var/tmp/ocis_output.log
 ----
 
-NOTE: In case of an extension overwriting its shared logging config that received from the main ocis.yaml file, you *MUST* specify all values.
+NOTE: In case of an extension overwriting its shared logging config received from the main ocis.yaml file, you *MUST* specify all values.
 
 ==== Log Config Keys
 
-This are the necessary log keys and the available values:
+These are the necessary log keys and the available values:
 
 [source,plaintext]
 ----

--- a/modules/ROOT/pages/deployment/manual/manual-setup.adoc
+++ b/modules/ROOT/pages/deployment/manual/manual-setup.adoc
@@ -2,15 +2,115 @@
 :toc: right
 :toclevels: 2
 
+:downloadpage_ocis_url: https://download.owncloud.com/ocis/ocis/
 :systemd-url: https://systemd.io/
 :traefik-url: https://doc.traefik.io/traefik/getting-started/install-traefik/
 
-=== Basic Setup
+:description: oCIS can be downloaded from ownCloud or installed via the package manger of your Linux system. Select the way you prefer most. Note that the download version is more often updated than the package manager version.
 
-Install oCIS via the package manager of your Linux system or download the binary from
-`https://download.owncloud.com/ocis/ocis/` and make it executable with `chmod +x ocis`. Depending on your system and preferences, you may want to save the binary as `/usr/bin/ocis`.
+== Introduction
 
-// URL with curl/wget command, once we know it. Recommended directory possibly to be adjusted when we actually have a recommended or standard location.
+{description}
+
+Using the manual method to install oCIS is best when you want to quickly test oCIS without doing additional tasks like docker preperation or kubernetes. Of course you can use it for production in your environment too. See the xref:availability/index.adoc[Availability and Scalability] documentation for impacts. 
+
+== Installation
+
+* To get the binary from ownCloud, visit {downloadpage_ocis_url}[download.owncloud.com], select the version and the platform of choice and copy the link of the file. Depending on your system and preferences, you may want to save the binary in `/usr/bin/`.
++
+To download use:
++
+[source,bash]
+----
+sudo wget -O /usr/bin/ocis <link>
+----
++
+Make the binary executable with
++
+[source,bash]
+----
+sudo chmod +x /usr/bin/ocis
+----
++
+Check the version installed
++
+[source,bash]
+----
+ocis --version
+----
++
+Which prints an output like
++
+[source,plaintext,subs="attributes+"]
+----
+ocis version {actual-ocis-version}
+----
+
+// fixme: recommended directory possibly to be adjusted when we actually have a recommended or standard location.
+
+* To install oCIS via the package manager of your Linux system, use the package manager commands to search for ocis and install it accordingly.
++
+[NOTE]
+====
+Package manager installation is in preperation and will be available soon.
+====
+
+== Getting Command Line Help
+
+To get a list of available options and commands type:
+
+[source,bash]
+----
+ocis
+----
+
+or
+
+[source,bash]
+----
+ocis --help
+----
+
+== Start and Stop oCIS
+
+=== Starting oCIS
+
+When oCIS has been installed, you can start oCIS as follows:
+
+[source,bash]
+----
+ocis server
+----
+
+Note that this will bind `ocis` to the shell you are running. If you want to decouple it from the shell, use the following command:
+
+[source,bash]
+----
+ocis server &
+----
+
+If you want to _add_ instances of an extension like `proxy`, run:
+
+[source,bash]
+----
+ocis run proxy
+----
+
+=== List Running oCIS Processes
+
+To list all running processes type
+
+[source,bash]
+----
+ps ax | grep ocis | grep -v grep
+----
+
+ps -ax | grep ocis | grep -v grep | awk '{ print $1 }'
+
+=== Stopping oCIS
+
+
+== Basic Setup
 
 You can now start the fullstack oCIS server with the command: `ocis server`. However, if you're using oCIS with self-signed certificates, you need to set the environment variable `OCIS_INSECURE=true`:
 

--- a/modules/ROOT/pages/deployment/manual/manual-setup.adoc
+++ b/modules/ROOT/pages/deployment/manual/manual-setup.adoc
@@ -6,13 +6,13 @@
 :systemd-url: https://systemd.io/
 :traefik-url: https://doc.traefik.io/traefik/getting-started/install-traefik/
 
-:description: oCIS can be downloaded from ownCloud or installed via the package manger of your Linux system. Select the way you prefer most. Note that the download version is more often updated than the package manager version.
+:description: oCIS can either be downloaded from ownCloud or installed via the package manger of your Linux system. Use the way you prefer, but keep in mind that the download version is updated more frequently than the package manager version.
 
 == Introduction
 
 {description}
 
-Using the manual method to install oCIS is best when you want to quickly test oCIS without doing additional tasks like docker preperation or kubernetes. Of course you can use it for production in your environment too. See the xref:availability/index.adoc[Availability and Scalability] documentation for impacts. 
+Installing oCIS manually works well if you want to quickly test oCIS without performing additional tasks like Docker preparation or Kubernetes deployment. Of course you can use it for production in your environment, too. See the xref:availability/index.adoc[Availability and Scalability] documentation for impacts. 
 
 == Installation
 
@@ -25,21 +25,21 @@ To download use:
 sudo wget -O /usr/bin/ocis <link>
 ----
 +
-Make the binary executable with
+Make the binary executable with:
 +
 [source,bash]
 ----
 sudo chmod +x /usr/bin/ocis
 ----
 +
-Check the version installed
+Check the version installed:
 +
 [source,bash]
 ----
 ocis --version
 ----
 +
-Which prints an output like
+The output looks like this:
 +
 [source,plaintext,subs="attributes+"]
 ----

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -4,6 +4,7 @@
 ** xref:availability_scaling/index.adoc[Availability and Scalability]
 ** xref:prerequisites/index.adoc[Prerequisites]
 ** xref:deployment/index.adoc[Deployment]
+*** xref:deployment/general/general-info.adoc[General Info]
 *** xref:deployment/manual/manual-setup.adoc[Manual Setup]
 *** xref:deployment/docker/docker-setup.adoc[Docker Setup]
 *** xref:deployment/security.adoc[Securing oCIS]

--- a/site.yml
+++ b/site.yml
@@ -71,6 +71,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
+    actual-ocis-version: '1.9.1'
 #   desktop
     latest-desktop-version: 'next'
     previous-desktop-version: 'next'


### PR DESCRIPTION
During work on manual/docker installation, I identified the need to have a general info document in the deployment section which is not dependent on the way how it is deployed.

Review welcome.

Most likely some content be added with regards to location precedence, waiting for answers from dev. Maybe other stuff will be added too, just a feeling...

Note that there are also changes in the manual installation part (because I started there), but this is definitley not finished. Reviewing this and merging is fine and a good starting point to continue 😄 

Note that heading `=== List Running oCIS Processes` in Manual Installation is also not finished and contains a copy/paste note for the ongoing work that needs refinement, but this will be another PR...

Stuff is already on staging.