### PR TITLE
move basic setup

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -233,15 +233,15 @@ log:
 
 == Accessing oCIS Via the WebUI
 
-You can access oCIS via ownCloud Web easily with minimal configuration needs. Without going too much into the details, following are the two environment variables you need to provide. See also the section about xref:handling-certificates[] and xref:login-with-demo-users-provided[].
+You can easily access oCIS via ownCloud Web with minimal configuration needs. Without going into too much detail, you need to provide the following two environment variables. See also the section about xref:handling-certificates[] and xref:login-with-demo-users-provided[].
 
 `OCIS_URL`::
 Expects a URL including _protocol_, _host_ and optionally _port_ to simplify configuring all the different services. Other extension environment variables also using an URL still take precedence if set, but will fall back to this URL if not set.
 +
-NOTE: If you need to access oCIS running in a docker container, on a VM or a remote machine via an other hostname than localhost, you need to configure the hostname with `OCIS_URL`. The same applies if you are not using hostnames but an IP address (e.g. 192.168.178.25) instead.
+NOTE: If you need to access oCIS running in a docker container, on a VM or a remote machine via a host name other than localhost, you need to configure the host name with `OCIS_URL`. The same applies if you are not using host names but an IP address (e.g. 192.168.178.25) instead.
 
 `PROXY_HTTP_ADDR`::
-When using `0.0.0.0:9200` the proxy will listen to all available interfaces. If you want or need to change hat based on requirements, you can use a different address e.g. to bind the proxy to an interface. 
+When using `0.0.0.0:9200`, the proxy will listen to all available interfaces. If you want or need to change that based on your requirements, you can use a different address e.g. to bind the proxy to an interface. 
 
 // fixme: explain the proxy - but on a different page.
 
@@ -249,7 +249,7 @@ When using `0.0.0.0:9200` the proxy will listen to all available interfaces. If 
 
 // https://owncloud.dev/ocis/deployment/basic-remote-setup/
 
-Certificates are necessary to secure browser access. oCIS can run with embedded self signed certificates mainly used for testing purposes or signed certificates provided by the admin. To tell oCIS which kind of certificates you are using, the environment variable `OCIS_INSECURE` is used.
+Certificates are necessary to secure browser access. oCIS can run with embedded self-signed certificates mainly used for testing purposes or signed certificates provided by the admin. To tell oCIS which kind of certificates you are using, the environment variable `OCIS_INSECURE` is used.
 
 === Using a Reverse Proxy
 
@@ -257,9 +257,9 @@ Certificates are necessary to secure browser access. oCIS can run with embedded 
 
 If you are using a reverse proxy like Traefik and the reverse proxy manages the certificates, there is no need to use these certificates between the reverse proxy and oCIS again. Therefore set `OCIS_INSECURE=false` or remove it completely.
 
-=== Embedded Self Signed Certificates
+=== Embedded Self-Signed Certificates
 
-In order to run oCIS with automatically generated and self signed certificates, set `OCIS_INSECURE=true`.
+In order to run oCIS with automatically generated and self-signed certificates, set `OCIS_INSECURE=true`.
 
 [source,console]
 ----
@@ -271,11 +271,11 @@ ocis server
 
 === Provided Signed Certificates
 
-==== Self Signed Certificates
+==== Self-Signed Certificates
 
-In case your certificates are self-signed, set `OCIS_INSECURE=true` like in the example of embedded self signed certificates above.
+In case your certificates are self-signed, set `OCIS_INSECURE=true` like in the example of embedded self-signed certificates above.
 
-==== Trusted CA Signed Certificates
+==== Certificates Signed by a Trusted CA
 
 If you have your own certificates already in place, make oCIS use them by adding the following environment variables to the command:
 
@@ -289,7 +289,7 @@ PROXY_TRANSPORT_TLS_CERT=./certs/your-host.crt \
 ocis server
 ----
 
-== Login With Demo Users Provided
+== Login With Demo Users
 
 // fixme: needs checking
 

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -9,7 +9,7 @@
 
 The example commands shown need to be adjusted depending on whether you are using the manual installation or a docker environment. See the xref:deployment/manual/manual-setup.adoc[Manual Setup] and the xref:deployment/docker/docker-setup.adoc[Docker Setup] for more details.  
 
-When using global options on startup, you can always use command line options or environment variables. Run `ocis --help` and see xref:starting-ocis-with-environment-variables[Starting oCIS With Environment Variables] for details.
+When using global options on startup, you can always use command line options or environment variables. Run `ocis --help` and see xref:starting-ocis-with-environment-variables[] for details.
 
 == Embedded Supervisor (Runtime)
 
@@ -200,7 +200,7 @@ PROXY_DEBUG_ADDR=localhost:6666 \
 ocis server
 ----
 
-Remember the note in xref:ocis-supervised-extensions[oCIS Supervised Extensions] when killing/restarting extensions in supervised mode.
+Remember the note in xref:ocis-supervised-extensions[] when killing/restarting extensions in supervised mode.
 
 === Globally Shared Logging Values
 
@@ -230,3 +230,101 @@ log:
   pretty: [ true | false ]
   file: [ path/to/log/file ] # MUST not be used with pretty = true
 ----
+
+== Accessing oCIS Via the WebUI
+
+You can access oCIS via ownCloud Web easily with minimal configuration needs. Without going too much into the details, following are the two environment variables you need to provide. See also the section about xref:handling-certificates[] and xref:login-with-demo-users-provided[].
+
+`OCIS_URL`::
+Expects a URL including _protocol_, _host_ and optionally _port_ to simplify configuring all the different services. Other extension environment variables also using an URL still take precedence if set, but will fall back to this URL if not set.
++
+NOTE: If you need to access oCIS running in a docker container, on a VM or a remote machine via an other hostname than localhost, you need to configure the hostname with `OCIS_URL`. The same applies if you are not using hostnames but an IP address (e.g. 192.168.178.25) instead.
+
+`PROXY_HTTP_ADDR`::
+When using `0.0.0.0:9200` the proxy will listen to all available interfaces. If you want or need to change hat based on requirements, you can use a different address e.g. to bind the proxy to an interface. 
+
+// fixme: explain the proxy - but on a different page.
+
+== Handling Certificates
+
+// https://owncloud.dev/ocis/deployment/basic-remote-setup/
+
+Certificates are necessary to secure browser access. oCIS can run with embedded self signed certificates mainly used for testing purposes or signed certificates provided by the admin. To tell oCIS which kind of certificates you are using, the environment variable `OCIS_INSECURE` is used.
+
+=== Using a Reverse Proxy
+
+// https://owncloud.dev/ocis/deployment/ocis_individual_services/
+
+If you are using a reverse proxy like Traefik and the reverse proxy manages the certificates, there is no need to use these certificates between the reverse proxy and oCIS again. Therefore set `OCIS_INSECURE=false` or remove it completely.
+
+=== Embedded Self Signed Certificates
+
+In order to run oCIS with automatically generated and self signed certificates, set `OCIS_INSECURE=true`.
+
+[source,console]
+----
+OCIS_INSECURE=true \
+PROXY_HTTP_ADDR=0.0.0.0:9200 \
+OCIS_URL=https://localhost:9200 \
+ocis server
+----
+
+=== Provided Signed Certificates
+
+==== Self Signed Certificates
+
+In case your certificates are self-signed, set `OCIS_INSECURE=true` like in the example of embedded self signed certificates above.
+
+==== Trusted CA Signed Certificates
+
+If you have your own certificates already in place, make oCIS use them by adding the following environment variables to the command:
+
+[source,console]
+----
+OCIS_INSECURE=false \
+PROXY_HTTP_ADDR=0.0.0.0:9200 \
+OCIS_URL=https://localhost:9200 \
+PROXY_TRANSPORT_TLS_KEY=./certs/your-host.key \
+PROXY_TRANSPORT_TLS_CERT=./certs/your-host.crt \
+ocis server
+----
+
+== Login With Demo Users Provided
+
+// fixme: needs checking
+
+With a fresh installation of oCIS, you can log in via the web interface at `\https://localhost:9200` using one of the demo users provided for testing purposes:
+
+[width="70%",cols="30%,30%,60%,30%",options="header"]
+|===
+| Username
+| Password
+| email
+| Role
+
+| admin
+| admin
+| \admin@example.org
+| admin
+
+| einstein
+| relativity
+| \einstein@example.org
+| user
+
+| marie
+| radioactivity
+| \marie@example.org
+| user
+
+| moss
+| vista
+| \moss@example.org
+| admin
+
+| richard
+| superfluidity
+| \richard@example.org
+| user
+|===
+

--- a/modules/ROOT/pages/deployment/manual/manual-setup.adoc
+++ b/modules/ROOT/pages/deployment/manual/manual-setup.adoc
@@ -158,48 +158,6 @@ To terminate the `ocis proxy` service, type:
 kill -15 221706
 ----
 
-== Basic Setup
-
-You can now start the fullstack oCIS server with the command: `ocis server`. However, if you're using oCIS with self-signed certificates, you need to set the environment variable `OCIS_INSECURE=true`:
-
-[source,console]
-----
-`OCIS_INSECURE=true ocis server`
-----
-
-If you have your own certificates already in place, you may want to make oCIS use them by adding the following environment variables to the command:
-
-[source,console]
-----
-OCIS_INSECURE=false \
-PROXY_HTTP_ADDR=0.0.0.0:9200 \
-OCIS_URL=https://your-host:9200 \
-PROXY_TRANSPORT_TLS_KEY=./certs/your-host.key \
-PROXY_TRANSPORT_TLS_CERT=./certs/your-host.crt \
-ocis server
-----
-
-In case your certificates are self-signed, better set `OCIS_INSECURE=true` in the above example.
-
-Log in via the web interface at https://localhost:9200 using one of the demo users provided for testing purposes:
-
-[source,console]
-----
-+----------+---------------+----------------------+-------+
-| username | password      | email                | role  |
-+----------+---------------+----------------------+------ +
-| admin    | admin         | admin@example.org    | admin |
-| einstein | relativity    | einstein@example.org | user  |
-| marie    | radioactivity | marie@example.org    | user  |
-| moss     | vista         | moss@example.org     | admin |
-| richard  | superfluidity | richard@example.org  | user  |
-+----------+---------------+----------------------+-------+
-----
-
-
-// https://owncloud.dev/ocis/deployment/basic-remote-setup/
-// Does not really match my test setup.
-
 === Setting up the systemd Service
 
 To run oCIS as a {systemd-url}[systemd] service, create the file `/etc/systemd/system/ocis.service` with the following content:
@@ -250,9 +208,6 @@ Now you can run oCIS as a systemd service. Start it with `systemctl enable --now
 If you need to restart oCIS because of configuration changes in `/etc/ocis/ocis.env`, run `systemctl restart ocis`.
 
 The logs of oCIS can be displayed by issuing `journalctl -f -u ocis`.
-
-// include::{latest-server-version}@server:admin_manual:page$installation/deployment_recommendations/nfs.adoc[leveloffset=+2]
-
 
 
 === Traefik


### PR DESCRIPTION
Moving some stuff from manual install to general info as it can also be used in docker

Already on staging

Note that xref pointing to a heading in the same document does not need to have a written description - it uses the heading text 😃  