### PR TITLE
Remove the account service from the list

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -45,7 +45,6 @@ This will print an output like:
 +------------------------+
 |       EXTENSION        |
 +------------------------+
-| accounts               |
 | glauth                 |
 | graph                  |
 | graph-explorer         |


### PR DESCRIPTION
Remove the account service from the list. When the LibreIDM gets merged in ocis soon, this service will go away