### PR TITLE
Add example configvars files

### DIFF
--- a/modules/ROOT/partials/extension_tables/appprovider_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/appprovider_configvars.adoc
@@ -1,0 +1,48 @@
+[caption=]
+.Environment variables for the appprovider extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `APP_PROVIDER_DEBUG_ADDR`
+| string
+| 127.0.0.1:9165
+| +1.20.0
+|
+
+| `APP_PROVIDER_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `APP_PROVIDER_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `APP_PROVIDER_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `APP_PROVIDER_GRPC_ADDR`
+| string
+| 127.0.0.1:9164
+| +1.20.0
+| The address of the grpc service.
+
+| `APP_PROVIDER_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/audit_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/audit_configvars.adoc
@@ -1,0 +1,78 @@
+[caption=]
+.Environment variables for the audit extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `AUDIT_DEBUG_ADDR`
+| string
+|
+| +1.20.0
+|
+
+| `AUDIT_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `AUDIT_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUDIT_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUDIT_EVENTS_ENDPOINT`
+| string
+| 127.0.0.1:9233
+| +1.20.0
+| the address of the streaming service
+
+| `AUDIT_EVENTS_CLUSTER`
+| string
+| ocis-cluster
+| +1.20.0
+| the clusterID of the streaming service. Mandatory when using nats
+
+| `AUDIT_EVENTS_GROUP`
+| string
+| audit
+| +1.20.0
+| the customergroup of the service. One group will only get one vopy of an event
+
+| `AUDIT_LOG_TO_CONSOLE`
+| bool
+| true
+| +1.20.0
+| logs to Stdout if true
+
+| `AUDIT_LOG_TO_FILE`
+| bool
+| false
+| +1.20.0
+| logs to file if true
+
+| `AUDIT_FILEPATH`
+| string
+|
+| +1.20.0
+| filepath to the logfile. Mandatory if LogToFile is true
+
+| `AUDIT_FORMAT`
+| string
+| json
+| +1.20.0
+| log format. using json is advised
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/auth-basic_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/auth-basic_configvars.adoc
@@ -1,0 +1,242 @@
+[caption=]
+.Environment variables for the auth-basic extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `AUTH_BASIC_DEBUG_ADDR`
+| string
+| 127.0.0.1:9147
+| +1.20.0
+|
+
+| `AUTH_BASIC_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `AUTH_BASIC_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUTH_BASIC_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUTH_BASIC_GRPC_ADDR`
+| string
+| 127.0.0.1:9146
+| +1.20.0
+| The address of the grpc service.
+
+| `AUTH_BASIC_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `AUTH_BASIC_AUTH_PROVIDER`
+| string
+| ldap
+| +1.20.0
+| The auth provider which should be used by the service
+
+| `AUTH_BASIC_JSON_PROVIDER_FILE`
+| string
+|
+| +1.20.0
+| The file to which the json provider writes the data.
+
+| `LDAP_URI` +
+`AUTH_BASIC_LDAP_URI`
+| string
+| ldaps://localhost:9235
+| +1.20.0
+|
+
+| `LDAP_CACERT` +
+`AUTH_BASIC_LDAP_CACERT`
+| string
+| ~/.ocis/idm/ldap.crt
+| +1.20.0
+|
+
+| `LDAP_INSECURE` +
+`AUTH_BASIC_LDAP_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_BIND_DN` +
+`AUTH_BASIC_LDAP_BIND_DN`
+| string
+| uid=reva,ou=sysusers,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_BIND_PASSWORD` +
+`AUTH_BASIC_LDAP_BIND_PASSWORD`
+| string
+| reva
+| +1.20.0
+|
+
+| `LDAP_USER_BASE_DN` +
+`AUTH_BASIC_LDAP_USER_BASE_DN`
+| string
+| ou=users,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_GROUP_BASE_DN` +
+`AUTH_BASIC_LDAP_GROUP_BASE_DN`
+| string
+| ou=groups,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_USER_SCOPE` +
+AUTH_BASIC_LDAP_USER_SCOPE
+| string
+| sub 
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCOPE` +
+`AUTH_BASIC_LDAP_GROUP_SCOPE`
+| string
+| sub
+| +1.20.0
+|
+
+| `LDAP_USERFILTER` +
+`AUTH_BASIC_LDAP_USERFILTER`
+| string
+|
+|
+|
+
+| `LDAP_GROUPFILTER` +
+`AUTH_BASIC_LDAP_USERFILTER`
+| string
+|
+| +1.20.0
+|
+
+| `LDAP_USER_OBJECTCLASS` +
+`AUTH_BASIC_LDAP_USER_OBJECTCLASS`
+| string
+| inetOrgPerson
+| +1.20.0
+|
+
+| `LDAP_GROUP_OBJECTCLASS` +
+`AUTH_BASIC_LDAP_GROUP_OBJECTCLASS`
+| string
+| groupOfNames
+| +1.20.0
+|
+
+| `LDAP_LOGIN_ATTRIBUTES` +
+`AUTH_BASIC_LDAP_LOGIN_ATTRIBUTES`
+|
+| [uid mail]
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`AUTH_BASIC_IDP_URL`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_ID` +
+`AUTH_BASIC_LDAP_USER_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_ID_IS_OCTETSTRING` +
+`AUTH_BASIC_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_MAIL` +
+`AUTH_BASIC_LDAP_USER_SCHEMA_MAIL`
+| string
+| mail
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_DISPLAYNAME` +
+`AUTH_BASIC_LDAP_USER_SCHEMA_DISPLAYNAME`
+| string
+| displayname
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_USERNAME` +
+`AUTH_BASIC_LDAP_USER_SCHEMA_USERNAME`
+| string
+| uid
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID` +
+`AUTH_BASIC_LDAP_GROUP_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING` +
+`AUTH_BASIC_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_MAIL` +
+`AUTH_BASIC_LDAP_GROUP_SCHEMA_MAIL`
+| string
+| mail
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_DISPLAYNAME` +
+`AUTH_BASIC_LDAP_GROUP_SCHEMA_DISPLAYNAME
+| string
+| cn
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_GROUPNAME` +
+`AUTH_BASIC_LDAP_GROUP_SCHEMA_GROUPNAME`
+| string
+| cn
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_MEMBER` +
+`AUTH_BASIC_LDAP_GROUP_SCHEMA_MEMBER`
+| string
+| member
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/auth-bearer_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/auth-bearer_configvars.adoc
@@ -1,0 +1,68 @@
+[caption=]
+.Environment variables for the auth-bearer extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `AUTH_BEARER_DEBUG_ADDR`
+| string
+| 127.0.0.1:9149
+| +1.20.0
+|
+
+| `AUTH_BEARER_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `AUTH_BEARER_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUTH_BEARER_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUTH_BEARER_GRPC_ADDR`
+| string
+| 127.0.0.1:9148
+| +1.20.0
+| The address of the grpc service.
+
+| `AUTH_BEARER_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `AUTH_BEARER_AUTH_PROVIDER`
+| string
+| ldap
+| +1.20.0
+| The auth provider which should be used by the service
+
+| `OCIS_URL` +
+`AUTH_BEARER_OIDC_ISSUER`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`AUTH_BEARER_OIDC_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/auth-machine_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/auth-machine_configvars.adoc
@@ -1,0 +1,61 @@
+[caption=]
+.Environment variables for the auth-machine extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `AUTH_MACHINE_DEBUG_ADDR`
+| string
+| 127.0.0.1:9167
+| +1.20.0
+|
+
+| `AUTH_MACHINE_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `AUTH_MACHINE_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUTH_MACHINE_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `AUTH_MACHINE_GRPC_ADDR`
+| string
+| 127.0.0.1:9166
+| +1.20.0
+| The address of the grpc service.
+
+| `AUTH_MACHINE_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `AUTH_MACHINE_AUTH_PROVIDER`
+| string
+| ldap
+| +1.20.0
+| The auth provider which should be used by the service
+
+| `OCIS_MACHINE_AUTH_API_KEY` +
+`AUTH_MACHINE_PROVIDER_API_KEY`
+| string
+| change-me-please
+| +1.20.0
+| The api key for the machine auth provider.
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/frontend_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/frontend_configvars.adoc
@@ -1,0 +1,81 @@
+[caption=]
+.Environment variables for the frontend extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `FRONTEND_DEBUG_ADDR`
+| string
+| 127.0.0.1:9141
+| +1.20.0
+|
+
+| `FRONTEND_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `FRONTEND_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `FRONTEND_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `FRONTEND_HTTP_ADDR`
+| string
+| 127.0.0.1:9140
+| +1.20.0
+| The address of the http service.
+
+| `FRONTEND_HTTP_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the http service.
+
+| `STORAGE_TRANSFER_SECRET`
+| string
+| replace-me-with-a-transfer-secret
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`FRONTEND_PUBLIC_URL`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`FRONTEND_ARCHIVER_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`FRONTEND_APPPROVIDER_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCIS_MACHINE_AUTH_API_KEY`
+| string
+| change-me-please
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/gateway_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/gateway_configvars.adoc
@@ -1,0 +1,61 @@
+[caption=]
+.Environment variables for the gateway extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `GATEWAY_DEBUG_ADDR`
+| string
+| 127.0.0.1:9143
+| +1.20.0
+|
+
+| `GATEWAY_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `GATEWAY_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `GATEWAY_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `GATEWAY_GRPC_ADDR`
+| string
+| 127.0.0.1:9142
+| +1.20.0
+| The address of the grpc service.
+
+| `GATEWAY_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `STORAGE_TRANSFER_SECRET`
+| string
+| replace-me-with-a-transfer-secret
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`GATEWAY_FRONTEND_PUBLIC_URL`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/graph-explorer_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/graph-explorer_configvars.adoc
@@ -1,0 +1,74 @@
+[caption=]
+.Environment variables for the graph-explorer extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `GRAPH_EXPLORER_DEBUG_ADDR`
+| string
+| 127.0.0.1:9136
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_HTTP_ADDR`
+| string
+| 127.0.0.1:9135
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_HTTP_ROOT`
+| string
+| /graph-explorer
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_CLIENT_ID`
+| string
+| ocis-explorer.js
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`GRAPH_EXPLORER_ISSUER`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`GRAPH_EXPLORER_GRAPH_URL_BASE`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `GRAPH_EXPLORER_GRAPH_URL_PATH`
+| string
+| /graph
+| +1.20.0
+| 
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/graph_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/graph_configvars.adoc
@@ -1,0 +1,249 @@
+[caption=]
+.Environment variables for the graph extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| GRAPH_DEBUG_ADDR
+| string
+| 127.0.0.1:9124
+| +1.20.0
+|
+
+| GRAPH_DEBUG_TOKEN
+| string
+|
+| +1.20.0
+|
+
+| GRAPH_DEBUG_PPROF
+| bool
+| false
+| +1.20.0
+|
+
+| GRAPH_DEBUG_ZPAGES
+| bool
+| false
+| +1.20.0
+|
+
+| GRAPH_HTTP_ADDR
+| string
+| 127.0.0.1:9120
+| +1.20.0
+|
+
+| GRAPH_HTTP_ROOT
+| string
+| /graph
+| +1.20.0
+|
+
+| REVA_GATEWAY
+| string
+| 127.0.0.1:9142
+| +1.20.0
+|
+
+| OCIS_JWT_SECRET +
+GRAPH_JWT_SECRET
+| string
+| Pive-Fumkiu4
+| +1.20.0
+|
+
+| OCIS_URL +
+GRAPH_SPACES_WEBDAV_BASE
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| GRAPH_SPACES_WEBDAV_PATH
+| string
+| /dav/spaces/
+| +1.20.0
+|
+
+| GRAPH_SPACES_DEFAULT_QUOTA
+| string
+| 1000000000
+| +1.20.0
+|
+
+| OCIS_INSECURE +
+GRAPH_SPACES_INSECURE
+| bool
+| false
+| +1.20.0
+|
+
+| GRAPH_SPACES_EXTENDED_SPACE_PROPERTIES_CACHE_TTL
+| int
+| 0
+| +1.20.0
+|
+
+| GRAPH_IDENTITY_BACKEND
+| string
+| ldap
+| +1.20.0
+|
+
+| LDAP_URI +
+GRAPH_LDAP_URI
+| string
+| ldaps://localhost:9235
+| +1.20.0
+|
+
+| OCIS_INSECURE +
+GRAPH_LDAP_INSECURE
+| bool
+| true
+| +1.20.0
+|
+
+| LDAP_BIND_DN +
+GRAPH_LDAP_BIND_DN
+| string
+| uid=libregraph,ou=sysusers,o=libregraph-idm
+| +1.20.0
+|
+
+| LDAP_BIND_PASSWORD +
+GRAPH_LDAP_BIND_PASSWORD
+| string
+| idm
+| +1.20.0
+|
+
+| GRAPH_LDAP_SERVER_UUID
+| bool
+| false
+| +1.20.0
+|
+
+| GRAPH_LDAP_SERVER_WRITE_ENABLED
+| bool
+| true
+| +1.20.0
+|
+
+| LDAP_USER_BASE_DN +
+GRAPH_LDAP_USER_BASE_DN
+| string
+| ou=users,o=libregraph-idm
+| +1.20.0
+|
+
+| LDAP_USER_SCOPE +
+GRAPH_LDAP_USER_SCOPE
+| string
+| sub
+| +1.20.0
+|
+
+| LDAP_USER_FILTER +
+GRAPH_LDAP_USER_FILTER
+| string
+|
+| +1.20.0
+|
+
+| LDAP_USER_OBJECTCLASS +
+GRAPH_LDAP_USER_OBJECTCLASS
+| string
+| inetOrgPerson
+| +1.20.0
+|
+
+| LDAP_USER_SCHEMA_MAIL +
+GRAPH_LDAP_USER_EMAIL_ATTRIBUTE
+| string
+| mail
+| +1.20.0
+|
+
+| LDAP_USER_SCHEMA_DISPLAY_NAME +
+GRAPH_LDAP_USER_DISPLAYNAME_ATTRIBUTE
+| string
+| displayName
+| +1.20.0
+|
+
+| LDAP_USER_SCHEMA_USERNAME +
+GRAPH_LDAP_USER_NAME_ATTRIBUTE
+| string
+| uid
+| +1.20.0
+|
+
+| LDAP_USER_SCHEMA_ID +
+GRAPH_LDAP_USER_UID_ATTRIBUTE
+| string
+| owncloudUUID
+| +1.20.0
+|
+
+| LDAP_GROUP_BASE_DN +
+GRAPH_LDAP_GROUP_BASE_DN
+| string
+| ou=groups,o=libregraph-idm
+| +1.20.0
+|
+
+| LDAP_GROUP_SCOPE +
+GRAPH_LDAP_GROUP_SEARCH_SCOPE
+| string
+| sub
+| +1.20.0
+|
+
+| LDAP_GROUP_FILTER +
+GRAPH_LDAP_GROUP_FILTER
+| string
+|
+| +1.20.0
+|
+
+| LDAP_GROUP_OBJECTCLASS +
+GRAPH_LDAP_GROUP_OBJECTCLASS
+| string
+| groupOfNames
+| +1.20.0
+|
+
+| LDAP_GROUP_SCHEMA_GROUPNAME +
+GRAPH_LDAP_GROUP_NAME_ATTRIBUTE
+| string
+| cn
+| +1.20.0
+|
+
+| LDAP_GROUP_SCHEMA_ID +
+GRAPH_LDAP_GROUP_ID_ATTRIBUTE
+| string
+| owncloudUUID
+| +1.20.0
+|
+
+| GRAPH_EVENTS_ENDPOINT
+| string
+| 127.0.0.1:9233
+| +1.20.0
+| the address of the streaming service
+
+| GRAPH_EVENTS_CLUSTER
+| string
+| ocis-cluster
+| +1.20.0
+| the clusterID of the streaming service. Mandatory when using nats
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/group_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/group_configvars.adoc
@@ -1,0 +1,230 @@
+[caption=]
+.Environment variables for the group extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| GROUPS_DEBUG_ADDR
+| string
+| 127.0.0.1:9161
+| +1.120.0
+|
+
+| `GROUPS_DEBUG_TOKEN`
+| string
+|
+| +1.120.0
+|
+
+| `GROUPS_DEBUG_PPROF`
+| bool
+| false
+| +1.120.0
+|
+
+| `GROUPS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.120.0
+|
+
+| `GROUPS_GRPC_ADDR`
+| string
+| 127.0.0.1:9160
+| +1.120.0
+| The address of the grpc service.
+
+| `GROUPS_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.120.0
+| The transport protocol of the grpc service.
+
+| `LDAP_URI` +
+`GROUPS_LDAP_URI`
+| string
+| ldaps://localhost:9235
+| +1.120.0
+|
+
+| `LDAP_CACERT` +
+`GROUPS_LDAP_CACERT`
+| string
+| ~/.ocis/idm/ldap.crt
+| +1.120.0
+|
+
+| `LDAP_INSECURE` +
+`GROUPS_LDAP_INSECURE`
+| bool
+| false
+| +1.120.0
+|
+
+| `LDAP_BIND_DN` +
+`GROUPS_LDAP_BIND_DN`
+| string
+| uid=reva,ou=sysusers,o=libregraph-idm
+| +1.120.0
+|
+
+| `LDAP_BIND_PASSWORD` +
+`GROUPS_LDAP_BIND_PASSWORD`
+| string
+| reva
+| +1.120.0
+|
+
+| `LDAP_USER_BASE_DN` +
+`GROUPS_LDAP_USER_BASE_DN`
+| string
+| ou=users,o=libregraph-idm
+| +1.120.0
+|
+
+| `LDAP_GROUP_BASE_DN` +
+`GROUPS_LDAP_GROUP_BASE_DN`
+| string
+| ou=groups,o=libregraph-idm
+| +1.120.0
+|
+
+| `LDAP_USER_SCOPE` +
+`GROUPS_LDAP_USER_SCOPE`
+| string
+| sub
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCOPE` +
+`GROUPS_LDAP_GROUP_SCOPE`
+| string
+| sub
+| +1.120.0
+|
+
+| `LDAP_USERFILTER` +
+`GROUPS_LDAP_USERFILTER`
+| string
+|
+| +1.120.0
+|
+
+| `LDAP_GROUPFILTER` +
+`GROUPS_LDAP_USERFILTER`
+| string
+|
+| +1.120.0
+|
+
+| `LDAP_USER_OBJECTCLASS` +
+`GROUPS_LDAP_USER_OBJECTCLASS`
+| string
+| inetOrgPerson
+| +1.120.0
+|
+
+| `LDAP_GROUP_OBJECTCLASS` +
+`GROUPS_LDAP_GROUP_OBJECTCLASS`
+| string
+| groupOfNames
+| +1.120.0
+|
+
+| `LDAP_LOGIN_ATTRIBUTES` +
+`GROUPS_LDAP_LOGIN_ATTRIBUTES`
+|
+| [uid mail]
+| +1.120.0
+|
+
+| `OCIS_URL` +
+`GROUPS_IDP_URL`
+| string
+| \https://localhost:9200
+| +1.120.0
+|
+
+| `LDAP_USER_SCHEMA_ID` +
+`GROUPS_LDAP_USER_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.120.0
+|
+
+| `LDAP_USER_SCHEMA_ID_IS_OCTETSTRING` +
+`GROUPS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.120.0
+|
+
+| `LDAP_USER_SCHEMA_MAIL` +
+`GROUPS_LDAP_USER_SCHEMA_MAIL`
+| string
+| mail
+| +1.120.0
+|
+
+| `LDAP_USER_SCHEMA_DISPLAYNAME` +
+`GROUPS_LDAP_USER_SCHEMA_DISPLAYNAME`
+| string
+| displayname
+| +1.120.0
+|
+
+| `LDAP_USER_SCHEMA_USERNAME` +
+`GROUPS_LDAP_USER_SCHEMA_USERNAME`
+| string
+| uid
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID` +
+`GROUPS_LDAP_GROUP_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING` +
+`GROUPS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCHEMA_MAIL` +
+`GROUPS_LDAP_GROUP_SCHEMA_MAIL`
+| string
+| mail
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCHEMA_DISPLAYNAME` +
+`GROUPS_LDAP_GROUP_SCHEMA_DISPLAYNAME`
+| string
+| cn
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCHEMA_GROUPNAME` +
+`GROUPS_LDAP_GROUP_SCHEMA_GROUPNAME`
+| string
+| cn
+| +1.120.0
+|
+
+| `LDAP_GROUP_SCHEMA_MEMBER` +
+`GROUPS_LDAP_GROUP_SCHEMA_MEMBER`
+| string
+| member
+| +1.120.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/idm_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/idm_configvars.adoc
@@ -1,0 +1,91 @@
+[caption=]
+.Environment variables for the idm extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `IDM_DEBUG_ADDR`
+| string
+|
+| +1.20.0
+|
+
+| `IDM_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `IDM_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `IDM_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `IDM_LDAPS_ADDR`
+| string
+| 127.0.0.1:9235
+| +1.20.0
+| Listen address for the ldaps listener (ip-addr:port)
+
+| `IDM_LDAPS_CERT`
+| string
+| ~/.ocis/idm/ldap.crt
+| +1.20.0
+| File name of the TLS server certificate for the ldaps listener
+
+| `IDM_LDAPS_KEY`
+| string
+| ~/.ocis/idm/ldap.key 
+| +1.20.0
+| File name for the TLS certificate key for the server certificate
+
+| `IDM_DATABASE_PATH`
+| string
+| ~/.ocis/idm/ocis.boltdb
+| +1.20.0
+| Full path to the idm backend database
+
+| `IDM_CREATE_DEMO_USERS` +
+`ACCOUNTS_DEMO_USERS_AND_GROUPS`
+| bool
+| false
+| +1.20.0
+| Flag to enabe/disable the creation of the demo users
+
+| `IDM_ADMIN_PASSWORD`
+| string
+| admin
+| +1.20.0
+| Password to set for the ocis "admin" user. Either cleartext or an argon2id hash
+
+| `IDM_SVC_PASSWORD`
+| string
+| idm
+|
+| Password to set for the "idm" service user. Either cleartext or an argon2id hash
+
+| `IDM_REVASVC_PASSWORD`
+| string
+| reva
+| +1.20.0
+| Password to set for the "reva" service user. Either cleartext or an argon2id hash
+
+| `IDM_IDPSVC_PASSWORD`
+| string
+| idp
+| +1.20.0
+| Password to set for the "idp" service user. Either cleartext or an argon2id hash
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/idp_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/idp_configvars.adoc
@@ -1,0 +1,231 @@
+[caption=]
+.Environment variables for the idp extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `GROUPS_DEBUG_ADDR`
+| string
+| 127.0.0.1:9161
+| +1.20.0
+|
+
+| `GROUPS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `GROUPS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `GROUPS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `GROUPS_GRPC_ADDR`
+| string
+| 127.0.0.1:9160
+| +1.20.0
+| The address of the grpc service.
+
+| `GROUPS_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `LDAP_URI` +
+`GROUPS_LDAP_URI`
+| string
+| ldaps://localhost:9235
+| +1.20.0
+|
+
+| `LDAP_CACERT` +
+`GROUPS_LDAP_CACERT`
+| string
+| ~/.ocis/idm/ldap.crt
+| +1.20.0
+|
+
+| `LDAP_INSECURE` +
+`GROUPS_LDAP_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_BIND_DN` +
+`GROUPS_LDAP_BIND_DN`
+| string
+| uid=reva,ou=sysusers,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_BIND_PASSWORD` +
+`GROUPS_LDAP_BIND_PASSWORD`
+| string
+| reva
+| +1.20.0
+|
+
+| `LDAP_USER_BASE_DN` +
+`GROUPS_LDAP_USER_BASE_DN`
+| string
+| ou=users,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_GROUP_BASE_DN`
+`GROUPS_LDAP_GROUP_BASE_DN`
+| string
+| ou=groups,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_USER_SCOPE` +
+`GROUPS_LDAP_USER_SCOPE`
+| string
+| sub
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCOPE` +
+`GROUPS_LDAP_GROUP_SCOPE`
+| string
+| sub
+| +1.20.0
+|
+
+| `LDAP_USERFILTER` +
+`GROUPS_LDAP_USERFILTER`
+| string
+|
+| +1.20.0
+|
+
+| `LDAP_GROUPFILTER` +
+`GROUPS_LDAP_USERFILTER`
+| string
+|
+| +1.20.0
+|
+
+| `LDAP_USER_OBJECTCLASS` +
+`GROUPS_LDAP_USER_OBJECTCLASS`
+| string
+| inetOrgPerson
+| +1.20.0
+|
+
+| `LDAP_GROUP_OBJECTCLASS` +
+`GROUPS_LDAP_GROUP_OBJECTCLASS`
+| string
+| groupOfNames
+| +1.20.0
+|
+
+| `LDAP_LOGIN_ATTRIBUTES` +
+`GROUPS_LDAP_LOGIN_ATTRIBUTES`
+|
+| [uid mail]
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`GROUPS_IDP_URL`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_ID` +
+`GROUPS_LDAP_USER_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_ID_IS_OCTETSTRING` +
+`GROUPS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_MAIL` +
+`GROUPS_LDAP_USER_SCHEMA_MAIL`
+| string
+| mail
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_DISPLAYNAME` +
+`GROUPS_LDAP_USER_SCHEMA_DISPLAYNAME`
+| string
+| displayname
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_USERNAME` +
+`GROUPS_LDAP_USER_SCHEMA_USERNAME`
+|
+string
+| uid
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID` +
+`GROUPS_LDAP_GROUP_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING` +
+`GROUPS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_MAIL` +
+`GROUPS_LDAP_GROUP_SCHEMA_MAIL`
+| string
+| mail
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_DISPLAYNAME` +
+`GROUPS_LDAP_GROUP_SCHEMA_DISPLAYNAME`
+| string
+| cn
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_GROUPNAME` +
+`GROUPS_LDAP_GROUP_SCHEMA_GROUPNAME`
+| string
+| cn
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_MEMBER` +
+`GROUPS_LDAP_GROUP_SCHEMA_MEMBER`
+| string
+| member
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/nats_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/nats_configvars.adoc
@@ -1,0 +1,60 @@
+[caption=]
+.Environment variables for the nats extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `NATS_DEBUG_ADDR`
+| string
+|
+| +1.20.0
+|
+
+| `NATS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `NATS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `NATS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `NATS_NATS_HOST`
+| string
+| 127.0.0.1
+| +1.20.0
+|
+
+| `NATS_NATS_PORT`
+| int
+| 9233
+| +1.20.0
+|
+
+| `NATS_NATS_CLUSTER_ID`
+| string
+| ocis-cluster
+| +1.20.0
+|
+
+| `NATS_NATS_STORE_DIR`
+| string
+| ~/.ocis/nats
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/notifications_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/notifications_configvars.adoc
@@ -1,0 +1,92 @@
+[caption=]
+.Environment variables for the notifications extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `NOTIFICATIONS_DEBUG_ADDR`
+| string
+|
+| +1.20.0
+|
+
+| `NOTIFICATIONS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `NOTIFICATIONS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `NOTIFICATIONS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `NOTIFICATIONS_SMTP_HOST`
+| string
+| 127.0.0.1
+| +1.20.0
+|
+
+| `NOTIFICATIONS_SMTP_PORT`
+| string
+| 1025
+| +1.20.0
+|
+
+| `NOTIFICATIONS_SMTP_SENDER`
+| string
+| \god@example.com
+| +1.20.0
+|
+
+| `NOTIFICATIONS_SMTP_PASSWORD`
+| string
+| godisdead
+| +1.20.0
+|
+
+| `NOTIFICATIONS_EVENTS_ENDPOINT`
+| string
+| 127.0.0.1:9233
+| +1.20.0
+|
+
+| `NOTIFICATIONS_EVENTS_CLUSTER`
+| string
+| ocis-cluster
+| +1.20.0
+|
+
+| `NOTIFICATIONS_EVENTS_GROUP`
+| string
+| notifications
+| +1.20.0
+|
+
+| `REVA_GATEWAY` +
+`NOTIFICATIONS_REVA_GATEWAY`
+| string
+| 127.0.0.1:9142
+| +1.20.0
+|
+
+| `OCIS_MACHINE_AUTH_API_KEY` +
+`NOTIFICATIONS_MACHINE_AUTH_API_KEY`
+| string
+| change-me-please
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/ocdav_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/ocdav_configvars.adoc
@@ -1,0 +1,62 @@
+[caption=]
+.Environment variables for the ocdav extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `OCDAV_DEBUG_ADDR`
+| string
+| 127.0.0.1:9163
+| +1.20.0
+|
+
+| `OCDAV_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `OCDAV_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCDAV_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCDAV_HTTP_ADDR`
+| string
+| 127.0.0.1:0
+| +1.20.0
+| The address of the http service.
+
+| `OCDAV_HTTP_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the http service.
+
+| `OCIS_URL` +
+`OCDAV_PUBLIC_URL`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`OCDAV_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/ocs_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/ocs_configvars.adoc
@@ -1,0 +1,88 @@
+[caption=]
+.Environment variables for the ocs extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `OCS_DEBUG_ADDR`
+| string
+| 127.0.0.1:9114
+| +1.20.0
+|
+
+| `OCS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `OCS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCS_HTTP_ADDR`
+| string
+| 127.0.0.1:9110
+| +1.20.0
+|
+
+| `OCS_HTTP_ROOT`
+| string
+| /ocs
+| +1.20.0
+|
+
+| `OCIS_JWT_SECRET` +
+`OCS_JWT_SECRET`
+| string
+| Pive-Fumkiu4
+| +1.20.0
+|
+
+| `REVA_GATEWAY`
+| string
+| 127.0.0.1:9142
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`OCS_IDM_ADDRESS`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCS_ACCOUNT_BACKEND_TYPE`
+| string
+| cs3
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER` +
+`OCS_STORAGE_USERS_DRIVER`
+| string
+| ocis
+| +1.20.0
+|
+
+| `OCIS_MACHINE_AUTH_API_KEY` +
+`OCS_MACHINE_AUTH_API_KEY`
+| string
+| change-me-please
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/proxy_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/proxy_configvars.adoc
@@ -1,0 +1,154 @@
+[caption=]
+.Environment variables for the proxy extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `PROXY_DEBUG_ADDR`
+| string
+| 127.0.0.1:9205
+| +1.20.0
+|
+
+| `PROXY_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `PROXY_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `PROXY_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `PROXY_HTTP_ADDR`
+| string
+| 0.0.0.0:9200
+| +1.20.0
+|
+
+| `PROXY_HTTP_ROOT`
+| string
+| /
+| +1.20.0
+|
+
+| `PROXY_TRANSPORT_TLS_CERT`
+| string
+| ~/.ocis/proxy/server.crt
+| +1.20.0
+|
+
+| `PROXY_TRANSPORT_TLS_KEY`
+| string
+| ~/.ocis/proxy/server.key
+| +1.20.0
+|
+
+| `PROXY_TLS`
+| bool
+| true
+| +1.20.0
+|
+
+| `REVA_GATEWAY`
+| string
+| 127.0.0.1:9142
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`PROXY_OIDC_ISSUER`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`PROXY_OIDC_INSECURE`
+| bool
+| true
+| +1.20.0
+|
+
+| `PROXY_OIDC_USERINFO_CACHE_SIZE`
+| int
+| 1024
+| +1.20.0
+|
+
+| `PROXY_OIDC_USERINFO_CACHE_TTL`
+| int
+| 10
+| +1.20.0
+|
+
+| `OCIS_JWT_SECRET` +
+`PROXY_JWT_SECRET`
+| string
+| Pive-Fumkiu4
+| +1.20.0
+|
+
+| `PROXY_ENABLE_PRESIGNEDURLS`
+| bool
+| true
+| +1.20.0
+|
+
+| `PROXY_ACCOUNT_BACKEND_TYPE`
+| string
+| cs3
+| +1.20.0
+|
+
+| `PROXY_USER_OIDC_CLAIM`
+| string
+| email
+| +1.20.0
+|
+
+| `PROXY_USER_CS3_CLAIM`
+| string
+| mail
+| +1.20.0
+|
+
+| `OCIS_MACHINE_AUTH_API_KEY` +
+`PROXY_MACHINE_AUTH_API_KEY`
+| string
+| change-me-please
+| +1.20.0
+|
+
+| `PROXY_AUTOPROVISION_ACCOUNTS`
+| bool
+| false
+| +1.20.0
+|
+
+| `PROXY_ENABLE_BASIC_AUTH`
+| bool
+| false
+| +1.20.0
+|
+
+| `PROXY_INSECURE_BACKENDS`
+| bool
+| false
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/sharing_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/sharing_configvars.adoc
@@ -1,0 +1,103 @@
+[caption=]
+.Environment variables for the sharing extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `SHARING_DEBUG_ADDR`
+| string
+| 127.0.0.1:9151
+| +1.20.0
+|
+
+| `SHARING_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `SHARING_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `SHARING_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `SHARING_GRPC_ADDR`
+| string
+| 127.0.0.1:9150
+| +1.20.0
+| The address of the grpc service.
+
+| `SHARING_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `SHARING_USER_JSON_FILE`
+| string
+| ~/.ocis/storage/shares.json
+| +1.20.0
+|
+
+| `SHARING_USER_SQL_USERNAME`
+| string
+|
+| +1.20.0
+|
+
+| `SHARING_USER_SQL_PASSWORD`
+| string
+|
+| +1.20.0
+|
+
+| `SHARING_USER_SQL_HOST`
+| string
+|
+| +1.20.0
+|
+
+| `SHARING_USER_SQL_PORT`
+| int
+| 1433
+| +1.20.0
+|
+
+| `SHARING_USER_SQL_NAME`
+| string
+|
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`SHARING_CS3_SERVICE_USER_IDP`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `OCIS_MACHINE_AUTH_API_KEY`
+| string
+|
+| +1.20.0
+|
+
+| `OCIS_MACHINE_AUTH_API_KEY`
+| string
+|
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/storage-metadata_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/storage-metadata_configvars.adoc
@@ -1,0 +1,79 @@
+[caption=]
+.Environment variables for the storage-metadata extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| STORAGE_METADATA_DEBUG_ADDR
+| string
+| 127.0.0.1:9217
+| +1.20.0
+|
+
+| STORAGE_METADATA_DEBUG_TOKEN
+| string
+|
+| +1.20.0
+|
+
+| STORAGE_METADATA_DEBUG_PPROF
+| bool
+| false
+| +1.20.0
+|
+
+| STORAGE_METADATA_DEBUG_ZPAGES
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_METADATA_GRPC_ADDR`
+| string
+| 127.0.0.1:9215
+| +1.20.0
+| The address of the grpc service.
+
+| `STORAGE_METADATA_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `STORAGE_METADATA_GRPC_ADDR`
+| string
+| 127.0.0.1:9216
+| +1.20.0
+| The address of the grpc service.
+
+| `STORAGE_METADATA_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `STORAGE_METADATA_DRIVER`
+| string
+| ocis
+| +1.20.0
+| The driver which should be used by the service
+
+| `STORAGE_METADATA_DRIVER_OCIS_ROOT`
+| string
+| ~/.ocis/storage/metadata
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`STORAGE_METADATA_DATAPROVIDER_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/storage-publiclink_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/storage-publiclink_configvars.adoc
@@ -1,0 +1,48 @@
+[caption=]
+.Environment variables for the storage-publiclink extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `STORAGE_METADATA_DEBUG_ADDR`
+| string
+| 127.0.0.1:9179
+| +1.20.0
+|
+
+| `STORAGE_METADATA_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `STORAGE_METADATA_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_METADATA_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_METADATA_GRPC_ADDR`
+| string
+| 127.0.0.1:9178
+| +1.20.0
+| The address of the grpc service.
+
+| `STORAGE_METADATA_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/storage-shares_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/storage-shares_configvars.adoc
@@ -1,0 +1,48 @@
+[caption=]
+.Environment variables for the storage-shares extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `STORAGE_METADATA_DEBUG_ADDR`
+| string
+| 127.0.0.1:9179
+| +1.20.0
+|
+
+| `STORAGE_METADATA_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `STORAGE_METADATA_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_METADATA_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_METADATA_GRPC_ADDR`
+| string
+| 127.0.0.1:9178
+| +1.20.0
+| The address of the grpc service.
+
+| `STORAGE_METADATA_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/storage-users_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/storage-users_configvars.adoc
@@ -1,0 +1,139 @@
+[caption=]
+.Environment variables for the storage-users extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `STORAGE_USERS_DEBUG_ADDR`
+| string
+| 127.0.0.1:9159
+| +1.20.0
+|
+
+| `STORAGE_USERS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `STORAGE_USERS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_USERS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORAGE_USERS_GRPC_ADDR`
+| string
+| 127.0.0.1:9157
+| +1.20.0
+| The address of the grpc service.
+
+| `STORAGE_USERS_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `STORAGE_USERS_GRPC_ADDR`
+| string
+| 127.0.0.1:9158
+| +1.20.0
+| The address of the grpc service.
+
+| `STORAGE_USERS_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `STORAGE_USERS_DRIVER`
+| string
+| ocis
+| +1.20.0
+| The storage driver which should be used by the service
+
+| `STORAGE_USERS_LOCAL_ROOT`
+| string
+| ~/.ocis/storage/local/users
+| +1.20.0
+|
+
+| `STORAGE_USERS_OCIS_ROOT`
+| string
+| ~/.ocis/storage/users
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_DATADIR`
+| string
+| ~/.ocis/storage/owncloud
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_SHARE_FOLDER`
+| string
+| /Shares
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_LAYOUT`
+| string
+| {{.Username}}
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_UPLOADINFO_DIR`
+| string
+| ~/.ocis/storage/uploadinfo
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBUSERNAME`
+| string
+| owncloud
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBPASSWORD`
+| string
+| owncloud
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBHOST`
+| string
+|
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBPORT`
+| int
+| 3306
+| +1.20.0
+|
+
+| `STORAGE_USERS_DRIVER_OWNCLOUDSQL_DBNAME`
+| string
+| owncloud
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`STORAGE_USERS_DATAPROVIDER_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/store_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/store_configvars.adoc
@@ -1,0 +1,48 @@
+[caption=]
+.Environment variables for the store_configvars extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `STORE_DEBUG_ADDR`
+| string
+| 127.0.0.1:9464
+| +1.20.0
+|
+
+| `STORE_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `STORE_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORE_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `STORE_GRPC_ADDR`
+| string
+| 127.0.0.1:9460
+| +1.20.0
+|
+
+| `STORE_DATA_PATH`
+| string
+| ~/.ocis/store
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/thumbnails_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/thumbnails_configvars.adoc
@@ -1,0 +1,98 @@
+[caption=]
+.Environment variables for the thumbnails_configvars extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `THUMBNAILS_DEBUG_ADDR`
+| string
+| 127.0.0.1:9189
+| +1.20.0
+|
+
+| `THUMBNAILS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `THUMBNAILS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `THUMBNAILS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `THUMBNAILS_GRPC_ADDR`
+| string
+| 127.0.0.1:9185
+| +1.20.0
+|
+
+| `THUMBNAILS_HTTP_ADDR`
+| string
+| 127.0.0.1:9186
+| +1.20.0
+|
+
+| `THUMBNAILS_HTTP_ROOT`
+| string
+| /thumbnails
+| +1.20.0
+|
+
+| `THUMBNAILS_FILESYSTEMSTORAGE_ROOT`
+| string
+| ~/.ocis/thumbnails
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`THUMBNAILS_WEBDAVSOURCE_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `OCIS_INSECURE` +
+`THUMBNAILS_CS3SOURCE_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `REVA_GATEWAY`
+| string
+| 127.0.0.1:9142
+| +1.20.0
+|
+
+| `THUMBNAILS_TXT_FONTMAP_FILE`
+| string
+|
+| +1.20.0
+|
+
+| `THUMBNAILS_TRANSFER_TOKEN`
+| string
+| changemeplease
+| +1.20.0
+|
+
+| `THUMBNAILS_DATA_ENDPOINT`
+| string
+| \http://127.0.0.1:9186/thumbnails/data
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/user_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/user_configvars.adoc
@@ -1,0 +1,230 @@
+[caption=]
+.Environment variables for the user extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `USERS_DEBUG_ADDR`
+| string
+| 127.0.0.1:9145
+| +1.20.0
+|
+
+| `USERS_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `USERS_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `USERS_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `USERS_GRPC_ADDR`
+| string
+| 127.0.0.1:9144
+| +1.20.0
+| The address of the grpc service.
+
+| `USERS_GRPC_PROTOCOL`
+| string
+| tcp
+| +1.20.0
+| The transport protocol of the grpc service.
+
+| `LDAP_URI` +
+`USERS_LDAP_URI`
+| string
+| ldaps://localhost:9235
+| +1.20.0
+|
+
+| `LDAP_CACERT` +
+`USERS_LDAP_CACERT`
+| string
+| ~/.ocis/idm/ldap.crt
+| +1.20.0
+|
+
+| `LDAP_INSECURE` +
+`USERS_LDAP_INSECURE`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_BIND_DN`
+`USERS_LDAP_BIND_DN`
+| string
+| uid=reva,ou=sysusers,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_BIND_PASSWORD` +
+`USERS_LDAP_BIND_PASSWORD`
+| string
+| reva
+| +1.20.0
+|
+
+| `LDAP_USER_BASE_DN` +
+`USERS_LDAP_USER_BASE_DN`
+| string
+| ou=users,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_GROUP_BASE_DN` +
+`USERS_LDAP_GROUP_BASE_DN`
+| string
+| ou=groups,o=libregraph-idm
+| +1.20.0
+|
+
+| `LDAP_USER_SCOPE` +
+`USERS_LDAP_USER_SCOPE`
+| string
+| sub
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCOPE` +
+`USERS_LDAP_GROUP_SCOPE`
+| string
+| sub
+| +1.20.0
+|
+
+| `LDAP_USERFILTER` +
+`USERS_LDAP_USERFILTER`
+| string
+|
+| +1.20.0
+|
+
+| `LDAP_GROUPFILTER` +
+`USERS_LDAP_USERFILTER`
+| string
+|
+| +1.20.0
+|
+
+| `LDAP_USER_OBJECTCLASS` +
+`USERS_LDAP_USER_OBJECTCLASS`
+| string
+| inetOrgPerson
+| +1.20.0
+|
+
+| `LDAP_GROUP_OBJECTCLASS` +
+`USERS_LDAP_GROUP_OBJECTCLASS`
+| string
+| groupOfNames
+| +1.20.0
+|
+
+| `LDAP_LOGIN_ATTRIBUTES` +
+`USERS_LDAP_LOGIN_ATTRIBUTES`
+|
+| [uid mail]
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`USERS_IDP_URL`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_ID` +
+`USERS_LDAP_USER_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_ID_IS_OCTETSTRING` +
+`USERS_LDAP_USER_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_MAIL` +
+`USERS_LDAP_USER_SCHEMA_MAIL`
+| string
+| mail
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_DISPLAYNAME` +
+`USERS_LDAP_USER_SCHEMA_DISPLAYNAME`
+| string
+| displayname
+| +1.20.0
+|
+
+| `LDAP_USER_SCHEMA_USERNAME` +
+`USERS_LDAP_USER_SCHEMA_USERNAME`
+| string
+| uid
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID` +
+`USERS_LDAP_GROUP_SCHEMA_ID`
+| string
+| ownclouduuid
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING` +
+`USERS_LDAP_GROUP_SCHEMA_ID_IS_OCTETSTRING`
+| bool
+| false
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_MAIL` +
+`USERS_LDAP_GROUP_SCHEMA_MAIL`
+| string
+| mail
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_DISPLAYNAME` +
+`USERS_LDAP_GROUP_SCHEMA_DISPLAYNAME`
+| string
+| cn
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_GROUPNAME` +
+`USERS_LDAP_GROUP_SCHEMA_GROUPNAME`
+| string
+| cn
+| +1.20.0
+|
+
+| `LDAP_GROUP_SCHEMA_MEMBER` +
+`USERS_LDAP_GROUP_SCHEMA_MEMBER`
+| string
+| member
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/web_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/web_configvars.adoc
@@ -1,0 +1,129 @@
+[caption=]
+.Environment variables for the web extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `WEB_DEBUG_ADDR`
+| string
+| 127.0.0.1:9104
+| +1.20.0
+|
+
+| `WEB_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `WEB_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `WEB_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `WEB_HTTP_ADDR`
+| string
+| 127.0.0.1:9100
+| +1.20.0
+|
+
+| `WEB_HTTP_ROOT`
+| string
+| /
+| +1.20.0
+|
+
+| `WEB_CACHE_TTL`
+| int
+| 604800
+| +1.20.0
+|
+
+| `WEB_ASSET_PATH`
+| string
+|
+| +1.20.0
+|
+
+| `WEB_UI_CONFIG`
+| string
+|
+| +1.20.0
+|
+
+| `WEB_UI_PATH`
+| string
+|
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`WEB_UI_THEME_SERVER`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `WEB_UI_THEME_PATH`
+| string
+| /themes/owncloud/theme.json
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`WEB_UI_CONFIG_SERVER`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `WEB_UI_CONFIG_VERSION`
+| string
+| 0.1.0
+| +1.20.0
+|
+
+| `WEB_OIDC_METADATA_URL`
+| string
+|
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`WEB_OIDC_AUTHORITY`
+| string
+| \https://localhost:9200
+| +1.20.0
+|
+
+| `WEB_OIDC_CLIENT_ID`
+| string
+| web
+| +1.20.0
+|
+
+| `WEB_OIDC_RESPONSE_TYPE`
+| string
+| code
+| +1.20.0
+|
+
+| `WEB_OIDC_SCOPE`
+| string
+| openid profile email
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated

--- a/modules/ROOT/partials/extension_tables/webdav_configvars.adoc
+++ b/modules/ROOT/partials/extension_tables/webdav_configvars.adoc
@@ -1,0 +1,67 @@
+[caption=]
+.Environment variables for the webdav extension
+[width="100%",cols="~,~,~,~,~",options="header"]
+|===
+| Name
+| Type
+| Default Value
+| Since Version
+| Description
+
+| `WEBDAV_DEBUG_ADDR`
+| string
+| 127.0.0.1:9119
+| +1.20.0
+|
+
+| `WEBDAV_DEBUG_TOKEN`
+| string
+|
+| +1.20.0
+|
+
+| `WEBDAV_DEBUG_PPROF`
+| bool
+| false
+| +1.20.0
+|
+
+| `WEBDAV_DEBUG_ZPAGES`
+| bool
+| false
+| +1.20.0
+|
+
+| `WEBDAV_HTTP_ADDR`
+| string
+| 127.0.0.1:9115
+| +1.20.0
+|
+
+| `WEBDAV_HTTP_ROOT`
+| string
+| /
+| +1.20.0
+|
+
+| `OCIS_URL` +
+`OCIS_PUBLIC_URL`
+| string
+| \https://127.0.0.1:9200
+| +1.20.0
+|
+
+| `STORAGE_WEBDAV_NAMESPACE`
+| string
+| /users/{{.Id.OpaqueId}}
+| +1.20.0
+|
+
+| `REVA_GATEWAY`
+| string
+| 127.0.0.1:9142
+| +1.20.0
+|
+|===
+
+Since Version: `+` added, `-` deprecated


### PR DESCRIPTION
Adding the current known configvar files from extensions contaning known environment variables - as starting point as this all is under heavy development.

Note that these files will be autogenerated in future and will contain actual data.
See:  https://github.com/owncloud/ocis/issues/3583 (Environment variable tables from extensions for admin docs (as includable .adoc file))

When this happens, we will include from external source and get rid of the problem that tables may have outdated content. The files merged here will be removed.