### PR TITLE
ocis init container

### DIFF
--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -78,7 +78,7 @@ Alternatively, install Docker depending on your OS from the Docker site. See {in
 
 === Check the Docker Group Membership
 
-Running a docker container without root privileges (`sudo`), requires the user to be a member of the docker group.
+Running a Docker container without root privileges (`sudo`), requires the user to be a member of the docker group.
 
 First check if the docker group is already created and you are member of this group:
 
@@ -92,7 +92,7 @@ cat /etc/group | grep docker
 docker:x:998:<your-user-name>
 ----
 
-If the group does not exist or you are not member of, continue with {docker-post-url}[Post-installation steps for Linux] to create the group respectively add your user to the group.
+If the group does not exist or you are not a member, continue with {docker-post-url}[Post-installation steps for Linux] to create the group and add your user to it.
 
 == Image Management
 
@@ -177,21 +177,21 @@ sudo docker rmi <image-id>
 
 == Start the oCIS Runtime
 
-The start of oCIS is made in two steps:
+oCIS is started in two steps:
 
 * A first time start to initiate the system and
-* A recurring start post initialisation.
+* a recurring start after initialization.
 
-Note the xref:deployment/general/general-info.adoc#default-users-and-groups[Default Users and Groups] section if you want to have demo users created when inizializing the system.
+Refer to the xref:deployment/general/general-info.adoc#default-users-and-groups[Default Users and Groups] section if you want to have demo users created when initializing the system.
 
 === Preperation
 
-In the examples shown, bind mounts with following folders are used to keep data persistent, located in your home directory. Change the locations according your needs:
+In the examples shown below, bind mounts with the following folders are used to keep data persistent and located in your home directory. Change the locations according your needs:
  
-* For the config the folder `~/ocis/ocis-config`
-* For the data the folder `~/ocis/ocis-data`
+* For the config we use the folder `~/ocis/ocis-config`.
+* For data we use the folder `~/ocis/ocis-data`.
 
-The oCIS container runs internally with the default user and group ID of 1000. To check this type:
+The oCIS container runs internally with the default user and group ID of 1000. To check this, type:
 
 [source,bash]
 ----
@@ -202,9 +202,9 @@ sudo docker inspect owncloud/ocis | less | grep -i user | sort -u
 "User": "1000",
 ----
 
-For the folders above, following rules apply:
+For the folders above, the following rules apply:
 
-* Because _bind-mounts_ used below create paths if they do not extist with the root user and group, the container user can not write into them. To overcome this issue, you have to create both folders upfront manually to avoid a permission denied problem. To do so type:
+* Because _bind-mounts_ (used in the example below) create paths if they do not exist with the root user and group, the container user cannot write into them. To overcome this issue, you have to create both folders upfront manually to avoid a permission denied problem. To do so, type:
 +
 --
 [source,bash]
@@ -217,19 +217,19 @@ mkdir -p ~/ocis/ocis-data
 ----
 --
 
-* The user you have logged in with must have the default user and group ID of 1000 to match the container user and group ID. If this does not match, you must take care that the container user can write into the created paths. As an example to do so type:
+* The user you have logged in with must have the default user and group ID of 1000 to match the container user and group ID. If this does not match, you must take care that the container user can write into the created paths. You can do this for example with the command:
 +
 --
 [source,bash]
 ----
 sudo chown -Rfv 1000:1000 ocis/
 ----
-In case, you now need to access the content of the `ocis` folder with root previledges or with a user matching the ID's.
+In this case, you need to access the content of the `ocis` folder with root privileges or with a user matching the owner ID.
 --
 
 === First Time Start
 
-oCIS needs a first time initialisation which will setup your enviroment. You will get questions asked and a default `ocis.yaml` file will be generated which you further can configure. Note that if you do not define a host directory like with a bind mount as target location, the initial setup will get lost because the container ends post executing the command. ownCloud therefore recommends either using bind mounts or docker volumes to make the initial setup, changes and your data persistent.
+oCIS needs a first time initialization to set up the environment. You will need to answer questions as basis for a default `ocis.yaml` file to be generated. This file you can edit later. Note that if you do not define a host directory with a bind mount as target location, the initial setup will get lost because the container ends after executing the command. ownCloud therefore recommends either using bind mounts or Docker volumes to make the initial setup, further changes and your data persistent.
 
 [source,bash]
 ----
@@ -271,11 +271,11 @@ WARNING: While this is not used in production and for testing purposes only, you
 
 === Delete a Setup
 
-If you want to delete your setup, which is _both_ the configuration and the data, just delete the `ocis-config` and the `ocis-data` folder and restart the process from this chapter.
+If you want to delete your setup, which is _both_ the configuration and the data, just delete the `ocis-config` and the `ocis-data` folder and restart the process described in this chapter.
 
 == Execute oCIS Commands
 
-To execute oCIS commands, you have to enter the shell of the running container. To do so xref:list-running-containers[list the running containers] first and type the following command replacing the <container-id> accordingly:
+To execute oCIS commands, you have to enter the shell of the running container. To do so, xref:list-running-containers[list the running containers] first and type the following command replacing the <container-id> accordingly:
 
 [source,bash]
 ----
@@ -308,7 +308,7 @@ Defines the port mapping `<hostPort>:<containerPort>`. Use the port mapping if y
 Tell the Docker daemon to clean up the container and remove the file system after the container exits.
 
 --env-file: Read in a file of environment variables::
-If you have more environment variables to hand over, put them all in a file and use this command-line option. Preferably have `/etc/ocis` at your host as location. See xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules] for more details.
+If you have more environment variables to hand over, put them all in a file and use this command-line option. Preferably use `/etc/ocis` on your host as location. See xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules] for more details.
 
 --name: Assign a name to the container::
 By default, containers created with _docker run_ are given a random name like `small_roentgen` which may not be suitable to identify their purpose properly. Giving containers a meaningful name helps identifying them more easily.
@@ -320,7 +320,7 @@ See the details in the _docker run_ documentation for available options. Conside
 {docker-mount-url}[Docker volumes] are completely managed by Docker and have no server OS dependency. See {docker-mount-nfs-url}[Create a service which creates an NFS volume] for an example. Note the volume mount target path `target=/var/lib/ocis` which uses the default oCIS data path if not otherwise defined. Note that the directory on the host must already exist, it will not be created. 
 
 --volume, -v: Bind mount a volume::
-{docker-bindmount-url}[Bind mounts] depend on the directory structure and OS of your server. Use this type to mount a local directory of your OS. Example: `-v /some/host/dir:/var/lib/ocis` which uses the default oCIS data path if not otherwise defined. If the bind-mount points to a directory that does not yet exist on the host, the directory will be created automatically - using the user the docker _service_ runs with, usually the root user.
+{docker-bindmount-url}[Bind mounts] depend on the directory structure and OS of your server. Use this type to mount a local directory of your OS. Example: `-v /some/host/dir:/var/lib/ocis`, which uses the default oCIS data path if not otherwise defined. If the bind-mount points to a directory that does not yet exist on the host, the directory will be created automatically using the user the docker _service_ runs with, usually the root user.
 +
 NOTE: The filesystem at your OS mount point must be a xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[supported filesystem] which supports extended attributes.
 +

--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -5,6 +5,7 @@
 :install-docker-server-url: https://docs.docker.com/engine/install/#server
 :install-docker-desktop-url: https://docs.docker.com/engine/install/#desktop
 :install-d-compose-url: https://docs.docker.com/compose/install/
+:docker-post-url: https://docs.docker.com/engine/install/linux-postinstall/
 :docker-cli-url: https://docs.docker.com/engine/reference/commandline/run/
 :docker-logs-url: https://docs.docker.com/engine/reference/commandline/logs/
 :docker-stop-url: https://docs.docker.com/engine/reference/commandline/stop/
@@ -75,6 +76,24 @@ Alternatively, install Docker depending on your OS from the Docker site. See {in
 
 * When using macOS, you have to install {docker-desktop-url}[Docker Desktop] which includes the Docker Engine, the Docker CLI client, Docker Compose, {docker-dashboard-url}[Docker Dashboard] and other tools.
 
+=== Check the Docker Group Membership
+
+Running a docker container without root privileges (`sudo`), requires the user to be a member of the docker group.
+
+First check if the docker group is already created and you are member of this group:
+
+[source,bash]
+----
+cat /etc/group | grep docker
+----
+
+[source,plaintext]
+----
+docker:x:998:<your-user-name>
+----
+
+If the group does not exist or you are not member of, continue with {docker-post-url}[Post-installation steps for Linux] to create the group respectively add your user to the group.
+
 == Image Management
 
 === Download the oCIS Image
@@ -85,7 +104,7 @@ Alternatively, install Docker depending on your OS from the Docker site. See {in
 
 To give some terminology guidance, images are unchangeable snapshots of live containers, while containers are running (or stopped) instances of an image.
 
-* To download the latest oCIS image, run the following command. Note that this command will download the correct image suitable for your OS if available. For Windows, oCIS Docker images are not available, but might be in the future:
+* To download the _latest_ oCIS image, run the following command. Note that this command will download the correct image suitable for your OS if available. For Windows, oCIS Docker images are not available, but might be in the future. The _latest_ tag always reflects the current master branch:
 +
 [source,bash]
 ----
@@ -158,6 +177,73 @@ sudo docker rmi <image-id>
 
 == Start the oCIS Runtime
 
+The start of oCIS is made in two steps:
+
+* A first time start to initiate the system and
+* A recurring start post initialisation.
+
+Note the xref:deployment/general/general-info.adoc#default-users-and-groups[Default Users and Groups] section if you want to have demo users created when inizializing the system.
+
+=== Preperation
+
+In the examples shown, bind mounts with following folders are used to keep data persistent, located in your home directory. Change the locations according your needs:
+ 
+* For the config the folder `~/ocis/ocis-config`
+* For the data the folder `~/ocis/ocis-data`
+
+The oCIS container runs internally with the default user and group ID of 1000. To check this type:
+
+[source,bash]
+----
+sudo docker inspect owncloud/ocis | less | grep -i user | sort -u
+----
+[source,plaintext]
+----
+"User": "1000",
+----
+
+For the folders above, following rules apply:
+
+* Because _bind-mounts_ used below create paths if they do not extist with the root user and group, the container user can not write into them. To overcome this issue, you have to create both folders upfront manually to avoid a permission denied problem. To do so type:
++
+--
+[source,bash]
+----
+mkdir -p ~/ocis/ocis-config
+----
+[source,bash]
+----
+mkdir -p ~/ocis/ocis-data
+----
+--
+
+* The user you have logged in with must have the default user and group ID of 1000 to match the container user and group ID. If this does not match, you must take care that the container user can write into the created paths. As an example to do so type:
++
+--
+[source,bash]
+----
+sudo chown -Rfv 1000:1000 ocis/
+----
+In case, you now need to access the content of the `ocis` folder with root previledges or with a user matching the ID's.
+--
+
+=== First Time Start
+
+oCIS needs a first time initialisation which will setup your enviroment. You will get questions asked and a default `ocis.yaml` file will be generated which you further can configure. Note that if you do not define a host directory like with a bind mount as target location, the initial setup will get lost because the container ends post executing the command. ownCloud therefore recommends either using bind mounts or docker volumes to make the initial setup, changes and your data persistent.
+
+[source,bash]
+----
+docker run --rm -it \
+    -v ~/ocis/ocis-config:/etc/ocis \
+    owncloud/ocis init
+----
+
+On success, you will see a message like:
+ 
+include::partial$deployment/ocis_init.adoc[]
+
+=== Recurring Start of oCIS
+
 When you run the oCIS container, you _must_ specify at least the `OCIS_URL` as environment variable to have browser access. This is  because `localhost` would point to a location inside the container and not to the server being accessed. For details see: xref:deployment/general/general-info.adoc#configurations-to-access-the-webui[Configurations to Access the WebUI].
 
 In the example below, replace `<your-hostname>` with the host name or IP address of your server.
@@ -171,15 +257,38 @@ sudo docker run \
     --rm \
     -it \
     -p 9200:9200 \
+    -v ~/ocis/ocis-config:/etc/ocis \
+    -v ~/ocis/ocis-data:/var/lib/ocis \
     -e OCIS_INSECURE=true \
     -e PROXY_HTTP_ADDR=0.0.0.0:9200 \
     -e OCIS_URL=https://<your-hostname>:9200 \
     owncloud/ocis
 ----
 
-TIP: Be aware that, when starting the container, the xref:deployment/general/general-info.adoc#define-the-ocis-data-path[oCIS data path] is by default _inside_ the container at `/var/lib/ocis` and therefore not persistent. All your data will be lost when the container stops. If you want to make the content of the oCIS data path persistent, you need to either mount a {docker-mount-url}[Docker volume] (`--mount`) or use a {docker-bindmount-url}[bind-mount] (`--volume, -v`). For details see the Docker command-line options below.
+To access oCIS, open your browser and type `\https://<your-hostname>:9200`.
 
 WARNING: While this is not used in production and for testing purposes only, you could run more than one oCIS runtime container concurrently. In such a case, you have to define different ports and data paths for each of the runtime containers to avoid unexpected behavior.
+
+=== Delete a Setup
+
+If you want to delete your setup, which is _both_ the configuration and the data, just delete the `ocis-config` and the `ocis-data` folder and restart the process from this chapter.
+
+== Execute oCIS Commands
+
+To execute oCIS commands, you have to enter the shell of the running container. To do so xref:list-running-containers[list the running containers] first and type the following command replacing the <container-id> accordingly:
+
+[source,bash]
+----
+docker exec -it <container-id> sh
+----
+
+You can now use commands like `ocis --help` or others to  xref:deployment/general/general-info.adoc#managing-extensions[manage your runtime extensions].
+
+To exit the container's shell, either type kbd:[exit] or kbd:[CTRL+D].
+
+// fixme: after a call with @cdegen, it is currently not clear how to restart a runtime extension properly as the extension needs an extension yaml file (see --config-file) and the question is - where is the location of this file - it cant be inside the container!
+
+== Useful Docker Parameters
 
 The following {docker-cli-url}[Docker command-line options] are quite helpful to know:
 
@@ -199,7 +308,7 @@ Defines the port mapping `<hostPort>:<containerPort>`. Use the port mapping if y
 Tell the Docker daemon to clean up the container and remove the file system after the container exits.
 
 --env-file: Read in a file of environment variables::
-If you have more environment variables to hand over, put them all in a file and use this command-line option. Preferably have `/etc/ocis` as location. See xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules] for more details.
+If you have more environment variables to hand over, put them all in a file and use this command-line option. Preferably have `/etc/ocis` at your host as location. See xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules] for more details.
 
 --name: Assign a name to the container::
 By default, containers created with _docker run_ are given a random name like `small_roentgen` which may not be suitable to identify their purpose properly. Giving containers a meaningful name helps identifying them more easily.
@@ -208,29 +317,14 @@ By default, containers created with _docker run_ are given a random name like `s
 See the details in the _docker run_ documentation for available options. Consider `always` as a good starting point.
 
 --mount: Attach a filesystem mount to the container::
-{docker-mount-url}[Docker volumes] are completely managed by Docker and have no server OS dependency. See {docker-mount-nfs-url}[Create a service which creates an NFS volume] for an example. Note the volume mount target path `target=/var/lib/ocis` which uses the default oCIS data path if not otherwise defined.
+{docker-mount-url}[Docker volumes] are completely managed by Docker and have no server OS dependency. See {docker-mount-nfs-url}[Create a service which creates an NFS volume] for an example. Note the volume mount target path `target=/var/lib/ocis` which uses the default oCIS data path if not otherwise defined. Note that the directory on the host must already exist, it will not be created. 
 
 --volume, -v: Bind mount a volume::
-{docker-bindmount-url}[Bind mounts] depend on the directory structure and OS of your server. Use this type to mount a local directory of your OS. Example: `-v /some/host/dir:/var/lib/ocis` which uses the default oCIS data path if not otherwise defined.
+{docker-bindmount-url}[Bind mounts] depend on the directory structure and OS of your server. Use this type to mount a local directory of your OS. Example: `-v /some/host/dir:/var/lib/ocis` which uses the default oCIS data path if not otherwise defined. If the bind-mount points to a directory that does not yet exist on the host, the directory will be created automatically - using the user the docker _service_ runs with, usually the root user.
 +
 NOTE: The filesystem at your OS mount point must be a xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[supported filesystem] which supports extended attributes.
 +
 WARNING: macOS cannot use bind mounts, as Docker Desktop for macOS does currently not fully support extended attributes. Use a Docker volume for persistent data instead.
-
-== Execute oCIS Commands
-
-To execute oCIS commands, you have to enter the shell of the running container. To do so xref:list-running-containers[list the running containers] first and type the following command replacing the <container-id> accordingly:
-
-[source,bash]
-----
-docker exec -it <container-id> sh
-----
-
-You can now use commands like `ocis --help` or others to  xref:deployment/general/general-info.adoc#managing-extensions[manage your runtime extensions].
-
-To exit the container's shell, either type kbd:[exit] or kbd:[CTRL+D].
-
-// fixme: after a call with @cdegen, it is currently not clear how to restart a runtime extension properly as the extension needs an extension yaml file (see --config-file) and the question is - where is the location of this file - it cant be inside the container!
 
 == Useful Docker Commands
 

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -156,7 +156,7 @@ NOTE: Administrators must be aware of the sources, the location and order applie
 
 . The default locations for config files are:
 +
-* For container images +
+* For container images (inside the container) +
 `/etc/ocis/`
 +
 * For binary releases +

--- a/modules/ROOT/partials/deployment/ocis_init.adoc
+++ b/modules/ROOT/partials/deployment/ocis_init.adoc
@@ -1,0 +1,12 @@
+[source,plaintext]
+----
+Do want to configure oCIS with certificate checking disabled?
+ This is not recommended for public instances! [yes | no = default]
+
+=========================================
+ generated OCIS Config
+=========================================
+ configpath : /etc/ocis/ocis-config/ocis.yaml
+ user       : admin
+ password   : <removed for documentation>
+----

--- a/modules/ROOT/partials/deployment/ocis_init.adoc
+++ b/modules/ROOT/partials/deployment/ocis_init.adoc
@@ -1,6 +1,6 @@
 [source,plaintext]
 ----
-Do want to configure oCIS with certificate checking disabled?
+Do you want to configure oCIS with certificate checking disabled?
  This is not recommended for public instances! [yes | no = default]
 
 =========================================


### PR DESCRIPTION
This fixes the container documentaion with regards to the `ocis init` command recently added.

Already on staging.

Note, the binary part and the quick guide will come next.