### PR TITLE
Rename the appprovider extension

### DIFF
--- a/modules/ROOT/pages/deployment/extensions/app-provider.adoc
+++ b/modules/ROOT/pages/deployment/extensions/app-provider.adoc
@@ -14,13 +14,13 @@
 
 === Environment Variables
 
-The `appprovider` extension is configured via the following environment variables:
+The `app-provider` extension is configured via the following environment variables:
 
-include::partial$extension_tables/appprovider_configvars.adoc[]
+include::partial$extension_tables/app-provider_configvars.adoc[]
 
 === YAML Example
 
 [source,yaml]
 ----
-include::{ocis-ext-includes}appprovider-config-example.yaml[]
+include::{ocis-ext-includes}app-provider-config-example.yaml[]
 ----

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -12,7 +12,7 @@
 *** xref:deployment/security/security.adoc[Securing oCIS]
 *** xref:deployment/nfs/nfs.adoc[Network File System Deployment]
 *** xref:deployment/extensions/extensions.adoc[Extensions]
-**** xref:deployment/extensions/appprovider.adoc[App Provider]
+**** xref:deployment/extensions/app-provider.adoc[App Provider]
 **** xref:deployment/extensions/audit.adoc[Audit]
 **** xref:deployment/extensions/auth-basic.adoc[Auth Basic]
 **** xref:deployment/extensions/auth-bearer.adoc[Auth Bearer]


### PR DESCRIPTION
Renaming the extension `appprovider` --> `app-provider`

References: https://github.com/owncloud/ocis/pull/3665 (approvider -> app-provider)

Note that the yaml file cant be rendered atm because the referenced PR needs merging first. Post merging and on the next docs build, rendering will be fine automatically. 