### PR TITLE
Add missing apostrophs to attribute

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -73,7 +73,7 @@ asciidoc:
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
     ocis-version: '2.0.0'
-    ocis-ext-includes: https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/
+    ocis-ext-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
 #   desktop
     latest-desktop-version: 'next'
     previous-desktop-version: 'next'


### PR DESCRIPTION
Small fix to add apostrops to an ocis attribute. No harm before but for harmionisation...