### PR TITLE
Update to the orchestartion stuff

### DIFF
--- a/modules/ROOT/pages/deployment/deployment/deployment_examples.adoc
+++ b/modules/ROOT/pages/deployment/deployment/deployment_examples.adoc
@@ -1,4 +1,4 @@
-= Container Orchestration
+= Deployment Examples
 :toc: right
 
 :docker-compose-url: https://docs.docker.com/get-started/08_using_compose/
@@ -54,11 +54,57 @@ which docker-compose
 
 If Docker-Compose is installed, you'll be informed. If not, you may get no output at all or a message that it couldn't be found. In that case you need to install Docker-Compose first. On most Linux distributions, you can simply use the package manager to do so.
 
-Create a project directory, like `ocis-compose` in your home directory to have a common location for your Infinite Scale compose files.
+Create a project directory, e.g. `ocis-compose` in your home directory. Depending on your deployment intentions, pick configurations from our {compose-examples-url}[example docker compose] files or a complete stack.
+
+These are bundles of containers. For example, https://owncloud.dev/ocis/deployment/ocis_keycloak/[ocis_keycloak] delivers Keycloak and Infinite Scale, running behind Traefik as reverse proxy. Traefik generates self-signed certificates for a local setup or obtains valid SSL certificates for a server setup. Keycloak acts as Identity Provider (IDP) and comes with a PostgreSQL database. In total, this stack consists of four containers.
+
+In this example, you'll need three domains set up. For experimenting with a local setup, you may want to simply add them to your `/etc/hosts` file.
+
+[source,plaintext]
+----
+127.0.0.1 ocis.owncloud.test
+127.0.0.1 traefik.owncloud.test
+127.0.0.1 keycloak.owncloud.test
+----
+
+Download the `ocis_keycloak` files from GitHub into your project directory. Open the `.env` file in a text editor and adjust the environment variables according to your wishes. The default configuration looks like this:
+
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/owncloud/ocis/master/deployments/examples/ocis_keycloak/docker-compose.yml[]
+----
+
+If you are installing Infinite Scale on a server and Traefik will obtain valid certificates for you, remove `INSECURE=true` or set it to `false`.
+
+If you want to use the Traefik dashboard, set `TRAEFIK_DASHBOARD=true`. Default is `false` and therefore the dashboard is not active. If you activate it, you must set a domain for the Traefik dashboard in `TRAEFIK_DOMAIN=`, e.g. `TRAEFIK_DOMAIN=traefik.owncloud.test`.
+
+The Traefik dashboard is secured by basic auth. Default credentials are the user `admin` with the password admin. To set your own credentials, generate a htpasswd, e.g. by using an {ht-pwd-url}[online tool] or a command-line tool.
+
+Traefik will issue certificates with LetsEncrypt and therefore you must set an email address in `TRAEFIK_ACME_MAIL=`.
+
+By default Infinite Scale will be started in the latest version. If you want to start a specific version set it with `OCIS_DOCKER_TAG=`. Available versions can be found on {docker-hub-url}[Docker Hub].
+
+Set your domain for the Infinite Scale frontend in `OCIS_DOMAIN=`, e.g. `OCIS_DOMAIN=ocis.owncloud.test`.
+
+If you want to change the OIDC client ID of the ownCloud Web frontend, specify the name with `OCIS_OIDC_CLIENT_ID=`.
+
+Set your domain for the Keycloak administration panel and authentication endpoints with `KEYCLOAK_DOMAIN=`, e.g. `KEYCLOAK_DOMAIN=keycloak.owncloud.test`.
+
+Changing the used Keycloak realm can be done by setting `KEYCLOAK_REALM=`. This defaults to the Infinite Scale realm `KEYCLOAK_REALM=oCIS`. The Infinite Scale realm will be automatically imported on startup and includes our demo users.
+
+You should secure your Keycloak admin account by setting `KEYCLOAK_ADMIN_USER=` and `KEYCLOAK_ADMIN_PASSWORD=` to values other than `admin`.
+
+When you're done with the configuration, save the file and start the application stack from the project directory with `docker-compose up -d`. For more details see {docker-compose-url}[Docker Compose].
+
+Check out the other container stacks on GitHub as well and adjust them to your needs.
+
+ownCloud provides some {compose-examples-url}[example docker compose] files as a starting point and guidance for your own setup. Change the data according your needs. Check the Infinite Scale version when using a template for production environments.
+
 
 == Kubernetes and Helm Charts
 
 // harvested from https://owncloud.dev/ocis/deployment/kubernetes/ 2022-04-21
+
 
 Kubernetes (K8s) is an open-source plattform for managing containers that run applications. It ensures there is no downtime and an optimal usage of resources. It offers a framework in which to run distributed systems. ownCloud Infinite Scale (Infinite Scale) was designed with Kubernetes in mind. Therefore we provide Helm charts for a convenient deployment of Infinite Scale on a Kubernetes cluster.
 
@@ -167,8 +213,6 @@ cd /var/tmp/ocis-charts/charts/ocis
 ----
 helm install ocis .
 ----
-
-// fixme: the minikube table needs to be updated !
 
 . Verify the application is running in the cluster with:
 +

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -8,7 +8,7 @@
 *** xref:deployment/general/general-info.adoc[General Info]
 *** xref:deployment/binary/binary-setup.adoc[Binary Setup]
 *** xref:deployment/container/container-setup.adoc[Container Setup]
-// *** xref:deployment/container/container-setup.adoc[Container Orchestration]
+*** xref:deployment/container/orchestration.adoc[Container Orchestration]
 *** xref:deployment/security/security.adoc[Securing oCIS]
 *** xref:deployment/nfs/nfs.adoc[Network File System Deployment]
 *** xref:deployment/extensions/extensions.adoc[Extensions]
@@ -40,6 +40,7 @@
 **** xref:deployment/extensions/users.adoc[Users]
 **** xref:deployment/extensions/web.adoc[Web]
 **** xref:deployment/extensions/webdav.adoc[WebDAV]
+// *** xref:deployment/deployment/deployment_examples.adoc[Deployment Examples]
 
 ////
 *** xref:deployment/configuration/index.adoc[Configuration]


### PR DESCRIPTION
The orchestration documentation is updated:

* Focus on Docker Compose and Kubnernetes - no examples
* Prepare a new section for compose examples - not visible atm
* The content for the new compose stuff is NOT ready for review atm

Already on Staging