### PR TITLE
Update the download version at the quick guide

### DIFF
--- a/modules/ROOT/pages/quickguide/quickguide.adoc
+++ b/modules/ROOT/pages/quickguide/quickguide.adoc
@@ -17,7 +17,7 @@ Open a shell and copy/paste the following commands:
 
 [source,bash,subs="attributes+"]
 ----
-sudo wget -O /usr/bin/ocis {ocis-downloadpage-url}{ocis-version}/ocis-{ocis-version}-linux-arm64
+sudo wget -O /usr/bin/ocis {ocis-downloadpage-url}{ocis-version}/ocis-{ocis-version}-linux-amd64
 ----
 
 [source,bash]


### PR DESCRIPTION
The download version of the quickguide was ARM64 but should be AMD64 - fixed.