### PR TITLE
Remove the ocis kill command

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -164,20 +164,13 @@ Depending what you want to stop, differnt commands need to be applied.
 
 If a service is being terminated with its PID, the signal `SIGTERM` (-15) is used. Note that SIGTERM politely ask a process to terminate. It shall terminate gracefully, cleaning up all resources (files, sockets, child processes, etc.), deleting temporary files and so on.
 
-Stopping an extension from the runtime::
-Note that the ocis runtime (`ocis server`) needs to be active or a default error message will be returned, see xref:deployment/general/general-info.adoc#default-runtime-error-response[Default Runtime Error Response]
-+
-[source,bash]
-----
-ocis kill [extension name]
-----
-
 Stopping the complete runtime with all its running extensions::
 Depending on the user you started `ocis` and with which user you are currently logged in, you may need to use `sudo` for proper permissions.
 + 
 [source,bash]
 ----
-ps ax | grep "ocis server" | grep -v grep | awk '{ print $1 }' | xargs kill -15
+ps ax | grep "ocis server" | grep -v grep | \
+   awk '{ print $1 }' | xargs kill -15
 ----
 
 Stopping a particular ocis PID::

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -93,7 +93,7 @@ When typing `ocis <extension-name> --help`, you will get detailed help regarding
 
 ==== Infinite Scale Supervised Extensions
 
-You can start all available extensions in supervised mode with the command below. Note that the extensions started with the runtime share the same PID.
+In supervised mode, all extensions are started with one command as you can see below in the example when using the binary setup. Note that the extensions started with the runtime share the same PID.
 
 Start the Infinite Scale Runtime::
 
@@ -108,6 +108,9 @@ List running extensions::
 ----
 ocis list
 ----
+
+Stopping the Infinite Scale Runtime::
+In supervised mode, you have to stop the `ocis server` which also stops all extensions. See xref:deployment/binary/binary-setup.adoc#stopping-infinite-scale[Stopping Infinite Scale] for more details.
 
 ==== Unsupervised Extensions
 
@@ -181,8 +184,6 @@ PROXY_HTTP_ADDR=localhost:5555 \
 PROXY_DEBUG_ADDR=localhost:6666 \
 ocis server
 ----
-
-Remember the note in xref:infinite-scale-supervised-extensions[] when killing/restarting extensions in supervised mode.
 
 === Globally Shared Logging Values
 

--- a/modules/ROOT/pages/quickguide/quickguide.adoc
+++ b/modules/ROOT/pages/quickguide/quickguide.adoc
@@ -17,7 +17,8 @@ Open a shell and copy/paste the following commands:
 
 [source,bash,subs="attributes+"]
 ----
-sudo wget -O /usr/bin/ocis {ocis-downloadpage-url}{ocis-version}/ocis-{ocis-version}-linux-amd64
+sudo wget -O /usr/bin/ocis \
+  {ocis-downloadpage-url}{ocis-version}/ocis-{ocis-version}-linux-amd64
 ----
 
 [source,bash]


### PR DESCRIPTION
Fixes: https://github.com/owncloud/docs-ocis/issues/181 (ocis kill no longer exists)