### PR TITLE
prepare_for_ocis_beta4

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -72,7 +72,7 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-version: '2.0.0-beta.3'
+    ocis-version: '2.0.0-beta.4'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/testing/'
 #   desktop
     latest-desktop-version: 'next'


### PR DESCRIPTION
Prepare for the upcoming ocis beta 4

This PR can safely be merged as it ist for this repo only.

The docs version must only be merged when beta.4 is finally out and available.

@micbar fyi