### PR TITLE
The link to the external URL for including ocis resources has changed

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,4 +7,4 @@ nav:
 
 asciidoc:
   attributes:
-    ocis-services-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/extensions/_includes/'
+    ocis-services-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/services/_includes/'


### PR DESCRIPTION
As the title says...
Based on renaming extension to services 😄 