### PR TITLE
Env rename OCIS_RUN_SERVICES

### DIFF
--- a/modules/ROOT/pages/deployment/services/services_rules.adoc
+++ b/modules/ROOT/pages/deployment/services/services_rules.adoc
@@ -32,7 +32,7 @@ image::deployment/services/concurrence.drawio.svg[width=600]
 +
 [source,bash]
 ----
-OCIS_RUN_EXTENSIONS=settings,storage-system, \
+OCIS_RUN_SERVICES=settings,storage-system, \
     graph,graph-explorer,idp,ocs,store,thumbnails, \
     web,webdav,frontend,gateway,users, groups, \
     auth-basic,auth-bearer,storage-authmachine, \


### PR DESCRIPTION
Referencing: https://github.com/owncloud/ocis/pull/4133 (fix OCIS_RUN_SERVICES)

The env got renamed as part of extensions --> services

@wkloucek fyi