### PR TITLE
Demote demo user "moss" from admin to space admin

### DIFF
--- a/modules/ROOT/partials/deployment/demo_user_table.adoc
+++ b/modules/ROOT/partials/deployment/demo_user_table.adoc
@@ -30,7 +30,7 @@ radium-lovers
 | moss
 | vista
 | \moss@example.org
-| admin
+| space admin
 | users
 
 | richard


### PR DESCRIPTION
Referencing: https://github.com/owncloud/ocis/pull/4261 (Demote demo user "moss" from admin to space-admin)

The role is now updated

@rhafer fyi