### PR TITLE
Update storage driver description - Prerequisite page

### DIFF
--- a/modules/ROOT/pages/prerequisites/prerequisites.adoc
+++ b/modules/ROOT/pages/prerequisites/prerequisites.adoc
@@ -276,8 +276,11 @@ ____
 
 Infinite Scale currently supports two different internal filesystem drivers which are `ocisfs` and `s3ng`.
 
-* When the `ocisfs` driver is used, data and metadata must be on a POSIX-compliant filesystem.
-* When the `s3ng` driver is used, data resides on a S3 bucket and the metadata will be stored on a POSIX-compliant filesystem which needs to be extra provisioned. This is necessary for performance reasons.
+* When the `ocisfs` driver is used, data and metadata must be on a POSIX-compliant filesystem. This driver decomposes the metadata and persists it in a POSIX filesystem. Blobs are stored on the filesystem as well. The layout makes extensive use of symlinks and extended attributes. A filesystem like xfs or zfs without practical inode size limitations is recommended. A further integration with file systems like CephFS or GPFS is under investigation.
++
+NOTE: Ext4 limits the number of bytes that can be used for extended attribute names and their values to the size of a single block (by default 4k). This reduces the number of shares for a single file or folder to roughly 20-30, as grants have to share the available space with other metadata.
+
+* When the `s3ng` driver is used, data resides on a S3 bucket and the metadata will be stored on a POSIX-compliant filesystem which needs to be extra provisioned. This is necessary for performance reasons. When listing extended attributes of an object, the result is currently limited to 64kB. Assuming a 20 byte uuid, a grant has ~40 bytes, which would limit the number of extended attributes to ~1630 entries or ~1600 shares. With further development, this limitation may be removed.
 
 Other drivers can be used too like for the Ceph or EOS filesystem, but no support can be given because they are not developed or maintained by ownCloud. 
 


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/4663 ([docs-only] update storage docs)

The text for the storage driver description in the Prerequisite page has been updated.

