### PR TITLE
Fix setting the correct path for binary and container ocis init response

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -99,7 +99,9 @@ ocis init
 ----
 
 On success, you will see a message like:
- 
+
+:init_path: pass:[<your-user>/.ocis/config/ocis.yaml]
+
 include::partial$deployment/ocis_init.adoc[]
 
 [NOTE]

--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -227,7 +227,9 @@ docker run --rm -it \
 ----
 
 On success, you will see a message like:
- 
+
+:init_path: /etc/ocis/ocis-config/ocis.yaml
+
 include::partial$deployment/ocis_init.adoc[]
 
 [NOTE]

--- a/modules/ROOT/partials/deployment/ocis_init.adoc
+++ b/modules/ROOT/partials/deployment/ocis_init.adoc
@@ -1,4 +1,10 @@
-[source,plaintext]
+// define a default value if the variable was not defined
+
+ifndef::init_path[]
+:init_path: /etc/ocis/ocis-config/ocis.yaml
+endif::[]
+
+[source,plaintext,subs="attributes+"]
 ----
 Do you want to configure Infinite Scale with certificate checking disabled?
  This is not recommended for public instances! [yes | no = default]
@@ -6,7 +12,7 @@ Do you want to configure Infinite Scale with certificate checking disabled?
 =========================================
  generated OCIS Config
 =========================================
- configpath : /etc/ocis/ocis-config/ocis.yaml
+ configpath : {init_path}
  user       : admin
  password   : <removed for documentation>
 ----


### PR DESCRIPTION
As the title says, the path printed in the response is different when it comes to binary and container setups.
