### PR TITLE
Create a logging page

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -25,3 +25,5 @@ asciidoc:
     kube-versions-url: /charts/ocis/docs/kube-versions.adoc
     values-versions-url: /charts/ocis/docs/values.adoc.yaml
     values-desc-versions-url: /charts/ocis/docs/values-desc-table.adoc
+    # used to define the include path for services without trailing /
+    s-path: deployment/services/s-list

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -126,14 +126,14 @@ The base directory is important, because other services use this directory as th
 
 For the time being, the following services have settings where the base directory is used if not manually defined in the service:
 
-* xref:deployment/services/s-list/nats.adoc[NATS_NATS_STORE_DIR]
-* xref:deployment/services/s-list/search.adoc[SEARCH_DATA_PATH]
-* xref:deployment/services/s-list/settings.adoc[SETTINGS_DATA_PATH]
-* xref:deployment/services/s-list/store.adoc[STORE_DATA_PATH]
-* xref:deployment/services/s-list/storage-users.adoc[STORAGE_USERS_OCIS_ROOT]
-* xref:deployment/services/s-list/storage-users.adoc[STORAGE_USERS_S3NG_ROOT]
-* xref:deployment/services/s-list/storage-users.adoc[STORAGE_USERS_OWNCLOUDSQL_DATADIR]
-* xref:deployment/services/s-list/thumbnails.adoc[THUMBNAILS_FILESYSTEMSTORAGE_ROOT]
+* xref:{s-path}/nats.adoc[NATS_NATS_STORE_DIR]
+* xref:{s-path}/search.adoc[SEARCH_DATA_PATH]
+* xref:{s-path}/settings.adoc[SETTINGS_DATA_PATH]
+* xref:{s-path}/store.adoc[STORE_DATA_PATH]
+* xref:{s-path}/storage-users.adoc[STORAGE_USERS_OCIS_ROOT]
+* xref:{s-path}/storage-users.adoc[STORAGE_USERS_S3NG_ROOT]
+* xref:{s-path}/storage-users.adoc[STORAGE_USERS_OWNCLOUDSQL_DATADIR]
+* xref:{s-path}/thumbnails.adoc[THUMBNAILS_FILESYSTEMSTORAGE_ROOT]
 
 The default locations for the _base_ directory are:
 
@@ -417,6 +417,10 @@ If you have enabled demo users and groups and you want to manage or delete them,
 
 See xref:deployment/services/ports-used.adoc[Used Port Ranges] at the _Services_ description for details.
 
+== Logging
+
+See xref:deployment/services/logging.adoc[Logging] at the _Services_ description for details.
+
 == Using a Reverse Proxy
 
 // https://owncloud.dev/ocis/deployment/ocis_individual_services/
@@ -425,7 +429,7 @@ If you are using a reverse proxy like Traefik and the reverse proxy manages the 
 
 == Manage Unfinished Uploads
 
-See xref:deployment/services/s-list/storage-users.adoc#manage-unfinished-uploads[Manage Unfinished Uploads] at the _Storage Users_ service for details. 
+See xref:{s-path}/storage-users.adoc#manage-unfinished-uploads[Manage Unfinished Uploads] at the _Storage Users_ service for details. 
 
 == Reindex a Space for Search
 

--- a/modules/ROOT/pages/deployment/services/env-var-note.adoc
+++ b/modules/ROOT/pages/deployment/services/env-var-note.adoc
@@ -1,13 +1,7 @@
 = Notes for Environment Variables
-:toc: macro
+:toc: right
 
 :description: Environment variables are key to configure Infinite Scale. To understand variables in a proper way, some notes are made.
-
-include::partial$deployment/services/beta-statement.adoc[]
-
-{empty} +
-
-toc::[]
 
 == Introduction
 
@@ -44,7 +38,7 @@ In the table showing the environment variables of a service, the _Default Value_
 ====
 
 Note on paths for binary vs. container installations::
-If a service offers path customization like the `IDM_LDAPS_CERT` (see the xref:deployment/services/s-list/idm.adoc[IDM] documentation), the path set references the environment used. This means, when using the binary installation, the path is based on the host filesystem. When using a container installation, the path references a target inside the container.
+If a service offers path customization like the `IDM_LDAPS_CERT` (see the xref:{s-path}/idm.adoc[IDM] documentation), the path set references the environment used. This means, when using the binary installation, the path is based on the host filesystem. When using a container installation, the path references a target inside the container.
 +
 [NOTE]
 ====

--- a/modules/ROOT/pages/deployment/services/logging.adoc
+++ b/modules/ROOT/pages/deployment/services/logging.adoc
@@ -1,0 +1,40 @@
+= Logging
+:toc: right
+
+:description: Setting the proper log level is a way of filtering important information about the state of Infinite Scale. Depending what you are looking for, the log output will be more or less verbose.
+
+== Introduction
+
+{description}
+
+== Log Levels
+
+Following log levels are provided by Infinite Scale. You can set the log level on a global base using the environment variable `OCIS_LOG_LEVEL` which is valid for all services. There are also independent logging variables for each service which are then only valid for that service overwriting the setting of the global one. Using this method is beneficial when drilling down an issue for a particular service without changing the level for other services. The default setting is `OCIS_LOG_LEVEL=error` without setting a particular log level for a service.
+
+=== FATAL
+
+FATAL means, that the application is about to stop a serious problem or corruption from happening. This level of logging shows that the application’s situation is catastrophic, such that an important function is not working. For example the application is unable to connect to the data store due to config errors or not able to parse the config.
+
+=== ERROR
+
+This is the default log level, all errors on this level are important for admins because they need to fix them. This log level is used when a severe issue is stopping functions within the application from operating correctly. ocis logs all kind of inter service communication errors on this level because these needs to be addressed.
+
+=== WARN
+
+The WARN log level is used when ocis detects an unexpected failure during an operation. It is also used if some operations might be incomplete. It does not mean that the application has been harmed, the code should continue to work as usual. Admins should eventually check these warnings just in case the problem reoccurs.
+
+=== INFO
+
+Messages on this level are documenting the normal behavior of applications. They state what happened. These entries are purely informative to confirm that the application is working as desired. The info log level also enables the ocis xref:{s-path}/proxy.adoc[Proxy] to write a full access log.
+
+=== DEBUG
+
+This log level provides diagnostic information in a detailed manner. It is verbose and has more information than you would need when using the application. This log level is used to understand problems in the application and during reproduction of problems. This log level could put a very high load on the output device and is not recommended in production environments. You should consider enabling this level only on a single service or very few services to pinpoint issues or bugs.
+
+== Correlate Incoming Requests
+
+To correlate client requests with logged ocis activity `X-Request-ID` headers are used.
+
+=== X-Request-ID
+
+It is a best practise for clients to send an `X-Request-ID` header with every request. This ID should be used when possible in the backend and should be added to the logging metadata.

--- a/modules/ROOT/pages/deployment/services/logging.adoc
+++ b/modules/ROOT/pages/deployment/services/logging.adoc
@@ -37,4 +37,4 @@ To correlate client requests with logged Infinite Scale activity `X-Request-ID` 
 
 === X-Request-ID
 
-It is a best practice for clients to send an `X-Request-ID` header with every request. This ID should be used when possible in the backend and should be added to the logging metadata.
+It is a best practice for clients to send an `X-Request-ID` header with every request. This ID should be used when possible in the backend and should be added to the logging metadata. Note that ownCloud Clients send an `X-Request-ID` header by default.

--- a/modules/ROOT/pages/deployment/services/logging.adoc
+++ b/modules/ROOT/pages/deployment/services/logging.adoc
@@ -1,7 +1,7 @@
 = Logging
 :toc: right
 
-:description: Setting the proper log level is a way of filtering important information about the state of Infinite Scale. Depending what you are looking for, the log output will be more or less verbose.
+:description: Setting the proper log level is a way of filtering important information about the state of Infinite Scale. Depending on what you are looking for, the log output will be more or less verbose.
 
 == Introduction
 
@@ -9,7 +9,7 @@
 
 == Log Levels
 
-Following log levels are provided by Infinite Scale. You can set the log level on a global base using the environment variable `OCIS_LOG_LEVEL` which is valid for all services. There are also independent logging variables for each service which are then only valid for that service overwriting the setting of the global one. Using this method is beneficial when drilling down an issue for a particular service without changing the level for other services. The default setting is `OCIS_LOG_LEVEL=error` without setting a particular log level for a service.
+The following log levels are provided by Infinite Scale. You can set the log level on a global basis using the environment variable `OCIS_LOG_LEVEL` which is valid for all services. There are also independent logging variables for each service which are only valid for that service, overwriting the setting of the global one. Using this method is beneficial when drilling down an issue for a particular service without changing the level for other services. The default setting is `OCIS_LOG_LEVEL=error` without setting a particular log level for a service.
 
 === FATAL
 
@@ -17,7 +17,7 @@ FATAL means, that the application is about to stop a serious problem or corrupti
 
 === ERROR
 
-This is the default log level, all errors on this level are important for admins because they need to fix them. This log level is used when a severe issue is stopping functions within the application from operating correctly. ocis logs all kind of inter service communication errors on this level because these needs to be addressed.
+This is the default log level, all errors on this level are important for admins because they need to fix them. This log level is used when a severe issue is stopping functions within the application from operating correctly. Infinite Scale logs all kinds of inter-service-communication errors on this level because these needs to be addressed.
 
 === WARN
 
@@ -25,7 +25,7 @@ The WARN log level is used when ocis detects an unexpected failure during an ope
 
 === INFO
 
-Messages on this level are documenting the normal behavior of applications. They state what happened. These entries are purely informative to confirm that the application is working as desired. The info log level also enables the ocis xref:{s-path}/proxy.adoc[Proxy] to write a full access log.
+Messages on this level are documenting the normal behavior of applications. They state what happened. These entries are purely informative to confirm that the application is working as desired. The info log level also enables the Infinite Scale xref:{s-path}/proxy.adoc[Proxy] to write a full access log.
 
 === DEBUG
 
@@ -33,8 +33,8 @@ This log level provides diagnostic information in a detailed manner. It is verbo
 
 == Correlate Incoming Requests
 
-To correlate client requests with logged ocis activity `X-Request-ID` headers are used.
+To correlate client requests with logged Infinite Scale activity `X-Request-ID` headers are used.
 
 === X-Request-ID
 
-It is a best practise for clients to send an `X-Request-ID` header with every request. This ID should be used when possible in the backend and should be added to the logging metadata.
+It is a best practice for clients to send an `X-Request-ID` header with every request. This ID should be used when possible in the backend and should be added to the logging metadata.

--- a/modules/ROOT/pages/security/security.adoc
+++ b/modules/ROOT/pages/security/security.adoc
@@ -11,7 +11,7 @@
 
 === API Gateway
 
-Infinite Scale uses a microservices architecture. But instead of handling authorization and authentication in each service, an API gateway (the xref:deployment/services/s-list/proxy.adoc[proxy service]) to handle these tasks has been implemented. All requests have to go through this gateway. This has the positive effect, that all other services can be hidden behind a firewall, which reduces the attack surface dramatically.
+Infinite Scale uses a microservices architecture. But instead of handling authorization and authentication in each service, an API gateway (the xref:{s-path}/proxy.adoc[proxy service]) to handle these tasks has been implemented. All requests have to go through this gateway. This has the positive effect, that all other services can be hidden behind a firewall, which reduces the attack surface dramatically.
 
 === Reverse Proxy
 
@@ -23,7 +23,7 @@ All Infinite Scale services support request tracing. This means, you can monitor
 
 === OpenID Connect
 
-Infinite Scale does not rely on a proprietary user management system, instead it uses OpenID Connect. For small instances or testing purposes, a xref:deployment/services/s-list/idm.adoc[minimal LDAP Service named IDM] is included. For anything else, it is recommended that customers hook to their own OpenID Connect provider using the xref:deployment/services/s-list/idp.adoc[IDP service]. If you don't have an OpenID Connect provider available, use secure standard software like Keycloak to connect to the existing user management system, like Active Directory or any LDAP server.
+Infinite Scale does not rely on a proprietary user management system, instead it uses OpenID Connect. For small instances or testing purposes, a xref:{s-path}/idm.adoc[minimal LDAP Service named IDM] is included. For anything else, it is recommended that customers hook to their own OpenID Connect provider using the xref:{s-path}/idp.adoc[IDP service]. If you don't have an OpenID Connect provider available, use secure standard software like Keycloak to connect to the existing user management system, like Active Directory or any LDAP server.
 
 == Technological Aspects
 

--- a/modules/ROOT/pages/security/security.adoc
+++ b/modules/ROOT/pages/security/security.adoc
@@ -11,7 +11,7 @@
 
 === API Gateway
 
-Infinite Scale uses a microservices architecture. But instead of handling authorization and authentication in each service, an API gateway (the xref:{s-path}/proxy.adoc[proxy service]) to handle these tasks has been implemented. All requests have to go through this gateway. This has the positive effect, that all other services can be hidden behind a firewall, which reduces the attack surface dramatically.
+Infinite Scale uses a microservices architecture. But instead of handling authorization and authentication in each service, an API gateway (the xref:{s-path}/proxy.adoc[proxy service]) has been implemented to handle these tasks. All requests have to go through this gateway. This has the positive effect that all other services can be hidden behind a firewall, which reduces the attack surface dramatically.
 
 === Reverse Proxy
 

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -15,9 +15,9 @@
 *** xref:deployment/nfs/nfs.adoc[Network File System Deployment]
 *** xref:deployment/services/services.adoc[Services]
 **** General Information
-***** xref:deployment/services/env-var-note.adoc[Environment Variables Notes]
+***** xref:deployment/services/env-var-note.adoc[Environment Variable Notes]
 ***** xref:deployment/services/ports-used.adoc[Ports Used]
-//***** Logging
+***** xref:deployment/services/logging.adoc[Logging]
 **** List of Services
 ***** xref:deployment/services/s-list/app-provider.adoc[App Provider]
 ***** xref:deployment/services/s-list/app-registry.adoc[App Registry]


### PR DESCRIPTION
Fixes: #266 (Document the use of log levels -especially the access log)

* Create a logging page embedded into the new service structure
* Create a version independent attribute defining the path to services for xref
* Using that attribute for existing xrefs making it easier to reference
* Adding a link to logging in the general info page

@micbar I took the referenced text and adapted it a little bit but one point is open for me. Maybe we could add more info HOW `X-Request-ID` can be added, in particualr for our webui...