### PR TITLE
Update binary-setup.adoc

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -204,7 +204,7 @@ To run the *Infinite Scale runtime* as a {systemd-url}[systemd] service, create 
 
 [source,bash]
 ----
-sudo systemctl edit ocis.service
+sudo systemctl edit --force --full ocis.service
 ----
 
 Then copy the content of the systemd file below into the editor and save it.


### PR DESCRIPTION
The documentation mentions this :
```
create the file /etc/systemd/system/ocis.service with the content provided below. The easiest way to do this is with the following command:

sudo systemctl edit ocis.service
```
The command fails with:

```
No files found for ocis.service.
Run 'systemctl edit --force --full ocis.service' to create a new unit.
```

And the proposed change creates a new ocis.service file.  