### PR TITLE
Update useful_mount_tip.adoc

### DIFF
--- a/modules/ROOT/pages/deployment/tips/useful_mount_tip.adoc
+++ b/modules/ROOT/pages/deployment/tips/useful_mount_tip.adoc
@@ -105,6 +105,6 @@ sudo systemctl show <name>.service | grep "After="
 --
 [source,bash]
 ----
-sudo system <name> restart
+sudo systemctl restart <name>
 ----
 --


### PR DESCRIPTION
In documentation Service Restart by invoking:
`sudo system <name> restart`

But this command fails with :
`sudo: system: command not found`

And the proposed changes executes properly