### PR TITLE
Update Docker Compose

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,25 +7,35 @@ nav:
 
 asciidoc:
   attributes:
+    # used to define the include path for services without trailing /
+    # note that any changes of this path also need adjustment in 
+    # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
+    s-path: deployment/services/s-list
+    #
     # used in deployment/services
     ocis-services-includes: 'https://raw.githubusercontent.com/owncloud/ocis/docs/services/_includes/'
+    #
     # used in orchestration.adoc
-    # tab_x will be used as part of the url accessing the raw content
-    # tab_x_tab_text will be used as tab text shown for tab_x
-    tab_1: master
-    tab_2: tab_2
-    tab_3: tab_3
+    # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts
+    helm_tab_1: master
+    helm_tab_2: tab_2
+    helm_tab_3: tab_3
+    # compose_tab_x will be used to assemble the url (tag) accessing the link for docker compose
+    compose_tab_1: master
+    compose_tab_2: tab_2
+    compose_tab_3: tab_3
+    # tab_x_tab_text will be used as tab text shown for tab_x, note we use the same tab texts for helm and compose
     tab_1_tab_text: 0.0.0
     tab_2_tab_text: 0.1.0
     tab_3_tab_text: 0.2.0
+    # define to use tabs, the first tab is always active
     use_tab_2:  # set to any value if tab 2 should be shown
     use_tab_3:  # set to any value if tab 3 should be shown
+    # set attributes defining path components which will be assembled in the document
     secrets: deployment/container/orchestration/orchestration.adoc#define-secrets
     ocis-charts-raw-url: https://raw.githubusercontent.com/owncloud/ocis-charts/
     kube-versions-url: /charts/ocis/docs/kube-versions.adoc
     values-versions-url: /charts/ocis/docs/values.adoc.yaml
     values-desc-versions-url: /charts/ocis/docs/values-desc-table.adoc
-    # used to define the include path for services without trailing /
-    # note that any changes of this path also need adjustment in 
-    # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
-    s-path: deployment/services/s-list
+    composer-raw-url: https://github.com/owncloud/ocis/tree/
+    composer-final-path: /deployments/examples

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -59,7 +59,7 @@ For Kubernetes, ownCloud provides basic {helm-charts-ocis-url}[Helm Charts] that
 
 Similarly, when using _docker run_ and handing over command-line parameters for a single container, you can define a `docker-compose.yml` yaml file which defines all the settings and environment variables for each container in one or more files. This is the next step when having multi-container environments.
 
-* Consider that when planning to run Infinite Scale via docker compose, the degree of freedom is not the same as when using Kubernetes with Helm as you are limited to the same server but it is usually more when running the pure binary when it comes to ease of configuration and maintaining your environment.
+* Consider that when planning to run Infinite Scale via Docker Compose, the degree of freedom is not the same as when using Kubernetes with Helm as you are limited to the same server and other limitations but it is usually more when running the pure binary when it comes to ease of configuration and maintaining your environment.
 
 * Use docker compose when planning an extended degree of freedom compared to the binary installation but not needing the full capabilities of Kubernetes and Helm.
 
@@ -90,9 +90,34 @@ If the output shows a version like 1.25.0-1, follow the {docker-compose-install-
 
 When done, create a project directory, like `ocis-compose` in your home directory to have a common location for your Infinite Scale compose files.
 
-=== Configuration Guideline
+=== Docker Compose Examples
 
-Manually adapt the examples provided for the Helm charts below to docker compose to configure the services properly. Also see the xref:deployment/services/services.adoc[services section] for details of available environment variables and yaml files.
+* See the xref:deployment/services/services.adoc[services section] for details about available environment variables and yaml files.
+
+* See below for example service configurations using Docker Compose, to get a first impression of how this can be achieved. Both, _ocis environment variables_ and _ocis service configuration_ yaml files are used.
++
+[tabs]
+====
+{tab_1_tab_text}::
++
+--
+{composer-raw-url}{compose_tab_1}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+--
+ifdef::use_tab_2[]
+{tab_2_tab_text}::
++
+--
+{composer-raw-url}{compose_tab_2}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+--
+endif::[]
+ifdef::use_tab_3[]
+{tab_3_tab_text}::
++
+--
+{composer-raw-url}{compose_tab_2}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+--
+endif::[]
+====
 
 == Kubernetes and Helm
 
@@ -213,20 +238,20 @@ The `~` represents all patch releases for that particular version:
 {tab_1_tab_text}::
 +
 --
-include::{ocis-charts-raw-url}{tab_1}{kube-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_1}{kube-versions-url}[]
 --
 ifdef::use_tab_2[]
 {tab_2_tab_text}::
 +
 --
-include::{ocis-charts-raw-url}{tab_2}{kube-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_2}{kube-versions-url}[]
 --
 endif::[]
 ifdef::use_tab_3[]
 {tab_3_tab_text}::
 +
 --
-include::{ocis-charts-raw-url}{tab_3}{kube-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_3}{kube-versions-url}[]
 --
 endif::[]
 ====

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/val-desc-tab-1.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/val-desc-tab-1.adoc
@@ -11,7 +11,7 @@ If there are xref's, these are resolved via an attribute defined in antora.yml
 
 This is an adoc table that gets included, not a yaml file.
 
-{ocis-charts-raw-url}{tab_1}{values-desc-versions-url}
+{ocis-charts-raw-url}{helm_tab_1}{values-desc-versions-url}
 ////
 
-include::{ocis-charts-raw-url}{tab_1}{values-desc-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_1}{values-desc-versions-url}[]

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/val-desc-tab-2.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/val-desc-tab-2.adoc
@@ -11,7 +11,7 @@ If there are xref's, these are resolved via an attribute defined in antora.yml
 
 This is an adoc table that gets included, not a yaml file.
 
-{ocis-charts-raw-url}{tab_2}{values-desc-versions-url}
+{ocis-charts-raw-url}{helm_tab_2}{values-desc-versions-url}
 ////
 
-include::{ocis-charts-raw-url}{tab_2}{values-desc-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_2}{values-desc-versions-url}[]

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/val-desc-tab-3.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/val-desc-tab-3.adoc
@@ -11,8 +11,8 @@ If there are xref's, these are resolved via an attribute defined in antora.yml
 
 This is an adoc table that gets included, not a yaml file.
 
-{ocis-charts-raw-url}{tab_3}{values-desc-versions-url}
+{ocis-charts-raw-url}{helm_tab_3}{values-desc-versions-url}
 ////
 
 
-include::{ocis-charts-raw-url}{tab_3}{values-desc-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_3}{values-desc-versions-url}[]

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/values-tab-1.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/values-tab-1.adoc
@@ -9,7 +9,7 @@ The source content comes from github.
 
 If there are xref's, these are resolved via an attribute defined in antora.yml
  
-{ocis-charts-raw-url}{tab_1}{values-versions-url}
+{ocis-charts-raw-url}{helm_tab_1}{values-versions-url}
 
 We need to allow substitution of attributes first, then macros
 ////
@@ -18,5 +18,5 @@ Note, to improve readbility, syntax highlighting is used. A drawback is that lin
 
 [source,yaml,subs="attributes+,+macros"]
 ----
-include::{ocis-charts-raw-url}{tab_1}{values-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_1}{values-versions-url}[]
 ----

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/values-tab-2.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/values-tab-2.adoc
@@ -9,7 +9,7 @@ The source content comes from github.
 
 If there are xref's, these are resolved via an attribute defined in antora.yml
  
-{ocis-charts-raw-url}{tab_2}{values-versions-url
+{ocis-charts-raw-url}{helm_tab_2}{values-versions-url
 
 We need to allow substitution of attributes first, then macros
 ////
@@ -18,5 +18,5 @@ Note, to improve readbility, syntax highlighting is used. A drawback is that lin
 
 [source,yaml,subs="attributes+,+macros"]
 ----
-include::{ocis-charts-raw-url}{tab_2}{values-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_2}{values-versions-url}[]
 ----

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/values-tab-3.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/values-tab-3.adoc
@@ -9,7 +9,7 @@ The source content comes from github.
 
 If there are xref's, these are resolved via an attribute defined in antora.yml
  
-{ocis-charts-raw-url}{tab_3}{values-versions-url}
+{ocis-charts-raw-url}{helm_tab_3}{values-versions-url}
 
 We need to allow substitution of attributes first, then macros
 ////
@@ -18,5 +18,5 @@ Note, to improve readbility, syntax highlighting is used. A drawback is that, li
 
 [source,yaml,subs="attributes+,+macros"]
 ----
-include::{ocis-charts-raw-url}{tab_3}{values-versions-url}[]
+include::{ocis-charts-raw-url}{helm_tab_3}{values-versions-url}[]
 ----

--- a/modules/ROOT/pages/deployment/services/services.adoc
+++ b/modules/ROOT/pages/deployment/services/services.adoc
@@ -1,17 +1,18 @@
 = Services
 :toc: macro
 
-:description: The Infinite Scale platform consists of microservices interconnecting with each other. Each service performs a particular task and can be configured independently. Services started with the runtime share the runtime management while services running outside the runtime are managed on their own but connect to each other when necessary.
+:description: The Infinite Scale platform consists of microservices interconnecting with each other. Each service performs a particular task and can be configured independently.
 
 include::partial$deployment/services/beta-statement.adoc[]
 
-{empty} +
+// remove the remark to get the toc rendered if there are mre than one headlines
+// {empty} +
 
-toc::[]
+// toc::[]
 
 == Introduction
 
-{description}
+{description} Services started with the runtime share the runtime management while services running outside the runtime are managed on their own but connect to each other when necessary.
 
 For more details see xref:deployment/general/general-info.adoc#managing-services[Managing Services].
 


### PR DESCRIPTION
References: #298 (Update the Docker Compose section)

Post a discussion with @wkloucek, we need to update the Docker Compose section.

* Adds, in the same way as we do with Helm, tabs which are aligned to releases (tags).
* We use the same tab descriptions for helm and compose (important to avoid confusion about releases!) but use different attributes to include/reference the origin of sources. This enables that the repos ocis-charts and ocis can use different tag names.
* The compose example files did not disappear, the original link was corrected to be one layer above.
* An issue has been created to maintain https://github.com/owncloud/ocis/issues/5040

@wkloucek pls create a README.MD in the ocis examples directory as discussed to avoid accidentially deletion or move without notice to docs


