### PR TITLE
fix_ocis_binary_location

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -25,14 +25,14 @@ To download use:
 +
 [source,bash]
 ----
-sudo wget -O /usr/bin/ocis <link>
+sudo wget -O /usr/local/bin/ocis <link>
 ----
 +
 Make the binary executable with:
 +
 [source,bash]
 ----
-sudo chmod +x /usr/bin/ocis
+sudo chmod +x /usr/local/bin/ocis
 ----
 +
 Check the version installed:
@@ -246,7 +246,7 @@ Type=simple
 User=ocis
 Group=ocis
 EnvironmentFile=/etc/ocis/ocis.env
-ExecStart=ocis server
+ExecStart=/usr/local/bin/ocis server
 Restart=always
 
 [Install]

--- a/modules/ROOT/pages/deployment/configuration/_ocis-config.adoc
+++ b/modules/ROOT/pages/deployment/configuration/_ocis-config.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :toclevels: 1
 
-The configuration of Infinite Scale is simple yet powerful and extremely flexible. If you have downloaded the binary from ownCloud directly instead of installing it via the package manager of your Linux operating system, copy or move the file to `/usr/bin/ocis` and make it executable with the command: `chmod +x /usr/bin/ocis`.
+The configuration of Infinite Scale is simple yet powerful and extremely flexible. If you have downloaded the binary from ownCloud directly instead of installing it via the package manager of your Linux operating system, copy or move the file to `/usr/local/bin/ocis` and make it executable with the command: `chmod +x /usr/local/bin/ocis`.
 
 Enter `ocis help` and you'll see all available options for the command.
 

--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -355,7 +355,7 @@ docker ps
 [source,plaintext,options="nowrap"]
 ----
 CONTAINER ID   IMAGE           COMMAND                  CREATED         STATUS         PORTS                                       NAMES
-a0e4db3e91e8   owncloud/ocis   "/usr/bin/ocis server"   8 seconds ago   Up 6 seconds   0.0.0.0:9200->9200/tcp, :::9200->9200/tcp   ocis_runtime
+a0e4db3e91e8   owncloud/ocis   "/usr/local/bin/ocis server"   8 seconds ago   Up 6 seconds   0.0.0.0:9200->9200/tcp, :::9200->9200/tcp   ocis_runtime
 ----
 
 === Stop a Running Container

--- a/modules/ROOT/pages/prerequisites/prerequisites.adoc
+++ b/modules/ROOT/pages/prerequisites/prerequisites.adoc
@@ -37,11 +37,6 @@ The minimum hardware requirements depend on the usage scenario you have in mind 
 * For more intense testing purposes, the recommended start hardware is a multicore processor with at least 4GB of RAM.
 * For production environments, CPU and RAM are the main limiting factors. A clear guideline for CPUs can't be provided at this time since there are too many influencing factors. See xref:ram-considerations[RAM Considerations] for memory and xref:bandwidth-considerations[Bandwidth Considerations] for network-related factors.
 
-// fixme: info of architectures came from willy, also see: 
-// https://download.owncloud.com/ocis/ocis/1.18.0/
-// https://hub.docker.com/r/owncloud/ocis/tags
-// fixme: do we still want to have 386?
-
 The following table shows the tested and supported hardware architecture matrix::
 [width="65%",cols="50%,50%",options="header"]
 |===

--- a/modules/ROOT/pages/quickguide/quickguide.adoc
+++ b/modules/ROOT/pages/quickguide/quickguide.adoc
@@ -17,13 +17,13 @@ Open a shell and copy/paste the following commands:
 
 [source,bash,subs="attributes+"]
 ----
-sudo wget -O /usr/bin/ocis \
+sudo wget -O /usr/local/bin/ocis \
   {ocis-downloadpage-url}{ocis-version}/ocis-{ocis-version}-linux-amd64
 ----
 
 [source,bash]
 ----
-sudo chmod +x /usr/bin/ocis
+sudo chmod +x /usr/local/bin/ocis
 ----
 
 [source,bash]


### PR DESCRIPTION
This fixes the path for the binary location of ocis from `/usr/bin/ocis` --> `/usr/local/bin/ocis` based on hint of @dragotin 