### PR TITLE
Fix broken generic-config links

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -584,7 +584,7 @@ ifdef::use_tab_3[]
 endif::[]
 ====
 
-===== Apply Generic Secrets
+===== Apply Generic Configs
 
 Configs can be applied by command or included in `extraResources` of your own `values.yaml` file. Adapt the data content according to your environment:
 

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/generic-configs-tab-1.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/generic-configs-tab-1.adoc
@@ -1,0 +1,10 @@
+= generic-configs.yaml 
+
+== Chart Version: {helm_tab_1_tab_text}
+
+// Note that this page is created because when the contents of the included yaml is big, the tab size would be too high and not comfortable to read.
+
+[source,yaml]
+----
+include::example$deployment/container/orchestration/generic-configs-tab-1.yaml[]
+----

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/generic-configs-tab-2.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/generic-configs-tab-2.adoc
@@ -1,0 +1,10 @@
+= generic-configs.yaml
+
+== Chart Version: {helm_tab_2_tab_text}
+
+// Note that this page is created because when the contents of the included yaml is big, the tab size would be too high and not comfortable to read.
+
+[source,yaml]
+----
+include::example$deployment/container/orchestration/generic-configs-tab-2.yaml[]
+----

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/generic-configs-tab-3.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/generic-configs-tab-3.adoc
@@ -1,0 +1,10 @@
+= generic-configs.yaml 
+
+== Chart Version: {helm_tab_3_tab_text}
+
+// Note that this page is created because when the contents of the included yaml is big, the tab size would be too high and not comfortable to read.
+
+[source,yaml]
+----
+include::example$deployment/container/orchestration/generic-configs-tab-3.yaml[]
+----


### PR DESCRIPTION
Fixes: #318 (Generic Config link broken)

The content was present, but the referencing adoc page files were missing - fixed. 