### PR TITLE
ldapsearch command password `idm` correction

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/idm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idm.adoc
@@ -56,7 +56,7 @@ For testing purposes it is sometimes helpful to query IDM using the ldap command
 ----
 ldapsearch -x -H ldaps://127.0.0.1:9235 -x \
     -D uid=libregraph,ou=sysusers,o=libregraph-idm \
-    -w idm -b o=libregraph-idm objectclass=inetorgperson
+    -W -b o=libregraph-idm objectclass=inetorgperson
 ----
 
 When using the default configuration with the self-signed server certificate, you might need to switch off the certificate validation using the `LDAPTL_REQCERT` env variable:
@@ -66,8 +66,10 @@ When using the default configuration with the self-signed server certificate, yo
 LDAPTLS_REQCERT=never \
     ldapsearch -x -H ldaps://127.0.0.1:9235 -x \
     -D uid=libregraph,ou=sysusers,o=libregraph-idm \
-    -w idm -b o=libregraph-idm objectclass=inetorgperson
+    -W -b o=libregraph-idm objectclass=inetorgperson
 ----
+
+Extract the `idm_password` password to enter from the `ocis.yaml`  
 
 == Configuration
 


### PR DESCRIPTION
Changed from `-w idm` to `-W` for interactive password entry Password needs to be extracted from `ocis.yaml`
It's the following one:
```
idm:
  service_user_passwords:
    idm_password: <this one>
```