### PR TITLE
Using the correct doc branch in the ocis repo

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -21,7 +21,7 @@ asciidoc:
     service_tab_2: docs-stable-2.0
     service_tab_3: tab_3
     # service_tab_x_tab_text will be used as tab text shown for tab_x
-    # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
+    # note that we are referring via the 'service_tab_x' branch to the ocis repo, not the master branch!
     service_tab_1_tab_text: latest
     service_tab_2_tab_text: 2.0.0
     service_tab_3_tab_text: 2.1.0

--- a/antora.yml
+++ b/antora.yml
@@ -16,12 +16,12 @@ asciidoc:
     # define to use tabs, the first tab is always active
     use_tab_2: true # set to any value if tab 2 should be shown
     use_tab_3:  # set to any value if tab 3 should be shown
-    # service_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    service_tab_1: docs
-    service_tab_2: docs
+    # service_tab_x will be used to assemble the url accessing the link for the services
+    service_tab_1: docs-stable-2.0
+    service_tab_2: docs-stable-2.0
     service_tab_3: tab_3
     # service_tab_x_tab_text will be used as tab text shown for tab_x
-    # note that we are using the 'docs' branch of the ocis repo, not the main branch!
+    # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
     service_tab_1_tab_text: latest
     service_tab_2_tab_text: 2.0.0
     service_tab_3_tab_text: 2.1.0

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -135,6 +135,8 @@ Note that github will not let you download a single directory easily. You can ge
 git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_2}
 ----
 
+// https://stackoverflow.com/questions/7106012/download-a-single-folder-or-directory-from-a-github-repo
+
 * Using an external page providing you the folder to download as zip file like:
 +
 [source,plaintext,subs="attributes+"]

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -10,8 +10,8 @@
 :kubernetes-url: https://kubernetes.io
 :swarm-v-kub-1-url: https://circleci.com/blog/docker-swarm-vs-kubernetes/#c-consent-modal
 :swarm-v-kub-2-url: https://vexxhost.com/blog/kubernetes-vs-docker-swarm-containerization-platforms/
-
 :helm-charts-ocis-url: https://github.com/owncloud/ocis-charts
+:download-gh-directory-url: https://download-directory.github.io
 
 :ocis_individual_services-url: https://github.com/owncloud/ocis/tree/master/deployments/examples/ocis_individual_services
 :ht-pwd-url: https://htpasswdgenerator.de/
@@ -102,12 +102,16 @@ When done, create a project directory, like `ocis-compose` in your home director
 +
 --
 {composer-raw-url}{compose_tab_1}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+
+Using git version name: `{compose_tab_1}`
 --
 ifdef::use_tab_2[]
 {compose_tab_2_tab_text}::
 +
 --
 {composer-raw-url}{compose_tab_2}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+
+Using git version name: `{compose_tab_2}`
 --
 endif::[]
 ifdef::use_tab_3[]
@@ -115,9 +119,29 @@ ifdef::use_tab_3[]
 +
 --
 {composer-raw-url}{compose_tab_2}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+
+Using git version name: `{compose_tab_3}`
 --
 endif::[]
 ====
++
+--
+Note that github will not let you download a single directory easily. You can get the examples using the following methods requiring minimum space, replace the version accordingly:
+
+* Using a shallow git clone which minimizes the required clone space like:
++
+[source,bash,subs="attributes+"]
+----
+git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_2}
+----
+
+* Using an external page providing you the folder to download as zip file like:
++
+[source,plaintext,subs="attributes+"]
+----
+{download-gh-directory-url}?url={composer-raw-url}{compose_tab_2}{composer-final-path}
+----
+--
 
 == Kubernetes and Helm
 


### PR DESCRIPTION
Fixes: https://github.com/owncloud/ocis/issues/5200 ([FR] Move deployment examples to separate place to save bandwidth/storage)

* After the ocis repo got a docs stable branch we can reference to, some adoptions were needed.
* Adding methods how to download the composer examples more easily.