### PR TITLE
Special Scope Environment Variables

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -1,0 +1,31 @@
+= Environment Variables with Special Scopes
+:toc: right
+
+// there is only an adoc table to include but no yaml file. this is only when using special scope envvars.
+:no_yaml: true
+
+:description: Some environment variables have an extended or global scope. Variables with extended scope do not directly configure services but function underneath. Variables with a global scope can configure more than one service.
+
+== Introduction
+
+{description}
+
+Examples:
+
+// * The global environment variable `OCIS_LOG_LEVEL` is available in multiple services.
+* The extended environment variable `OCIS_CONFIG_DIR` can be used with `ocis init`.
+
+== Extended Environment Variables
+
+:ext_name: extended
+
+include::partial$deployment/services/env-and-yaml.adoc[]
+
+// prepared but not available for now
+////
+== Global Environment Variables
+
+:ext_name: global
+
+include::partial$deployment/services/env-and-yaml.adoc[]
+////

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -1,6 +1,19 @@
+// the attribute ext_name (mandatory) and no_yaml (not mandatory) will be handed over by the calling page.
+// if no_yaml is set, it will exclude rendering yaml files because it does not exist.
+
+// print a dependent explanation line
+// no_yaml is not set = standard extension,
+// no_yaml is set = special scope envvars
+ 
+ifndef::no_yaml[]
 === Environment Variables
 
 The `{ext_name}` service is configured via the following environment variables:
+endif::[]
+
+ifdef::no_yaml[]
+The `{ext_name}` variables are defined in the following way:
+endif::[]
 
 [tabs]
 ====
@@ -32,6 +45,8 @@ endif::[]
 endif::[]
 endif::[]
 ====
+
+ifndef::no_yaml[]
 
 === YAML Example
 
@@ -75,3 +90,4 @@ endif::[]
 endif::[]
 ====
 
+endif::[]

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -15,8 +15,9 @@
 *** xref:deployment/nfs/nfs.adoc[Network File System Deployment]
 *** xref:deployment/services/services.adoc[Services]
 **** General Information
-***** xref:deployment/services/env-var-note.adoc[Environment Variable Notes]
 ***** xref:deployment/services/deployment-considerations.adoc[Deployment Considerations]
+***** xref:deployment/services/env-var-note.adoc[Environment Variable Notes]
+***** xref:deployment/services/env-vars-special-scope.adoc[Environment Variables with Special Scope]
 ***** xref:deployment/services/gateways.adoc[Gateways]
 ***** xref:deployment/services/logging.adoc[Logging]
 ***** xref:deployment/services/ports-used.adoc[Ports Used]


### PR DESCRIPTION
This PR adds a page covering environment variables with a special scope.

* Variables with extended scope do not directly configure services but functions underneath.
* Variables with a global scope can configure more than one service.

The page and the required stuff around in the documentation is ready, but the content coming from the ocis repo which gets included not. Extended scope vars are already available but the file needs renaming and the CI an update. The progarm that creates the table for global scope vars needs to be made.

Keeping this PR therefore as draft to avoid accidentially merging.

A language review for my comments is always welcomed.

Currently visible on staging.

@kobergj fyi