### PR TITLE
Fix antora.yml to reference the correct master version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -12,12 +12,12 @@ asciidoc:
     # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
     s-path: deployment/services/s-list
     #
-    # used in orchestration.adoc and in partials/env-and-yaml.adoc for all services
+    # used via orchestration.adoc and in partials/env-and-yaml.adoc for all services
     # define to use tabs, the first tab is always active
     use_tab_2: true # set to any value if tab 2 should be shown
-    use_tab_3:  # set to any value if tab 3 should be shown
+    use_tab_3:      # set to any value if tab 3 should be shown
     # service_tab_x will be used to assemble the url accessing the link for the services
-    service_tab_1: docs-stable-2.0
+    service_tab_1: docs # do not change, the docs branch contains changes of master
     service_tab_2: docs-stable-2.0
     service_tab_3: tab_3
     # service_tab_x_tab_text will be used as tab text shown for tab_x


### PR DESCRIPTION
This is a small fix to update the antora.yml file referencing the correct branch for master, which is technically the docs branch (in the ocis repo). 