### PR TITLE
Add the postprocessing service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -1,0 +1,49 @@
+= Postprocessing Service Configuration
+:toc: right
+
+:ext_name: postprocessing
+
+// remember to REMOVE the corresponding tab if a new ocis release will be published
+
+:no_second_tab: true
+:no_third_tab: true
+
+:description: The Infinite Scale postprocessing service handles the coordination of asynchronous postprocessing steps.
+
+== Introduction
+
+{description} 
+
+== General Prerequisites
+
+To use the postprocessing service, an event system needs to be configured for all services. By default, `ocis` ships with a preconfigured `nats` service.
+
+== Postprocessing Functionality
+
+The storageprovider service (xref:deployment/services/s-list/storage-users.adoc[storage-users]) can be configured to initiate asynchronous postprocessing by setting the `STORAGE_USERS_OCIS_ASYNC_UPLOADS` environment variable to `true`. If this is the case, postprocessing will get initiated _after_ uploading a file and all bytes have been received.
+
+The `postprocessing` service will then coordinate configured postprocessing steps like scanning the file for viruses. During postprocessing, the file will be in a `processing state` where only a limited set of actions are available.
+
+NOTE: The processing state excludes file accessability by users.
+
+When all postprocessing steps have completed successfully, the file will be made accessible for users.
+
+== Additional Prerequisites for the postprocessing Service
+
+When postprocessing has been enabled, configuring any postprocessing step will require the requested services to be enabled and pre-configured. For example, to use the `virusscan` step, one needs to have an enabled and configured `antivirus` service. 
+
+== Postprocessing Steps
+
+As of now, `ocis` allows two different postprocessing steps to be enabled via an environment variable.
+
+=== Virus Scanning
+
+To enable virus scanning as a postprocessing step after uploading a file, the environment variable  `POSTPROCESSING_VIRUSSCAN` needs to be set to `true`. As a result, each uploaded file gets virus scanned as part of the postprocessing steps. Note that the `antivirus` service is required to be enabled and configured for this to work.
+
+=== Delay
+
+Though this is for development purposes only and NOT RECOMMENDED on production systems, setting the environment variable `POSTPROCESSING_DELAY` to a duration not equal to zero will add a delay step with the configured amount of time. ocis will continue postprocessing the file after the configured delay.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/services.adoc
+++ b/modules/ROOT/pages/deployment/services/services.adoc
@@ -11,4 +11,6 @@ For more details see xref:deployment/general/general-info.adoc#managing-services
 
 There are descriptions and configuration details for each service available.
 
+When a service gets added to Infinite Scale, a page describing the service is added but the configuration will only show up for those releases where the service is available.
+
 Also see the supporting documents describing various topics around services.

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -1,6 +1,6 @@
 === Environment Variables
 
-The `{ext_name}` extension is configured via the following environment variables:
+The `{ext_name}` service is configured via the following environment variables:
 
 [tabs]
 ====
@@ -9,6 +9,9 @@ The `{ext_name}` extension is configured via the following environment variables
 --
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
 --
+// disable printing the second tab if not allowed (eg. if service is fresh created)
+// set this if required in the calling page!
+ifndef::no_second_tab[]
 ifdef::use_tab_2[]
 {service_tab_2_tab_text}::
 +
@@ -16,12 +19,17 @@ ifdef::use_tab_2[]
 include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
 --
 endif::[]
+// disable printing the third tab if not allowed (eg. if service is fresh created)
+// set this if required in the calling page!
+ifndef::no_third_tab[]
 ifdef::use_tab_3[]
 {service_tab_3_tab_text}::
 +
 --
 include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
 --
+endif::[]
+endif::[]
 endif::[]
 ====
 
@@ -37,6 +45,9 @@ endif::[]
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}{ext_name}-config-example.yaml[]
 ----
 --
+// disable printing the second tab if not allowed (eg. if service is fresh created)
+// set this if required in the calling page!
+ifndef::no_second_tab[]
 ifdef::use_tab_2[]
 {service_tab_2_tab_text}::
 +
@@ -47,6 +58,9 @@ include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}{ext_na
 ----
 --
 endif::[]
+// disable printing the third tab if not allowed (eg. if service is fresh created)
+// set this if required in the calling page!
+ifndef::no_third_tab[]
 ifdef::use_tab_3[]
 {service_tab_3_tab_text}::
 +
@@ -56,6 +70,8 @@ ifdef::use_tab_3[]
 include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}{ext_name}-config-example.yaml[]
 ----
 --
+endif::[]
+endif::[]
 endif::[]
 ====
 

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -38,6 +38,7 @@
 ***** xref:deployment/services/s-list/notifications.adoc[Notification]
 ***** xref:deployment/services/s-list/ocdav.adoc[OCDAV]
 ***** xref:deployment/services/s-list/ocs.adoc[OCS]
+***** xref:deployment/services/s-list/postprocessing.adoc[Postprocessing]
 ***** xref:deployment/services/s-list/proxy.adoc[Proxy]
 ***** xref:deployment/services/s-list/search.adoc[Search]
 ***** xref:deployment/services/s-list/settings.adoc[Settings]


### PR DESCRIPTION
Add the postprocessing service to the service list.

This also needed an adoption of the tab handling to only show tabs where the service is available.

Keeping this as draft until the service and variable descriptions are final.

@kobergj fyi