### PR TITLE
Add a documentation about S3 bucket policy

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -1,5 +1,6 @@
 = General Info
 :toc: right
+:aws-bucket-policy-url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html
 
 :description: This document covers general aspects of Infinite Scale like start modes, services, important minimum configuration etc. for a common understanding.
 
@@ -450,4 +451,32 @@ CATEGORY:
 OPTIONS:
    --space value, -s value  the ID of the space to travers and index the files
    --user value, -u value   the username of the user that shall be used to access the files
+----
+
+== S3 Bucket Policy
+
+With S3 bucket policies, you can configure and secure access to objects in your buckets, see
+{aws-bucket-policy-url}[Using bucket policies]. The following S3 bucket policies are a requirement when connecting to an S3 bucket, replace the bucket name accordingly. When using an S3 bucket you have to set the storage driver to `s3ng`. Also see the xref:deployment/container/orchestration/orchestration.adoc#deploy-the-chart[Deploy the Chart] section in the `Container Orchestration` documentation and the xref:{s-path}/storage-users.adoc[STORAGE_USERS_DRIVER] configuration value.
+
+{empty}
+[source,yaml]
+----
+# The S3NG driver needs an existing S3 bucket with following permissions:
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListObjectsInBucket",
+            "Effect": "Allow",
+            "Action": ["s3:ListBucket"],
+            "Resource": ["arn:aws:s3:::bucket-name"]
+        },
+        {
+            "Sid": "AllObjectActions",
+            "Effect": "Allow",
+            "Action": "s3:*Object",
+            "Resource": ["arn:aws:s3:::bucket-name/*"]
+        }
+    ]
+}
 ----


### PR DESCRIPTION
Fixes: #288 (S3ng documentation)

Added a documentation about S3 bucket policy which is not only necessary for Helm but also in container deployments.

Needs PR [Complete description of STORAGE_USERS_DRIVER](https://github.com/owncloud/ocis/pull/5345) including the backport before merging to avoid referencing to content which is not fully present.

Therefore Set to draft to avoid accidentially merging.