### PR TITLE
Consequently using the 's-path' attribute

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -32,7 +32,7 @@ This mode is used when _availability, scaling and the adjustment to dynamically 
 
 == Managing Services
 
-Services are built as microservices which can be started, stopped or instantiated. xref:deployment/services/s-list/services_rules.adoc[Services Rules] documentation as been added to explain some background. Please read this carefully to avoid unwanted behavior. For details of each service see the xref:deployment/services/services.adoc[Services] documentation.
+Services are built as microservices which can be started, stopped or instantiated. xref:{s-path}/services_rules.adoc[Services Rules] documentation as been added to explain some background. Please read this carefully to avoid unwanted behavior. For details of each service see the xref:deployment/services/services.adoc[Services] documentation.
 
 === List Available Services
 

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -32,7 +32,7 @@ This mode is used when _availability, scaling and the adjustment to dynamically 
 
 == Managing Services
 
-Services are built as microservices which can be started, stopped or instantiated. xref:{s-path}/services_rules.adoc[Services Rules] documentation as been added to explain some background. Please read this carefully to avoid unwanted behavior. For details of each service see the xref:deployment/services/services.adoc[Services] documentation.
+Services are built as microservices which can be started, stopped or instantiated. xref:{s-path}/services_rules.adoc[Services Rules] documentation has been added to explain some background. Read this carefully to avoid unwanted behavior. For details of each service see the xref:deployment/services/services.adoc[Services] documentation.
 
 === List Available Services
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -36,7 +36,7 @@ The datagateway endpoint, by default `/data`, forwards file up- and download req
 
 === ocs
 
-The ocs endpoint, by default `/ocs`, implements the ownCloud 10 Open Collaboration Services API by translating it into CS3 API requests. It can handle users, groups, capabilities and also implements the file sharing functionality on top of CS3. The `/ocs/v[12].php/cloud/user/signing-key` is currently handled by the dedicated xref:deployment/services/s-list/ocs.adoc[ocs] service.
+The ocs endpoint, by default `/ocs`, implements the ownCloud 10 Open Collaboration Services API by translating it into CS3 API requests. It can handle users, groups, capabilities and also implements the file sharing functionality on top of CS3. The `/ocs/v[12].php/cloud/user/signing-key` is currently handled by the dedicated xref:{s-path}/ocs.adoc[ocs] service.
 
 == Scalability
 

--- a/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
@@ -3,7 +3,7 @@
 
 :ext_name: ocdav
 
-:description: The ocDAV service is responsible for translating ownCloud flavoured WebDAV into CS3 API calls. Note that previews (thumbnails) are provided by the xref:deployment/services/s-list/webdav.adoc[WebDAV service].
+:description: The ocDAV service is responsible for translating ownCloud flavoured WebDAV into CS3 API calls. Note that previews (thumbnails) are provided by the xref:{s-path}/webdav.adoc[WebDAV service].
 
 // references https://github.com/owncloud/ocis/pull/3864 ([docs-only] add PROPFIND sequence diagram examples)
 // also see: https://owncloud.dev/architecture/protocol-changes/ 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -20,7 +20,7 @@ To use the postprocessing service, an event system needs to be configured for al
 
 == Postprocessing Functionality
 
-The storageprovider service (xref:deployment/services/s-list/storage-users.adoc[storage-users]) can be configured to initiate asynchronous postprocessing by setting the `STORAGE_USERS_OCIS_ASYNC_UPLOADS` environment variable to `true`. If this is the case, postprocessing will get initiated _after_ uploading a file and all bytes have been received.
+The storageprovider service (xref:{s-path}/storage-users.adoc[storage-users]) can be configured to initiate asynchronous postprocessing by setting the `STORAGE_USERS_OCIS_ASYNC_UPLOADS` environment variable to `true`. If this is the case, postprocessing will get initiated _after_ uploading a file and all bytes have been received.
 
 The `postprocessing` service will then coordinate configured postprocessing steps like scanning the file for viruses. During postprocessing, the file will be in a `processing state` where only a limited set of actions are available.
 

--- a/modules/ROOT/pages/deployment/services/s-list/webdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/webdav.adoc
@@ -3,7 +3,7 @@
 
 :ext_name: webdav
 
-:description: The webdav service, like the xref:deployment/services/s-list/ocdav.adoc[ocdav] service, provides a HTTP API following the webdav protocol. It receives HTTP calls from requestors like clients and issues gRPC calls to other services executing these requests. After the called service has finished the request, the webdav service will render their responses in `xml` and sends them back to the requestor.
+:description: The webdav service, like the xref:{s-path}/ocdav.adoc[ocdav] service, provides a HTTP API following the webdav protocol. It receives HTTP calls from requestors like clients and issues gRPC calls to other services executing these requests. After the called service has finished the request, the webdav service will render their responses in `xml` and sends them back to the requestor.
 
 == Introduction
 
@@ -21,13 +21,13 @@ Currently, the webdav service handles request for two functionalities, which are
 
 The webdav service provides various `GET` endpoints to get the thumbnails of a file in authenticated and unauthenticated contexts. It also provides thumbnails for spaces on different endpoints. 
 
-See the xref:deployment/services/s-list/thumbnails.adoc[thumbnails] service for more information about thumbnails.
+See the xref:{s-path}/thumbnails.adoc[thumbnails] service for more information about thumbnails.
 
 === Search Service
 
 The webdav service provides access to the search functionality. It offers multiple `REPORT` endpoints for getting search results. 
 
-See the xref:deployment/services/s-list/search.adoc[search] service for more details about the search functionality. 
+See the xref:{s-path}/search.adoc[search] service for more details about the search functionality. 
 
 == Scalability
 


### PR DESCRIPTION
There were from history some paths to services hardcoded and not referenced via an attribute which was created for exactly that reason - fixed by using he attribute.