### PR TITLE
Enable global envvars

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -4,7 +4,7 @@
 // there is only an adoc table to include but no yaml file. this is only when using special scope envvars.
 :no_yaml: true
 
-:description: Some environment variables have an extended or global scope. Variables with extended scope do not directly configure services but function underneath. Variables with a global scope can configure more than one service.
+:description: Some environment variables have an extended or global scope. Variables with extended scope do not directly configure services but functions underneath. Variables with a global scope can configure more than one service.
 
 == Introduction
 
@@ -12,7 +12,7 @@
 
 Examples:
 
-// * The global environment variable `OCIS_LOG_LEVEL` is available in multiple services.
+* The global environment variable `OCIS_LOG_LEVEL` is available in multiple services.
 * The extended environment variable `OCIS_CONFIG_DIR` can be used with `ocis init`.
 
 == Extended Environment Variables
@@ -21,11 +21,8 @@ Examples:
 
 include::partial$deployment/services/env-and-yaml.adoc[]
 
-// prepared but not available for now
-////
 == Global Environment Variables
 
 :ext_name: global
 
 include::partial$deployment/services/env-and-yaml.adoc[]
-////


### PR DESCRIPTION
Refernces: https://github.com/owncloud/ocis/pull/5378 ([docs-only] Backport Docs Helpers to 2.0)

This PR finalizes the colletcion of environment variables with special purpose.
Both `extended` and `global` ones are now shown in latest (master) and 2.0.0 (GA).

Tested via local build, currently visible for preview on staging.