### PR TITLE
Add internal comment to extended envvars

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -17,6 +17,10 @@ Examples:
 
 == Extended Environment Variables
 
+// note that if a description of an extended envvar is missing, you need to fix this in:
+// https://github.com/owncloud/ocis/blob/master/docs/helpers/extended_vars.yaml
+// see the readme.md file in that folder
+ 
 :ext_name: extended
 
 include::partial$deployment/services/env-and-yaml.adoc[]


### PR DESCRIPTION
Forgot to add an internal comment where to change extended envvar descriptions if one is empty. This PR does not change any content is is meant as reminder of one searches where to fix a missing entry.