### PR TITLE
Fix typo in the Helm documentation

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -559,7 +559,7 @@ minikube kubectl -- apply -f generic-secrets.yaml
 
 ==== Define Generic Configs
 
-Infinite Scale requires some generic configuration to work. It was decided not to create them automatically, because Helm does not support _on-off_ generation of configuration out of the box.
+Infinite Scale requires some generic configuration to work. It was decided not to create them automatically, because Helm does not support _one-off_ generation of configuration out of the box.
 
 For these reasons, ownCloud cannot take responsibility for these generic configuration. Any information necessary to use this application-relevant data is provided by ownCloud via examples.
 


### PR DESCRIPTION
Fixed a typo in the Helm documentation as dicsussed in RC.

It is not a switch (on-off) but one-time and off.

@d7oc FYI