### PR TITLE
Add a description in the General/Default Paths section about S3

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -109,7 +109,7 @@ ocis list
 
 === Configuration Directory
 
-The default locations for _config_ files are:
+The default locations for _config_ files, which have to be on a POSIX storage, without the need setting them explicitely are:
 
 * For container images (inside the container) +
 `/etc/ocis/`
@@ -123,9 +123,16 @@ NOTE: When using a system user for the runtime, which has no login and therefore
 
 === Base Data Directory
 
-The base directory is important, because other services use this directory as the base path if service dependent variables are not explicitly defined. Defining them independently can be required when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup.
+The base directory contains, dependent on how the system is setup, not only the metadata but also the user data, see xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
 
-For the time being, the following services have settings where the base directory is used if not manually defined in the service:
+* When only using a supported POSIX filesystem, user data and metadata are stored on that filesystem.  
+* When using S3 and POSIX, user data is stored as blob on S3 while metadata is stored on POSIX. Also see xref:using-s3-for-user-data[Using S3 for User Data]
+
+The base directory is important, because services need this directory for writing data. Some services can overwrite that path if necessary. Defining them independently can be required when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup.
+
+The base path has default locations, see below, if not manually defined by the environment variable `OCIS_BASE_DATA_PATH`.
+
+The environment variable `OCIS_BASE_DATA_PATH`, if manually defined, sets the base path in a generic way. Following services can overwrite the base path for that service if necessary.
 
 * xref:{s-path}/nats.adoc[NATS_NATS_STORE_DIR]
 * xref:{s-path}/search.adoc[SEARCH_DATA_PATH]
@@ -136,8 +143,12 @@ For the time being, the following services have settings where the base director
 * xref:{s-path}/storage-users.adoc[STORAGE_USERS_OWNCLOUDSQL_DATADIR]
 * xref:{s-path}/thumbnails.adoc[THUMBNAILS_FILESYSTEMSTORAGE_ROOT]
 
-The default locations for the _base_ directory are:
+// necessary to properly break the list item from the next component
+{empty}
 
+.The default locations for the _base_ directory are:
+{empty}
+--
 * For container images (inside the container) +
 `/var/lib/ocis`
 +
@@ -148,6 +159,32 @@ NOTE: You can deviate from the default location and define a custom configuratio
 the environment variable `OCIS_BASE_DATA_PATH`. When setting the base directory manually, it will be used automatically for the services described above - if they are not otherwise manually defined. 
 +
 NOTE: When using a system user for the runtime, which has no login and therefore no home directory, like in the scenario xref:deployment/binary/binary-setup.adoc#setting-up-systemd-for-infinite-scale[Setting up systemd for Infinite Scale], you *must* specify a base directory location.
+--
+
+=== Using S3 for User Data
+
+When using S3 for storing user data, metadata must reside on POSIX using the base directory as path. For more details see the section xref:base-data-directory[Base Data Directory] above.
+
+Configuring the xref:{s-path}/storage-users.adoc[Storage-Users] service is necessary to define the usage of POSIX and S3 storage for Infinite Scale.
+
+Following environment variables are necessary to be configured for the use with S3, see the Storage-Users service for details:
+
+[source, yaml]
+----
+# activate s3ng storage driver
+STORAGE_USERS_DRIVER: s3ng
+# keep system data on ocis storage
+STORAGE_SYSTEM_DRIVER: ocis
+
+# s3ng specific settings
+STORAGE_USERS_S3NG_ENDPOINT:
+STORAGE_USERS_S3NG_REGION:
+STORAGE_USERS_S3NG_ACCESS_KEY:
+STORAGE_USERS_S3NG_SECRET_KEY:
+STORAGE_USERS_S3NG_BUCKET:
+----
+
+Also see the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples].
 
 == Initialize Infinite Scale
 

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -111,7 +111,7 @@ As you will read below, the config directory and the base directory for storing 
 
 === Configuration Directory
 
-The default locations for _config_ files, which have to be on a POSIX storage, without the need setting them explicitely are:
+The default locations (no need to set them explicitly) for _config_ files, which have to be on a POSIX storage, are:
 
 * For container images (inside the container) +
 `/etc/ocis/`
@@ -125,16 +125,16 @@ NOTE: When using a system user for the runtime, which has no login and therefore
 
 === Base Data Directory
 
-The base directory contains, dependent on how the system is setup, not only the metadata but also the user data, see xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
+Depending on the system setup, the base directory contains not only the metadata but also the user data. See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
 
 * When only using a supported POSIX filesystem, user data and metadata are stored on that filesystem.  
-* When using S3 and POSIX, user data is stored as blob on S3 while metadata is stored on POSIX. Also see xref:using-s3-for-user-data[Using S3 for User Data]
+* When using S3 and POSIX, user data is stored as blob on S3 while metadata is stored on POSIX. Also see xref:using-s3-for-user-data[Using S3 for User Data].
 
 The base directory is important, because services need this directory for writing data. Some services can overwrite that path if necessary. Defining them independently can be required when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup.
 
-The base path has default locations, see below, if not manually defined by the environment variable `OCIS_BASE_DATA_PATH`.
+The base path has default locations (see below) if not manually defined by the environment variable `OCIS_BASE_DATA_PATH`.
 
-The environment variable `OCIS_BASE_DATA_PATH`, if manually defined, sets the base path in a generic way. Following services can overwrite the base path for that service if necessary.
+The environment variable `OCIS_BASE_DATA_PATH`, if manually defined, sets the base path in a generic way. The following services can overwrite the base path for that service if necessary.
 
 * xref:{s-path}/nats.adoc[NATS_NATS_STORE_DIR]
 * xref:{s-path}/search.adoc[SEARCH_DATA_PATH]
@@ -169,7 +169,7 @@ When using S3 for storing user data, metadata must reside on POSIX using the bas
 
 Configuring the xref:{s-path}/storage-users.adoc[Storage-Users] service is necessary to define the usage of POSIX and S3 storage for Infinite Scale.
 
-Following environment variables are necessary to be configured for the use with S3, see the Storage-Users service for details:
+The following environment variables are need to be configured for the use with S3 (see the Storage-Users service for details):
 
 [source, yaml]
 ----

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -107,6 +107,8 @@ ocis list
 
 == Default Paths
 
+As you will read below, the config directory and the base directory for storing metadata must be located on POSIX filesystems. Consider for the ease of backup and restore, to keep both directories on the same filesystem.
+
 === Configuration Directory
 
 The default locations for _config_ files, which have to be on a POSIX storage, without the need setting them explicitely are:


### PR DESCRIPTION
Add a description about S3 in the Default Paths section in the General Info documentation.

Currently visible on staging.