### PR TITLE
Fix a typo

### DIFF
--- a/modules/ROOT/pages/deployment/wopi/wopi.adoc
+++ b/modules/ROOT/pages/deployment/wopi/wopi.adoc
@@ -31,7 +31,7 @@ Configured applications can be selected by users when opening a document via the
 
 Office applications are:
 
-* provided via the xref:{s-path}/app-provider.adoc[App-Provider Service] because they are not able to register themself, see the xref:#wopi-coniguration-examples[docker-copmpose.yml] file. 
+* provided via the xref:{s-path}/app-provider.adoc[App-Provider Service] because they are not able to register themself, see the xref:#wopi-coniguration-examples[docker-compose.yml] file. 
 
 * configured for use with the WebUI via the xref:{s-path}/app-registry.adoc[App-Registry Service]. Here, default office apps and their appearance in the list of available apps in the webUI are defined. For more information see the xref:#wopi-coniguration-examples[app-registry.yaml] file.
 


### PR DESCRIPTION
`copmose` --> `compose`