### PR TITLE
Update the postprocessing service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -50,7 +50,7 @@ By using the envvar `POSTPROCESSING_STEPS`, custom postprocessing steps can be a
 
 === Prerequisites
 
-For using custom postprocessing steps you need a custom service listening to the configured event system (see General Prerequisites)
+For using custom postprocessing steps, you need a custom service listening to the configured event system, see xref:general-prerequisites[General Prerequisites]
 
 === Workflow
 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -16,9 +16,9 @@
 
 == General Prerequisites
 
-To use the postprocessing service, an event system needs to be configured for all services. By default, Infinite Scale ships with a preconfigured `nats` service.
+To use the post-processing service, an event system needs to be configured for all services. By default, Infinite Scale ships with a preconfigured `nats` service.
 
-== Postprocessing Functionality
+== Post-Processing Functionality
 
 The storageprovider service (xref:{s-path}/storage-users.adoc[storage-users]) can be configured to initiate asynchronous postprocessing by setting the `STORAGE_USERS_OCIS_ASYNC_UPLOADS` environment variable to `true`. If this is the case, postprocessing will get initiated _after_ uploading a file and all bytes have been received.
 
@@ -32,31 +32,31 @@ When all postprocessing steps have completed successfully, the file will be made
 
 When postprocessing has been enabled, configuring any postprocessing step will require the requested services to be enabled and pre-configured. For example, to use the `virusscan` step, one needs to have an enabled and configured `antivirus` service. 
 
-== Postprocessing Steps
+== Post-Processing Steps
 
-The postporcessing service is individually configurable. This is achieved by allowing a list of postprocessing steps that are processed in order of their appearance in the `POSTPROCESSING_STEPS` envvar. This envvar expects a comma separated list of steps that will be executed. Currently known steps to the system are `virusscan` and `delay`. Custom steps can be added but need an existing target for processing.
+The post-processing service is individually configurable. This is achieved by allowing a list of post-processing steps to be performed in order of their appearance in the `POSTPROCESSING_STEPS` envvar. This envvar expects a comma-separated list of steps that will be executed. Currently known steps to the system are `virusscan` and `delay`. Custom steps can be added but need an existing target for processing.
 
 === Virus Scanning
 
-To enable virus scanning as a postprocessing step after uploading a file, the environment variable `POSTPROCESSING_STEPS` needs to contain the word `virusscan` at one location in the list of steps. As a result, each uploaded file gets virus scanned as part of the postprocessing steps. Note that the `antivirus service` is required to be enabled and configured for this to work.
+To enable virus scanning as a post-processing step after uploading a file, the environment variable `POSTPROCESSING_STEPS` needs to contain the word `virusscan` at one location in the list of steps. As a result, each uploaded file gets virus-scanned as part of the post-processing steps. Note that the `antivirus service` must be enabled and configured for this to work.
 
 === Delay
 
-Though this is for development purposes only and NOT RECOMMENDED on production systems, setting the environment variable `POSTPROCESSING_DELAY` to a duration not equal to zero will add a delay step with the configured amount of time. Infinite Scale will continue postprocessing the file after the configured delay. Use the enviroment variable `POSTPROCESSING_STEPS` and the keyword `delay` if you have multiple postprocessing steps and want to define their order. If `POSTPROCESSING_DELAY` is set but the keyword `delay` is not contained in `POSTPROCESSING_STEPS`, it will be processed as last postprocessing step without being listed there. In this case, a log entry will be written on service startup to notify the admin about that situation. That log entry can be avoided by adding the keyword `delay` to `POSTPROCESSING_STEPS`.
+Though this is for development purposes only and NOT RECOMMENDED on production systems, setting the environment variable `POSTPROCESSING_DELAY` to a duration not equal to zero will add a delay step with the configured amount of time. Infinite Scale will continue post-processing the file after the configured delay. Use the enviroment variable `POSTPROCESSING_STEPS` and the keyword `delay` if you have multiple post-processing steps and want to define their order. If `POSTPROCESSING_DELAY` is set but the keyword `delay` is not contained in `POSTPROCESSING_STEPS`, it will be executed as the last post-processing step without being listed as the last one. In this case, a log entry will be written on service startup to notify the admin about the situation. That log entry can be avoided by adding the keyword `delay` to `POSTPROCESSING_STEPS`.
 
-== Custom Postprocessing Steps
+== Custom Post-Processing Steps
 
-By using the envvar `POSTPROCESSING_STEPS`, custom postprocessing steps can be added. Any word can be used as step name but be careful not to conflict with exising keywords like `virusscan` and `delay`. In addition, if a keyword is misspelled or the corresponding service does either not exist or does not follow the necessary event communication, the postprocessing service will wait forever getting the required response to proceed and does not continue any other processing.
+By using the envvar `POSTPROCESSING_STEPS`, custom post-processing steps can be added. Any word can be used as step name but be careful not to conflict with existing keywords like `virusscan` and `delay`. In addition, if a keyword is misspelled or the corresponding service does either not exist or does not follow the necessary event communication, the post-processing service will wait forever to get the required response to proceed and therefore does not continue with any other processing.
 
 === Prerequisites
 
-For using custom postprocessing steps, you need a custom service listening to the configured event system, see xref:general-prerequisites[General Prerequisites]
+To use custom post-processing steps, you need a custom service listening to the configured event system. For more information, see xref:general-prerequisites[General Prerequisites].
 
 === Workflow
 
-When setting a custom postprocessing step (eg. "customstep") the postprocessing service will eventually sent an event during postprocessing. The event will be of type StartPostprocessingStep with its field StepToStart set to "customstep". When the custom service receives this event, it can savely execute its actions. The postprocessing service will wait until it has finished its work. The event contains further information (like filename, executing user, size, ...) and required tokens respectively urls to download the file in case byte inspection is necessary.
+When setting a custom post-processing step (eg. "customstep") the post-processing service will eventually send an event during post-processing. The event will be of the type StartPostprocessingStep with its field StepToStart set to "customstep". When the custom service receives this event, it can safely execute its actions. The post-processing service will wait until it has finished its work. The event contains further information (like filename, executing user, size, ...) and required tokens respectively URLs to download the file in case byte inspection is necessary.
 
-Once the custom service has finished its work, it should sent an event of type `PostprocessingFinished` via the configured events system. This event needs to contain a `FinishedStep` field set to "customstep". It also must contain the outcome of the step, which can be one of `delete` (abort postprocessing, delete the file), `abort` (abort postprocessing, keep the file) and `continue` (continue postprocessing, this is the success case).
+Once the custom service has finished its work, it should send an event of the type `PostprocessingFinished` via the configured event system. This event needs to contain a `FinishedStep` field set to "customstep". It also must contain the outcome of the step, which can be one of `delete` (abort post-processing, delete the file), `abort` (abort post-processing, keep the file) and `continue` (continue post-processing, this is the success case).
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -16,7 +16,7 @@
 
 == General Prerequisites
 
-To use the postprocessing service, an event system needs to be configured for all services. By default, `ocis` ships with a preconfigured `nats` service.
+To use the postprocessing service, an event system needs to be configured for all services. By default, Infinite Scale ships with a preconfigured `nats` service.
 
 == Postprocessing Functionality
 
@@ -34,15 +34,29 @@ When postprocessing has been enabled, configuring any postprocessing step will r
 
 == Postprocessing Steps
 
-As of now, `ocis` allows two different postprocessing steps to be enabled via an environment variable.
+The postporcessing service is individually configurable. This is achieved by allowing a list of postprocessing steps that are processed in order of their appearance in the `POSTPROCESSING_STEPS` envvar. This envvar expects a comma separated list of steps that will be executed. Currently known steps to the system are `virusscan` and `delay`. Custom steps can be added but need an existing target for processing.
 
 === Virus Scanning
 
-To enable virus scanning as a postprocessing step after uploading a file, the environment variable  `POSTPROCESSING_VIRUSSCAN` needs to be set to `true`. As a result, each uploaded file gets virus scanned as part of the postprocessing steps. Note that the `antivirus` service is required to be enabled and configured for this to work.
+To enable virus scanning as a postprocessing step after uploading a file, the environment variable `POSTPROCESSING_STEPS` needs to contain the word `virusscan` at one location in the list of steps. As a result, each uploaded file gets virus scanned as part of the postprocessing steps. Note that the `antivirus service` is required to be enabled and configured for this to work.
 
 === Delay
 
-Though this is for development purposes only and NOT RECOMMENDED on production systems, setting the environment variable `POSTPROCESSING_DELAY` to a duration not equal to zero will add a delay step with the configured amount of time. ocis will continue postprocessing the file after the configured delay.
+Though this is for development purposes only and NOT RECOMMENDED on production systems, setting the environment variable `POSTPROCESSING_DELAY` to a duration not equal to zero will add a delay step with the configured amount of time. Infinite Scale will continue postprocessing the file after the configured delay. Use the enviroment variable `POSTPROCESSING_STEPS` and the keyword `delay` if you have multiple postprocessing steps and want to define their order. If `POSTPROCESSING_DELAY` is set but the keyword `delay` is not contained in `POSTPROCESSING_STEPS`, it will be processed as last postprocessing step without being listed there. In this case, a log entry will be written on service startup to notify the admin about that situation. That log entry can be avoided by adding the keyword `delay` to `POSTPROCESSING_STEPS`.
+
+== Custom Postprocessing Steps
+
+By using the envvar `POSTPROCESSING_STEPS`, custom postprocessing steps can be added. Any word can be used as step name but be careful not to conflict with exising keywords like `virusscan` and `delay`. In addition, if a keyword is misspelled or the corresponding service does either not exist or does not follow the necessary event communication, the postprocessing service will wait forever getting the required response to proceed and does not continue any other processing.
+
+=== Prerequisites
+
+For using custom postprocessing steps you need a custom service listening to the configured event system (see General Prerequisites)
+
+=== Workflow
+
+When setting a custom postprocessing step (eg. "customstep") the postprocessing service will eventually sent an event during postprocessing. The event will be of type StartPostprocessingStep with its field StepToStart set to "customstep". When the custom service receives this event, it can savely execute its actions. The postprocessing service will wait until it has finished its work. The event contains further information (like filename, executing user, size, ...) and required tokens respectively urls to download the file in case byte inspection is necessary.
+
+Once the custom service has finished its work, it should sent an event of type `PostprocessingFinished` via the configured events system. This event needs to contain a `FinishedStep` field set to "customstep". It also must contain the outcome of the step, which can be one of `delete` (abort postprocessing, delete the file), `abort` (abort postprocessing, keep the file) and `continue` (continue postprocessing, this is the success case).
 
 == Configuration
 

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -4,7 +4,14 @@
 // print a dependent explanation line
 // no_yaml is not set = standard extension,
 // no_yaml is set = special scope envvars
+
+// the following included file just has an attribute necessary for rendering deprecations
+// this is necessary as attributes that are defined INSIDE a tabset will not get recognized,
+// attributes need to be defined OUTSIDE the tabset definition. example content:
+// :show-deprecation: true
  
+include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+
 ifndef::no_yaml[]
 === Environment Variables
 


### PR DESCRIPTION
References:
https://github.com/owncloud/ocis/pull/5457 (Better Configuration for Postprocessing Service)
https://github.com/owncloud/ocis/pull/5467 ([docs-only] Fix Envvar Deprecation)

The postporcessing service got updated:
* new fuctionality
* the first deprecation
(note that this deprecation should be removed before the next stable release gets published)

Hurra, we have the first deprecation and it is working like a charm 😃 

Note that the text added is more or less a 1:1 copy of the text from the ocis repo, see 5457 above. If we find any changes (consider checking the whole document), we should do the changes in the ocis repo too.

Currently visible on staging

@kobergj fyi