### PR TITLE
Update of paths and terms used

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -109,6 +109,31 @@ ocis list
 
 As you will read below, the config directory and the base directory for storing metadata must be located on POSIX filesystems. Consider for the ease of backup and restore, to keep both directories on the same filesystem.
 
+Note that the term _blob_ is used for file data the user uploads while _metatdata_ refers to all data that describes the blob.
+
+[width="100%",cols="30%,70%",options="header"]
+|===
+| Environment variable
+| Description
+
+a| xref:deployment/services/env-vars-special-scope.adoc#extended-environment-variables[OCIS_CONFIG_DIR]
+| Path to config files.
+
+a| xref:deployment/services/env-vars-special-scope.adoc#extended-environment-variables[OCIS_BASE_DATA_PATH]
+| Path to system relevant data.
+
+a| xref:{s-path}/storage-users.adoc[STORAGE_USERS_OCIS_ROOT]
+a| Path to blobs and metadata if POSIX is used. +
+Derives from `OCIS_BASE_DATA_PATH` if not set otherwise. +
+Used if `STORAGE_USERS_DRIVER` is set to `ocis`
+
+a| xref:{s-path}/storage-users.adoc[STORAGE_USERS_S3NG_ROOT]
+a| Path to metadata if S3 is used. +
+Derives from `OCIS_BASE_DATA_PATH` if not set otherwise. +
+Used if `STORAGE_USERS_DRIVER` is set to `s3ng`. +
+See xref:using-s3-for-blobs[Using S3 for Blobs] for the S3 configuration.
+|===
+
 === Configuration Directory
 
 The default locations (no need to set them explicitly) for _config_ files, which have to be on a POSIX storage, are:
@@ -125,10 +150,10 @@ NOTE: When using a system user for the runtime, which has no login and therefore
 
 === Base Data Directory
 
-Depending on the system setup, the base directory contains not only the metadata but also the user data. See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
+Depending on the system setup, the base directory contains not only the metadata but also blobs. See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
 
-* When only using a supported POSIX filesystem, user data and metadata are stored on that filesystem.  
-* When using S3 and POSIX, user data is stored as blobs on S3 while metadata is stored on POSIX. Also see xref:using-s3-for-user-data[Using S3 for User Data].
+* When only using a supported POSIX filesystem, blobs and metadata is stored on POSIX.  
+* When using S3 and POSIX, blobs are stored on S3 while metadata is stored on POSIX. Also see xref:using-s3-for-blobs[Using S3 for Blobs].
 
 The base directory is important, because services need this directory for writing data. Some services can overwrite that path if necessary. Defining them independently can be required when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup.
 
@@ -163,7 +188,7 @@ the environment variable `OCIS_BASE_DATA_PATH`. When setting the base directory 
 NOTE: When using a system user for the runtime, which has no login and therefore no home directory, like in the scenario xref:deployment/binary/binary-setup.adoc#setting-up-systemd-for-infinite-scale[Setting up systemd for Infinite Scale], you *must* specify a base directory location.
 --
 
-=== Using S3 for User Data
+=== Using S3 for Blobs
 
 When using S3 for storing user data, metadata must reside on POSIX using the base directory as path. For more details see the section xref:base-data-directory[Base Data Directory] above.
 
@@ -175,6 +200,8 @@ The following environment variables are need to be configured for the use with S
 ----
 # activate s3ng storage driver
 STORAGE_USERS_DRIVER: s3ng
+# Path to metadata stored on POSIX
+STORAGE_USERS_S3NG_ROOT:
 # keep system data on ocis storage
 STORAGE_SYSTEM_DRIVER: ocis
 

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -109,7 +109,7 @@ ocis list
 
 As you will read below, the config directory and the base directory for storing metadata must be located on POSIX filesystems. Consider for the ease of backup and restore, to keep both directories on the same filesystem.
 
-Note that the term _blob_ is used for file data the user uploads while _metatdata_ refers to all data that describes the blob.
+Note that the term _blob_ is used for file data the user uploads, while _metatdata_ refers to all data that describes the blob.
 
 [width="100%",cols="30%,70%",options="header"]
 |===
@@ -152,8 +152,8 @@ NOTE: When using a system user for the runtime, which has no login and therefore
 
 Depending on the system setup, the base directory contains not only the metadata but also blobs. See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
 
-* When only using a supported POSIX filesystem, blobs and metadata is stored on POSIX.  
-* When using S3 and POSIX, blobs are stored on S3 while metadata is stored on POSIX. Also see xref:using-s3-for-blobs[Using S3 for Blobs].
+* When only using a supported POSIX filesystem, blobs and metadata are stored on POSIX.  
+* When using S3 and POSIX, blobs are stored on S3, while metadata is stored on POSIX. Also see xref:using-s3-for-blobs[Using S3 for Blobs].
 
 The base directory is important, because services need this directory for writing data. Some services can overwrite that path if necessary. Defining them independently can be required when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup.
 

--- a/modules/ROOT/pages/maintenance/backup.adoc
+++ b/modules/ROOT/pages/maintenance/backup.adoc
@@ -13,8 +13,8 @@ Though no backup strategies are covered, reading this document can add valuable 
 
 Infinite Scale can run in two different setups when it comes to storing data:
 
-* All data, meaning configuration, user data and metadata, is stored on POSIX-compliant filesystems.
-* User data is stored as blobs on an S3-compliant storage while configuration and metadata are stored on POSIX.
+* All data, meaning configuration, blobs and metadata, is stored on POSIX-compliant filesystems.
+* Blobs are stored on an S3-compliant storage while configuration and metadata are stored on POSIX.
 
 For details on supported filesystems, see: xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage].
 
@@ -30,19 +30,19 @@ Keep in mind that you always have to back up all three data sets consistently:
 
 * config data
 * metadata ^1^
-* user data ^1^
+* blobs ^1^
 
-(1) ... For POSIX-only setups, the location for user data and metadata is currently the same. When using S3, the location differs.
+(1) ... For POSIX-only setups, the location for blobs and metadata is currently the same. When using S3, the location differs.
 
 As a rule of thumb, consider also to backup the Infinite Scale binary or the container used. This avoids difficulties when restoring the instance and possibly using an updated Infinite Scale version compared to the version used when backing up. Restoring and updating should always be different tasks.
 
 == Pure POSIX Setup
 
-If all data - configuration, user data and metadata - are stored on POSIX-compliant filesystems, create a consistent state and back up the data sets. This is easiest if you have only one filesystem for all of them. If you have different filesystems for the config and user/metadata, you need to do this task for each of them.
+If all data - configuration, blobs and metadata - are stored on POSIX-compliant filesystems, create a consistent state and back up the data sets. This is easiest if you have only one filesystem for all of them. If you have different filesystems for the config and blobs/metadata, you need to do this task for each of them.
 
 == Distributed Setup
 
-If data is distributed with configuration and metadata stored on POSIX-compliant filesystems and user data stored as blobs on S3, create a consistent state and back up:
+If data is distributed with configuration and metadata stored on POSIX-compliant filesystems and blobs are stored on S3, create a consistent state and back up:
 
 * the configuration and metadata,
 * the S3 bucket according to the rules and possibilities of the S3 provider.

--- a/modules/ROOT/pages/maintenance/restore.adoc
+++ b/modules/ROOT/pages/maintenance/restore.adoc
@@ -13,8 +13,8 @@ Though no restore strategies are covered, reading this document can add valuable
 
 Same as described in the xref:maintenance/backup.adoc#general-considerations[backup documentation], Infinite Scale can run in two different setups when it comes to storing data:
 
-* All data, meaning configuration, user data and metadata, is stored on POSIX-compliant filesystems.
-* User data is stored as blobs on an S3-compliant storage while configuration and metadata are stored on POSIX.
+* All data, meaning configuration, blobs and metadata, is stored on POSIX-compliant filesystems.
+* Blobs are stored on an S3-compliant storage while configuration and metadata are stored on POSIX.
 
 See the linked backup documentation for more details.
 
@@ -22,16 +22,14 @@ When it comes to restoring data, keep in mind that you always have to restore al
 
 * config data
 * metadata ^1^
-* user data ^1^
+* blobs ^1^
 
-(1) ... For POSIX-only environments, the location for user data and metadata is currently the same. When using S3, the location differs.
+(1) ... For POSIX-only environments, the location for blobs and metadata is currently the same. When using S3, the location differs.
 
 Valid for all restore procedures:
 
 * first check the basic configuration of Infinite Scale on the backup to prepare the necessary volumes, mount points and directories if they are not present on your Infinite Scale instance,
 * Infinite Scale must be in stopped state.
-
-NOTE: It is not possible to restore a backup from one type of setup to another. A restore can only be made to the same kind of setup.
 
 As a rule of thumb, consider also to restore the Infinite Scale binary or the backed-up container. This avoids difficulties after restoring the instance and possibly using an updated Infinite Scale version compared to the version used when backing up. Restoring and updating should always be different tasks.
 
@@ -40,7 +38,7 @@ As a rule of thumb, consider also to restore the Infinite Scale binary or the ba
 From the backup, restore:
 
 * config data
-* user data and metadata
+* blobs and metadata
 
 to their prepared locations. When done, you can start your Infinite Scale instance as usual.
 
@@ -49,6 +47,6 @@ to their prepared locations. When done, you can start your Infinite Scale instan
 From the backup, restore:
 
 * the configuration and metadata to the POSIX locations
-* the user data to the S3 bucket according to the rules, possibilities and methods of the S3 provider.
+* blobs to the S3 bucket according to the rules, possibilities and methods of the S3 provider.
 
 When done, you can start your Infinite Scale instance as usual.


### PR DESCRIPTION
This PR updates:

* the description for paths used
* harmonizes the term **blob** and removes **user data**
* removes a statement in the restore documentation --> I have new info
to be added in a new document: migrate between ocis and s3 filesystems 