### PR TITLE
Fix 404 for deprecations in extended and global envvars

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -22,11 +22,13 @@ Examples:
 // see the readme.md file in that folder
  
 :ext_name: extended
+:no_deprecation: true
 
 include::partial$deployment/services/env-and-yaml.adoc[]
 
 == Global Environment Variables
 
 :ext_name: global
+:no_deprecation: true
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -5,12 +5,18 @@
 // no_yaml is not set = standard extension,
 // no_yaml is set = special scope envvars
 
-// the following included file just has an attribute necessary for rendering deprecations
+// the included deprecation file just has an attribute necessary for rendering deprecations
 // this is necessary as attributes that are defined INSIDE a tabset will not get recognized,
 // attributes need to be defined OUTSIDE the tabset definition. example content:
 // :show-deprecation: true
- 
+// the file contains the attribute too to be easy used outside of tabsets.
+
+// exclude a deprecation file if not wanted - like when the file will just not exist
+// manually unset the attribute if required via ':!no_deprecation:'
+
+ifndef::no_deprecation[]
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+endif::[]
 
 ifndef::no_yaml[]
 === Environment Variables


### PR DESCRIPTION
Global- and Extended envvars do not have deprecations by design - needs to be handled differertly in the ocis code. No deprecations to be rendered - the file to include defining if there is a deprecation does not exist in that case and renders therefore to a 404.