### PR TITLE
Add hardware sizing to the Office documentation

### DIFF
--- a/modules/ROOT/pages/conf-examples/office-integration.adoc
+++ b/modules/ROOT/pages/conf-examples/office-integration.adoc
@@ -3,6 +3,7 @@
 :wopi_subdir: /ocis_wopi
 :traefik_url: https://traefik.io/traefik/
 :wopiserver_url: https://hub.docker.com/r/cs3org/wopiserver/tags?page=1&ordering=last_updated
+:onlyoffice_hw_url: https://helpcenter.onlyoffice.com/installation/docs-community-sys-reqs-docker.aspx
 
 :description: If you install the WOPI (Web Application Open Platform Interface) server extension, you can integrate major office applications like Collabora and ONLYOFFICE in Infinite Scale.
 
@@ -22,6 +23,10 @@ The docker stack consists of several containers:
 * and Collabora and OnlyOffice containers.
 
 Note that it is not mandatory to use and configure both example office application stacks. Configure only the application stacks that you need.
+
+== Hardware Requirements
+
+With focus on the office container, ONLYOFFICE provides a link with some guidance for hardware requirements depending on concurrent active users when using their community edition and docker, see {onlyoffice_hw_url}[ONLYOFFICE Docs Community Edition for Docker system requirements] for more details. This information can give an estimation without any guarantees.
 
 == Requirements
 

--- a/modules/ROOT/pages/conf-examples/office-integration.adoc
+++ b/modules/ROOT/pages/conf-examples/office-integration.adoc
@@ -26,7 +26,7 @@ Note that it is not mandatory to use and configure both example office applicati
 
 == Hardware Requirements
 
-With focus on the office container, ONLYOFFICE provides a link with some guidance for hardware requirements depending on concurrent active users when using their community edition and docker, see {onlyoffice_hw_url}[ONLYOFFICE Docs Community Edition for Docker system requirements] for more details. This information can give an estimation without any guarantees.
+With focus on the office container, ONLYOFFICE provides a link with some guidance for hardware requirements depending on concurrent active users when using their community edition and docker. See {onlyoffice_hw_url}[ONLYOFFICE Docs Community Edition for Docker system requirements] for more details. This information gives estimates without any guarantees.
 
 == Requirements
 


### PR DESCRIPTION
This adds a link to ONLYOFFICE where a hardware requirement description is documented.

Language review welcomed.