### PR TITLE
Add explanation text for yaml file naming

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -99,6 +99,8 @@ ocis.yaml
 [service name].yaml
 ----
 
+When using `ocis.yaml` and you configure a service, the topic for the service configuration must be the service name.
+
 You can list the possible services names by typing:
 
 [source,bash]

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -63,6 +63,9 @@ ifndef::no_yaml[]
 
 === YAML Example
 
+Note that the filename shown below is by purpose. +
+If you want to use it with your own configuration, you must name it `{ext_name}.yaml`
+
 [tabs]
 ====
 {service_tab_1_tab_text}::

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -64,7 +64,7 @@ ifndef::no_yaml[]
 === YAML Example
 
 Note that the filename shown below has been chosen on purpose. +
-If you want to use it with your own configuration, you must name it `{ext_name}.yaml`
+See the xref:deployment/general/general-info.adoc#configuration-file-naming[Configuration File Naming] for details when setting up your own configuration.
 
 [tabs]
 ====

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -63,7 +63,7 @@ ifndef::no_yaml[]
 
 === YAML Example
 
-Note that the filename shown below is by purpose. +
+Note that the filename shown below has been chosen on purpose. +
 If you want to use it with your own configuration, you must name it `{ext_name}.yaml`
 
 [tabs]


### PR DESCRIPTION
Fixes: #379 (Wrong frontend.yaml filename)

Adds a note to yaml files in services because they need a proper naming.

On draft, waiting for dev feedback.