### PR TITLE
Adding the eventhistory service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -1,6 +1,6 @@
 = Eventhistory Service Configuration
 :toc: right
-:description: The Infinite Scale eventhistory service consumes all events from the configured event system like NATS, stores them and allows other services to retrieve them via an eventid.
+:description: The Infinite Scale eventhistory service consumes all events from the configured event system like NATS, stores them and allows other services to retrieve them via an event ID.
 
 :ext_name: eventhistory
 
@@ -36,17 +36,17 @@ The `eventhistory` service stores each consumed event via the configured store i
 | `ocmem`
 | Advanced in-memory store allowing max size.
 
-| `redis`
-| Stores data in a configured redis cluster.
+| `Redis`
+| Stores data in a configured Redis cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.
 
 | `nats-js`
-| Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[nats jetstream].
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
 
 | `noop`
-| Stores nothing. Useful for testing. Not recommended in productive enviroments.
+| Stores nothing. Useful for testing. Not recommended in productive environments.
 |===
 
 1. Note that in-memory stores are by nature not reboot persistent.
@@ -56,7 +56,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 
 == Retrieving
 
-Other services can call the `eventhistory` service via a grpc call to retrieve events. The request must contain the eventid that should be retrieved.
+Other services can call the `eventhistory` service via a gRPC call to retrieve events. The request must contain the event ID that should be retrieved.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -1,0 +1,63 @@
+= Eventhistory Service Configuration
+:toc: right
+:description: The Infinite Scale eventhistory service consumes all events from the configured event system like NATS, stores them and allows other services to retrieve them via an eventid.
+
+:ext_name: eventhistory
+
+// remember to REMOVE the corresponding tab if a new ocis release will be published
+
+:no_second_tab: true
+:no_third_tab: true
+
+== Introduction
+
+{description} 
+
+== Prerequisites
+
+Running the eventhistory service without an event sytem like NATS is not possible.
+
+== Consuming
+
+The `eventhistory` services consumes all events from the configured event sytem.
+
+== Storing
+
+The `eventhistory` service stores each consumed event via the configured store in `EVENTHISTORY_STORE_TYPE`. Possible stores are:
+
+[width=85%,cols="15%,90%",options=header]
+|===
+| Store Type
+| Description
+
+| `mem`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `redis`
+| Stores data in a configured redis cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[nats jetstream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in productive enviroments.
+|===
+
+1. Note that in-memory stores are by nature not reboot persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicapable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
+4. The eventhistory service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+
+== Retrieving
+
+Other services can call the `eventhistory` service via a grpc call to retrieve events. The request must contain the eventid that should be retrieved.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -30,6 +30,7 @@
 **** xref:deployment/services/s-list/auth-basic.adoc[Auth Basic]
 **** xref:deployment/services/s-list/auth-bearer.adoc[Auth Bearer]
 **** xref:deployment/services/s-list/auth-machine.adoc[Auth Machine]
+**** xref:deployment/services/s-list/eventhistory.adoc[Eventhistory]
 **** xref:deployment/services/s-list/frontend.adoc[Frontend]
 **** xref:deployment/services/s-list/gateway.adoc[Gateway]
 **** xref:deployment/services/s-list/graph.adoc[Graph]


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/5600 (Eventhistory Service)

This PR adds the eventhistory service which was recently added in the ocis repo.

Currently visible on staging.

Language review welcomed.

@kobergj fyi