### PR TITLE
Add a note that descriptions of global envvars can differ context based

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -58,4 +58,6 @@ include::partial$deployment/services/env-and-yaml.adoc[]
 :ext_name: global
 :no_deprecation: true
 
+Note that the descriptions of these environment variables may differ dependent on the service context.
+
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -58,6 +58,6 @@ include::partial$deployment/services/env-and-yaml.adoc[]
 :ext_name: global
 :no_deprecation: true
 
-Note that the descriptions of these environment variables may differ dependent on the service context.
+Note that the descriptions of these environment variables may differ depending on the service context.
 
 include::partial$deployment/services/env-and-yaml.adoc[]


### PR DESCRIPTION
As the title says. Global envvars may not have a uniformed description in the servcies used.