### PR TITLE
Add the new userlog service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -15,7 +15,7 @@
 
 == Prerequisites
 
-Running the eventhistory service without an event sytem like NATS is not possible.
+Running the `eventhistory` service without an event sytem like NATS is not possible.
 
 == Consuming
 
@@ -52,7 +52,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 1. Note that in-memory stores are by nature not reboot persistent.
 2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicapable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
 3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
-4. The eventhistory service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4. The `eventhistory` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 
 == Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -50,7 +50,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 |===
 
 1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicapable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
 3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
 4. The `eventhistory` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -52,7 +52,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 1. Note that in-memory stores are by nature not reboot persistent.
 2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicapable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
 3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
-4. The `eventhistory` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4. The `eventhistory` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 
 == Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -1,6 +1,6 @@
 = Userlog Service Configuration
 :toc: right
-:description: The Infinite Scale userlog service is a mediator between the eventhistory service and clients who want to be informed about user related events. It provides an API to retrieve those.
+:description: The Infinite Scale userlog service is a mediator between the eventhistory service and clients who want to be informed about user-related events. It provides an API to retrieve those.
 
 :oc10-api-url: https://doc.owncloud.com/server/next/developer_manual/core/apis/ocs-notification-endpoint-v1.html#get-user-notifications
 
@@ -48,12 +48,12 @@ The `userlog` service persists information via the configured store in `USERLOG_
 |===
 
 1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicapable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
 3. The `userlog` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 
 == Configuring Events
 
-For the time being, the configuration which user related events are of interest is hardcoded and cannot be changed.
+Currently, the configuration which user-related events are of interest is hard-coded and cannot be changed.
 
 == Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -1,0 +1,75 @@
+= Userlog Service Configuration
+:toc: right
+:description: The Infinite Scale userlog service is a mediator between the eventhistory service and clients who want to be informed about user related events. It provides an API to retrieve those.
+
+:oc10-api-url: https://doc.owncloud.com/server/next/developer_manual/core/apis/ocs-notification-endpoint-v1.html#get-user-notifications
+
+:ext_name: userlog
+
+// remember to REMOVE the corresponding tab if a new ocis release will be published
+
+:no_second_tab: true
+:no_third_tab: true
+
+== Introduction
+
+{description} 
+
+== Prerequisites
+
+Running the `userlog` service without running the xref:{s-path}/eventhistory.adoc[eventhistory] service is not possible.
+
+== Storing
+
+The `userlog` service persists information via the configured store in `USERLOG_STORE_TYPE`. Possible stores are:
+
+[width=100%,cols="15%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `mem`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in productive environments.
+|===
+
+1. Note that in-memory stores are by nature not reboot persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicapable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3. The `userlog` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+
+== Configuring Events
+
+For the time being, the configuration which user related events are of interest is hardcoded and cannot be changed.
+
+== Retrieving
+
+The `userlog` service provides an API to retrieve configured events. For now, this API is mostly following the {oc10-api-url}[ownCloud Server notification GET API, window=_blank].
+
+== Deleting
+
+To delete events for an user, use a `DELETE` request to:
+
+[source,plaintext]
+----
+https://<your-ocis-instance>/ocs/v2.php/apps/notifications/api/v1/notification
+----
+
+containing the IDs to delete.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -52,6 +52,7 @@
 **** xref:deployment/services/s-list/storage-system.adoc[Storage-System]
 **** xref:deployment/services/s-list/storage-users.adoc[Storage-Users]
 **** xref:deployment/services/s-list/thumbnails.adoc[Thumbnails]
+**** xref:deployment/services/s-list/userlog.adoc[Userlog]
 **** xref:deployment/services/s-list/users.adoc[Users]
 **** xref:deployment/services/s-list/web.adoc[Web]
 **** xref:deployment/services/s-list/webdav.adoc[WebDAV]


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/5610 (Userlog Service)

As the title says.

Currently on draft, because the referenced PR is not merged.

More or less a copy of the eventhistory service + some changes.