### PR TITLE
Update the basic-auth service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/auth-basic.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-basic.adoc
@@ -15,6 +15,8 @@ The `auth-basic` service is responsible for validating authentication of incomin
 
 To enable `auth-basic`, you first must set `PROXY_ENABLE_BASIC_AUTH` to `true`.
 
+NOTE: The basic authentication implementation does not support cookies and is therefore not intended to be used for benchmarks.
+
 == Default Values
 
 * Auth Basic listens on port 9146 by default.


### PR DESCRIPTION
Basic authentication should not be used in production (as already stated) but also not for benchmarking.