### PR TITLE
Describe that https is default to access the webui

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -360,7 +360,7 @@ Expects a URL including _protocol_, _host_ and optionally _port_ to simplify con
 +
 NOTE: If you need to access Infinite Scale running on a VM or a remote machine via a host name other than localhost or in a container, you need to configure the host name with `OCIS_URL`. The same applies if you are not using host names but an IP address (e.g. 192.168.178.25) instead.
 +
-NOTE: By default, Infinite Scale enforces https for web and client access, which can be changed to http if necessary though not recommended for production. For details see xref:deployment/services/tls.adoc#tls-for-the-http-frontend[TLS for the HTTP Frontend] and xref:deployment/services/s-list/proxy.adoc[Proxy Service Configuration].
+NOTE: By default, Infinite Scale enforces https for web and client access. If necessary, this can be changed to http, which is not recommended for production. For details see xref:deployment/services/tls.adoc#tls-for-the-http-frontend[TLS for the HTTP Frontend] and xref:deployment/services/s-list/proxy.adoc[Proxy Service Configuration].
 
 
 PROXY_HTTP_ADDR::

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -359,6 +359,9 @@ OCIS_URL::
 Expects a URL including _protocol_, _host_ and optionally _port_ to simplify configuring all the different services. Other service environment variables also using an URL still take precedence if set, but will fall back to this URL if not set.
 +
 NOTE: If you need to access Infinite Scale running on a VM or a remote machine via a host name other than localhost or in a container, you need to configure the host name with `OCIS_URL`. The same applies if you are not using host names but an IP address (e.g. 192.168.178.25) instead.
++
+NOTE: By default, Infinite Scale enforces https for web and client access, which can be changed to http if necessary though not recommended for production. For details see xref:deployment/services/tls.adoc#tls-for-the-http-frontend[TLS for the HTTP Frontend] and xref:deployment/services/s-list/proxy.adoc[Proxy Service Configuration].
+
 
 PROXY_HTTP_ADDR::
 When using `0.0.0.0:9200`, the proxy will listen to all available interfaces. If you want or need to change that based on your requirements, you can use a different address e.g. to bind the proxy to an interface. 

--- a/modules/ROOT/pages/deployment/services/tls.adoc
+++ b/modules/ROOT/pages/deployment/services/tls.adoc
@@ -161,7 +161,7 @@ Disable TLS certificate validation for the LDAP connections. Do not set this in 
 === TLS for the HTTP Frontend
 
 PROXY_TLS::
-Use the HTTPS server instead of the HTTP server.
+Enable/Disable HTTPS for the external HTTP services.
 
 PROXY_TRANSPORT_TLS_KEY::
 Path/File name of the TLS server certificate key for the HTTPS server.


### PR DESCRIPTION
When setting up ocis, accessing the webui or clients is defaulted to https wich can be changed by an environment variable. Though the description was already present, it is now added on a more prominent location including links to the details.