### PR TITLE
Add subversion explanation for Kubernetes versions

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -248,7 +248,10 @@ As the Helm chart has currently not been published to a Helm repository, you nee
 
 * Check the supported Kubernetes versions before you download the chart.
 +
-The `~` represents all patch releases for that particular version:
+--
+** The `~` represents all patch releases for that particular version.
+** The `-0` represents subversions for that particular version.
+--
 +
 [tabs]
 ====

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -250,7 +250,7 @@ As the Helm chart has currently not been published to a Helm repository, you nee
 +
 --
 ** The `~` represents all patch releases for that particular version.
-** The `-0` represents subversions for that particular version.
+** The `-0` represents subversions of that particular version.
 --
 +
 [tabs]


### PR DESCRIPTION
References: https://github.com/owncloud/ocis-charts/pull/147 (- add support for Kubernetes sub versions)

As the title says.

Renders now as:
![image](https://user-images.githubusercontent.com/3321281/225050984-ecf54996-aa81-47da-b665-6e9f785aee36.png)
