### PR TITLE
Add missing port description to services

### DIFF
--- a/modules/ROOT/pages/deployment/services/ports-used.adoc
+++ b/modules/ROOT/pages/deployment/services/ports-used.adoc
@@ -19,7 +19,7 @@ The following port ranges are used by services:
 | 9100-9104  | xref:{s-path}/web.adoc[web]
 | 9105-9109  | https://github.com/owncloud/ocis-hello[hello]
 | 9110-9114  | xref:{s-path}/ocs.adoc[ocs]
-| 9115-9119  | xxref:{s-path}/webdav.adoc[webdav]
+| 9115-9119  | xref:{s-path}/webdav.adoc[webdav]
 | 9120-9124  | xref:{s-path}/graph.adoc[graph]
 | 9125-9129  | xref:{s-path}/policies.adoc[policies]
 | 9130-9134  | xref:{s-path}/idp.adoc[idp]

--- a/modules/ROOT/pages/deployment/services/s-list/app-provider.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/app-provider.adoc
@@ -11,6 +11,10 @@
 // fixme: source description is still missing, and a better description is needed
 // fixme: currently found at: https://owncloud.dev/extensions/storage/apps/#app-provider-capability
 
+== Default Values
+
+* App Provider listens on port 9165 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/app-registry.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/app-registry.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* App-Registry listens on port 9240 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/auth-bearer.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-bearer.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Users listens on port 9148 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/auth-machine.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-machine.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Auth Machine listens on port 9166 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Gateway listens on port 9142 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Graph listens on port 9120 by default.
+
 == Manual Filters
 
 Using the API, you can manually filter like for users. See the https://owncloud.dev/libre-graph-api/#/users/ListUsers[Libre Graph API] for examples in the https://owncloud.dev[developer documentation]. Note that you can use `and` and `or` to refine results.

--- a/modules/ROOT/pages/deployment/services/s-list/groups.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/groups.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Groups listens on port 9160 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/idp.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idp.adoc
@@ -14,6 +14,10 @@ By default, the IDP service is configured to use the Infinite Scale xref:{s-path
 
 To use the embedded IDP service, it must be accessed with https. Accessing it with http is not possible and generates an error that is logged.
 
+== Default Values
+
+* IDP listens on port 9130 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -8,6 +8,10 @@
 
 {description} To do this, it hooks into the event system and listens for certain events that the users need to be informed about. As an example, when a user is added to a share, a notification email will be sent to the user.
 
+== Default Values
+
+* Notifications listens on port 9170 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
@@ -11,6 +11,10 @@
 
 {description} For more details on CS3 see the xref:architecture/architecture.adoc#reva-and-cs3[REVA and CS3] description in the Architecture and Concepts section.
 
+== Default Values
+
+* OCDAV listens on port 9163 by default.
+
 == Sequence Diagram
 
 // https://github.com/owncloud/ocis/pull/3864

--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* OCS listens on port 9110 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/search.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/search.adoc
@@ -13,6 +13,10 @@
 * Metadata: all data that _describes_ the file like `Name`, `Size`, `MimeType`, `Tags` and `Mtime`.
 * Content: all data that _relates to content_ of the file like `words`, `geo data`, `exif data` etc.
 
+== Default Values
+
+* Search listens on port 9220 by default.
+
 == General Considerations
 
 * To use the search service, an event system needs to be configured for all services like NATS, which is shipped and preconfigured.

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Settings listens on port 9190 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Sharing listens on port 9150 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-publiclink.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-publiclink.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Storage-Publiclink listens on port 9175 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-shares.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-shares.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Storage-Shares listens on port 9154 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Storage-System listens on port 9215 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -11,6 +11,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Storage-Users listens on port 9157 by default.
+
 == Manage Unfinished Uploads
 
 // referencing: [oCIS FS] clean up aborted uploads https://github.com/owncloud/ocis/issues/2622

--- a/modules/ROOT/pages/deployment/services/s-list/store.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/store.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Store listens on port 9460 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/users.adoc
@@ -10,6 +10,10 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Default Values
+
+* Users listens on port 9144 by default.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/web.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/web.adoc
@@ -12,6 +12,10 @@ Note that clients will respond with a connection error if the web service is not
 
 The web service also provides a minimal API for branding functionality like changing the logo shown.
 
+== Default Values
+
+* Web listens on port 9100 by default.
+
 == Custom Compiled Web Assets
 
 If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See https://owncloud.dev/clients/web/getting-started/[ownCloud Web / Getting Started] and https://owncloud.dev/clients/web/backend-ocis/[ownCloud Web / Setup with oCIS] in the developer documentation for more details.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -38,7 +38,7 @@
 **** xref:deployment/services/s-list/idm.adoc[IDM]
 **** xref:deployment/services/s-list/idp.adoc[IDP]
 **** xref:deployment/services/s-list/nats.adoc[NATS]
-**** xref:deployment/services/s-list/notifications.adoc[Notification]
+**** xref:deployment/services/s-list/notifications.adoc[Notifications]
 **** xref:deployment/services/s-list/ocdav.adoc[OCDAV]
 **** xref:deployment/services/s-list/ocs.adoc[OCS]
 **** xref:deployment/services/s-list/policies.adoc[Policies]


### PR DESCRIPTION
Ports were described in some, but not all services.
This PR makes this consistent
Some minor fixes added.