### PR TITLE
Fixed typo

### DIFF
--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -289,7 +289,7 @@ docker exec -it <container-id> sh
 
 You can now use commands like `ocis --help` or others to  xref:deployment/general/general-info.adoc#managing-services[manage your runtime services].
 
-To exit the container's shell, either type kbd:[exit] or kbd:[CTRL+D].
+To exit the container's shell, either type `exit` or kbd:[CTRL+D].
 
 // fixme: after a call with @cdegen, it is currently not clear how to restart a runtime service properly as the service needs a service yaml file (see --config-file) and the question is - where is the location of this file - it cant be inside the container!
 


### PR DESCRIPTION
`exit` was shown as if it was available as key combination on the keyboard. But in fact it has to be typed so the layout should be as any other command.