### PR TITLE
Add the invitations service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
@@ -1,0 +1,73 @@
+= Invitations Service Configuration
+:toc: right
+:description: The Infinite Scale invitations service provides an Invitation Manager that can be used to invite external users, aka guests, to an organization.
+
+:ext_name: invitations
+
+// remember to REMOVE the corresponding tab if a new ocis release will be published
+
+:no_second_tab: true
+:no_third_tab: true
+
+== Introduction
+
+{description} See the https://learn.microsoft.com/en-us/graph/api/invitation-post?view=graph-rest-1.0&tabs=http[Invitation Manager] for more details.
+
+*   Users invited via the Invitation Manager (via the LibreGraph API) will have the `userType="Guest"`.
+*   Users belonging to the organization have the `userType="Member"`.
+
+== Provisioning Backends
+
+When Infinite Scale is used via the IDM service for the user management, users are created using the `/graph/v1.0/users` endpoint via the LibreGraph API. For larger deployments, the Keycloak admin API can be used to provision users. In a future step, the endpoint, credentials and body might be made configurable using templates.
+
+=== Keycloak
+
+The default and currently only available backend used to handle invitations is https://www.keycloak.org/[Keycloak]. Keycloak is an open source identity and access management (IAM) system which is also integrated by other Infinite Scale services as an authentication and authorization backend.
+
+==== Keycloak Realm Configuration
+
+See the https://github.com/owncloud/ocis/blob/master/services/invitations/md-sources/example-realm.json[example configuration json file,window=_blank] of a Keycloak realm the backend will work with. This file includes the `invitations` client, which is relevant for this service.
+
+To use the example json, set the `INVITATIONS_KEYCLOAK_CLIENT_ID` setting to `invitations`, though any other client ID can be configured. 
+
+Importing this example into Keycloak will give you a realm that federates with an LDAP server, has the right
+clients configured and all mappers correctly set. Be sure to set all the credentials after the import,
+as they will be disabled.
+
+The most relevant bits are the mappers for the `OWNCLOUD_ID` and `OWNCLOUD_USER_TYPE` user properties.
+
+== Backend Configuration
+
+After Keycloak has been configured, the invitation service needs to be configured with the following environment variables:
+
+[width=100%,cols="~,~",options=header]
+|===
+| Environment Variable
+| Description
+
+| `INVITATIONS_KEYCLOAK_BASE_PATH`
+| The URL to access Keycloak.
+
+| `INVITATIONS_KEYCLOAK_CLIENT_ID`
+| The client ID of the client to use. In the above example, `invitations` is used.
+
+| `INVITATIONS_KEYCLOAK_CLIENT_SECRET`
+| The client secret used to authenticate. This can be found in the Keycloak UI.
+
+| `INVITATIONS_KEYCLOAK_CLIENT_REALM`
+| The realm where the client was added. In the example above, `ocis` is used.
+
+| `INVITATIONS_KEYCLOAK_USER_REALM`
+| The realm where to add the users. In the example above, `ocis` is used.
+
+| `INVITATIONS_KEYCLOAK_INSECURE_SKIP_VERIFY`
+| If set to true, the verification of the Keycloak HTTPS certificate is skipped. This is not recommended in production environments.
+|===
+
+== Bridging Provisioning Delay
+
+Consider that when a guest account has to be provisioned in an external user management, there might be a delay between creating the user and the user being available in the local Infinite Scale system.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -37,6 +37,7 @@
 **** xref:deployment/services/s-list/graph.adoc[Graph]
 **** xref:deployment/services/s-list/groups.adoc[Groups]
 **** xref:deployment/services/s-list/idm.adoc[IDM]
+**** xref:deployment/services/s-list/invitations.adoc[Invitations]
 **** xref:deployment/services/s-list/idp.adoc[IDP]
 **** xref:deployment/services/s-list/nats.adoc[NATS]
 **** xref:deployment/services/s-list/notifications.adoc[Notifications]


### PR DESCRIPTION
Fixes #425 (Add Invitations Service)

Adds the invitations service.

Content has been copied from the referenced ocis repo PR where it was already reviewed by @EParzefall 