### PR TITLE
Fix tab mismatch and update services

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -23,37 +23,38 @@ asciidoc:
     use_helm_tab_3: true # set to any value if tab 3 should be shown
 
     # service_tab_x will be used to assemble the url accessing the link for the services
-    # note that tab 2 always contains the actual release and tab 3 the former.
+    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1: 'docs' # do not change, the docs branch contains changes of master
     service_tab_2: 'docs-stable-2.0'
     service_tab_3: 'docs-stable-3.0'
 
-    # service_tab_x_tab_text will be used as tab text shown for tab_x
-    # note that we are referring via the 'service_tab_x' branch to the ocis repo, not the master branch!
-    # note that tab 2 always contains the actual release and tab 3 the former.
+    # service_tab_x_tab_text will be used as tab text shown for service_tab_x
+    # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
+    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1_tab_text: 'latest'
     service_tab_2_tab_text: '2.0.0'
-    service_tab_3_tab_text: '1.0.0'
+    service_tab_3_tab_text: '3.0.0'
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
+    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1: 'master'
     compose_tab_2: 'v2.0.0'
     compose_tab_3: 'v3.0.0'
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    # note that tab 2 always contains the actual release and tab 3 the former.
+    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1_tab_text: 'latest'
     compose_tab_2_tab_text: '2.0.0'
-    compose_tab_3_tab_text: '1.0.0'
+    compose_tab_3_tab_text: '3.0.0'
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
-    # note that tab 2 always contains the actual release and tab 3 the former.
+    # note that tab 2 always contains the actual release and tab 3 the former
     helm_tab_1: 'master'
     helm_tab_2: 'v0.2.0'
     helm_tab_3: 'v0.1.0'
 
     # helm_tab_x_tab_text will be used as tab text shown for tab_x
-    # note that tab 2 always contains the actual release and tab 3 the former.
+    # note that tab 2 always contains the actual release and tab 3 the former
     helm_tab_1_tab_text: 'latest'
     helm_tab_2_tab_text: '0.2.0'
     helm_tab_3_tab_text: '0.1.0'

--- a/antora.yml
+++ b/antora.yml
@@ -10,46 +10,64 @@ asciidoc:
     # used to define the include path for services without trailing /
     # note that any changes of this path also need adjustment in
     # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
-    s-path: deployment/services/s-list
-    #
-    # used via orchestration.adoc and in partials/env-and-yaml.adoc for all services
-    # define to use tabs, the first tab is always active
-    use_tab_2: true # set to any value if tab 2 should be shown
-    use_tab_3: true     # set to any value if tab 3 should be shown
+    s-path: 'deployment/services/s-list'
+
+    # used in partials/env-and-yaml.adoc for all services, based on releases
+    # define to use tabs, the first tab is always active (master)
+    use_service_tab_2: true  # set to any value if tab 2 should be shown
+    use_service_tab_3:       # set to any value if tab 3 should be shown
+
+    # used in orchestration.adoc for helm charts
+    # define to use tabs, the first tab is always active (master)
+    use_helm_tab_2: true # set to any value if tab 2 should be shown
+    use_helm_tab_3: true # set to any value if tab 3 should be shown
+
     # service_tab_x will be used to assemble the url accessing the link for the services
-    service_tab_1: docs # do not change, the docs branch contains changes of master
-    service_tab_2: docs-stable-2.0
-    service_tab_3: tab_3
+    # note that tab 2 always contains the actual release and tab 3 the former.
+    service_tab_1: 'docs' # do not change, the docs branch contains changes of master
+    service_tab_2: 'docs-stable-2.0'
+    service_tab_3: 'docs-stable-3.0'
+
     # service_tab_x_tab_text will be used as tab text shown for tab_x
     # note that we are referring via the 'service_tab_x' branch to the ocis repo, not the master branch!
-    service_tab_1_tab_text: latest
-    service_tab_2_tab_text: 2.0.0
-    service_tab_3_tab_text: 2.1.0
+    # note that tab 2 always contains the actual release and tab 3 the former.
+    service_tab_1_tab_text: 'latest'
+    service_tab_2_tab_text: '2.0.0'
+    service_tab_3_tab_text: '1.0.0'
+
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_tab_1: master
-    compose_tab_2: v2.0.0
-    compose_tab_3: tab_3
+    compose_tab_1: 'master'
+    compose_tab_2: 'v2.0.0'
+    compose_tab_3: 'v3.0.0'
+
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    compose_tab_1_tab_text: latest
-    compose_tab_2_tab_text: 2.0.0
-    compose_tab_3_tab_text: 2.1.0
+    # note that tab 2 always contains the actual release and tab 3 the former.
+    compose_tab_1_tab_text: 'latest'
+    compose_tab_2_tab_text: '2.0.0'
+    compose_tab_3_tab_text: '1.0.0'
+
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
-    helm_tab_1: master
-    helm_tab_2: v0.2.0
-    helm_tab_3: v0.1.0
+    # note that tab 2 always contains the actual release and tab 3 the former.
+    helm_tab_1: 'master'
+    helm_tab_2: 'v0.2.0'
+    helm_tab_3: 'v0.1.0'
+
     # helm_tab_x_tab_text will be used as tab text shown for tab_x
-    helm_tab_1_tab_text: latest
-    helm_tab_2_tab_text: 0.2.0
-    helm_tab_3_tab_text: 0.1.0
+    # note that tab 2 always contains the actual release and tab 3 the former.
+    helm_tab_1_tab_text: 'latest'
+    helm_tab_2_tab_text: '0.2.0'
+    helm_tab_3_tab_text: '0.1.0'
+
     # set attributes defining path components which will be assembled in the document
-    secrets: deployment/container/orchestration/orchestration.adoc#define-secrets
-    ocis-charts-raw-url: https://raw.githubusercontent.com/owncloud/ocis-charts/
-    kube-versions-url: /charts/ocis/docs/kube-versions.adoc
-    values-versions-url: /charts/ocis/docs/values.adoc.yaml
-    values-desc-versions-url: /charts/ocis/docs/values-desc-table.adoc
-    composer-url: https://github.com/owncloud/ocis/tree/
-    composer-raw-url: https://raw.githubusercontent.com/owncloud/ocis/
-    composer-final-path: /deployments/examples
+    secrets: 'deployment/container/orchestration/orchestration.adoc#define-secrets'
+    ocis-charts-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis-charts/'
+    kube-versions-url: '/charts/ocis/docs/kube-versions.adoc'
+    values-versions-url: '/charts/ocis/docs/values.adoc.yaml'
+    values-desc-versions-url: '/charts/ocis/docs/values-desc-table.adoc'
+    composer-url: 'https://github.com/owncloud/ocis/tree/'
+    composer-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis/'
+    composer-final-path: '/deployments/examples'
+
     # used in deployment/services via partials/env-and-yaml.adoc
     ocis-services-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis/'
     ocis-services-final-path: '/services/_includes/'

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -96,7 +96,7 @@ When done, create a project directory like `ocis-compose` in your home directory
 
 Using git version name: `{compose_tab_1}`
 --
-ifdef::use_tab_2[]
+ifdef::use_service_tab_2[]
 {compose_tab_2_tab_text}::
 +
 --
@@ -105,7 +105,7 @@ ifdef::use_tab_2[]
 Using git version name: `{compose_tab_2}`
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_servicetab_3[]
 {compose_tab_3_tab_text}::
 +
 --
@@ -229,12 +229,12 @@ See the following table to match the Helm chart versions with Infinite Scale rel
 | {helm_tab_1_tab_text}
 | 3.0.0-alpha.1
 
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 | {helm_tab_2_tab_text}
 | 3.0.0-alpha
 endif::[]
 
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 | {helm_tab_3_tab_text}
 | 2.0.0
 endif::[]
@@ -251,7 +251,7 @@ Breaking changes are only published for Helm Chart versions that have been relea
 
 [tabs]
 ====
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -259,7 +259,7 @@ xref:deployment/container/orchestration/tab-pages/breaking-changes.adoc#{helm_ta
 --
 endif::[]
 
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -288,14 +288,14 @@ As the Helm chart has currently not been published to a Helm repository, you nee
 --
 include::{ocis-charts-raw-url}{helm_tab_1}{kube-versions-url}[]
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
 include::{ocis-charts-raw-url}{helm_tab_2}{kube-versions-url}[]
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -353,7 +353,7 @@ helm install ocis ./charts/ocis
 | {t2_text}
 |===
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -370,7 +370,7 @@ ifdef::use_tab_2[]
 |===
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -409,7 +409,7 @@ In all examples, adapt the settings according your needs.
 include::example$deployment/container/orchestration/values-overwrite-tab-1.yaml[]
 ----
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -419,7 +419,7 @@ include::example$deployment/container/orchestration/values-overwrite-tab-2.yaml[
 ----
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -447,7 +447,7 @@ endif::[]
 include::example$deployment/container/orchestration/service-monitor-tab-1.yaml[]
 ----
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -457,7 +457,7 @@ include::example$deployment/container/orchestration/service-monitor-tab-2.yaml[]
 ----
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -485,7 +485,7 @@ endif::[]
 include::example$deployment/container/orchestration/email-notification-tab-1.yaml[]
 ----
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -495,7 +495,7 @@ include::example$deployment/container/orchestration/email-notification-tab-2.yam
 ----
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -537,7 +537,7 @@ For these reasons, ownCloud cannot take responsibility for these generic secrets
 | {t_text}
 |===
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -551,7 +551,7 @@ ifdef::use_tab_2[]
 |===
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -606,7 +606,7 @@ For these reasons, ownCloud cannot take responsibility for these generic configu
 | {t_text}
 |===
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -620,7 +620,7 @@ ifdef::use_tab_2[]
 |===
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -675,7 +675,7 @@ As the operator of Helm Charts, you are responsible for these user management se
 | {t_text}
 |===
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -689,7 +689,7 @@ ifdef::use_tab_2[]
 |===
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -744,7 +744,7 @@ If you're using Helm Charts, you are responsible for these user management secre
 | {t_text}
 |===
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -758,7 +758,7 @@ ifdef::use_tab_2[]
 |===
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
@@ -805,7 +805,7 @@ This is an example with NGINX ingress and certificates issued by cert-manager. T
 include::example$deployment/container/orchestration/nginx-ingress-tab-1.yaml[]
 ----
 --
-ifdef::use_tab_2[]
+ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
@@ -815,7 +815,7 @@ include::example$deployment/container/orchestration/nginx-ingress-tab-2.yaml[]
 ----
 --
 endif::[]
-ifdef::use_tab_3[]
+ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -30,7 +30,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 | Store Type
 | Description
 
-| `mem`
+| `memory`
 | Basic in-memory store and the default.
 
 | `ocmem`
@@ -38,6 +38,9 @@ The `eventhistory` service stores each consumed event via the configured store i
 
 | `Redis`
 | Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured redis sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.
@@ -53,6 +56,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
 3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
 4. The `eventhistory` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
+5.  When using `redis-sentinel`, the Redis master to use is configured via `EVENTHISTORY_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -40,7 +40,7 @@ The `eventhistory` service stores each consumed event via the configured store i
 | Stores data in a configured Redis cluster.
 
 | `redis-sentinel`
-| Stores data in a configured redis sentinel cluster.
+| Stores data in a configured Redis Sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -14,6 +14,29 @@
 
 * Gateway listens on port 9142 by default.
 
+== Caching
+
+The `gateway` service can use a configured store via `GATEWAY_CACHE_STORE`. Possible stores are:
+
+[width=100%,cols="15%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+|===
+
+1. Note that in-memory stores are by nature not reboot persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3. The `gateway` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -26,6 +26,42 @@ The following image gives an overview of the scenario when a client requests to 
 
 image::deployment/services/graph/mermaid-graph.svg[width=600]
 
+== Caching
+
+The `graph` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
+
+[width=100%,cols="15%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured redis sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in productive environments.
+|===
+
+1. Note that in-memory stores are by nature not reboot persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3. The `graph` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `GRAPH_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -45,7 +45,7 @@ The `graph` service can use a configured store via `GRAPH_STORE_TYPE`. Possible 
 | Stores data in a configured Redis cluster.
 
 | `redis-sentinel`
-| Stores data in a configured redis sentinel cluster.
+| Stores data in a configured Redis Sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.
@@ -54,7 +54,7 @@ The `graph` service can use a configured store via `GRAPH_STORE_TYPE`. Possible 
 | Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
 
 | `noop`
-| Stores nothing. Useful for testing. Not recommended in productive environments.
+| Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
 1. Note that in-memory stores are by nature not reboot persistent.

--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -33,7 +33,7 @@ The `ocs` service can use a configured store via `GRAPH_STORE_TYPE`. Possible st
 | Stores data in a configured Redis cluster.
 
 | `redis-sentinel`
-| Stores data in a configured redis sentinel cluster.
+| Stores data in a configured Redis Sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.

--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -14,6 +14,42 @@
 
 * OCS listens on port 9110 by default.
 
+== Caching
+
+The `ocs` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
+
+[width=100%,cols="15%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured redis sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in productive environments.
+|===
+
+1. Note that in-memory stores are by nature not reboot persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3. The `ocs` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `OCS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -107,7 +107,7 @@ The `proxy` service can use a configured store via `GRAPH_STORE_TYPE`. Possible 
 | Stores data in a configured Redis cluster.
 
 | `redis-sentinel`
-| Stores data in a configured redis sentinel cluster.
+| Stores data in a configured Redis Sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -88,6 +88,42 @@ guest: ocisGuest
 
 * In a production deployment, you want to have basic authentication (`PROXY_ENABLE_BASIC_AUTH`) _disabled_ which is the default state. You should also set up a firewall to only allow requests to the proxy service or the reverse proxy if you have one. Requests to the other services should be blocked by the firewall.
 
+== Caching
+
+The `proxy` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
+
+[width=100%,cols="15%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured redis sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in productive environments.
+|===
+
+1. Note that in-memory stores are by nature not reboot persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3. The `proxy` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `PROXY_OIDC_USERINFO_CACHE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -38,7 +38,7 @@ The `userlog` service persists information via the configured store in `USERLOG_
 | Stores data in a configured Redis cluster.
 
 | `redis-sentinel`
-| Stores data in a configured redis sentinel cluster.
+| Stores data in a configured Redis Sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -28,7 +28,7 @@ The `userlog` service persists information via the configured store in `USERLOG_
 | Store Type
 | Description
 
-| `mem`
+| `memory`
 | Basic in-memory store and the default.
 
 | `ocmem`
@@ -36,6 +36,9 @@ The `userlog` service persists information via the configured store in `USERLOG_
 
 | `redis`
 | Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured redis sentinel cluster.
 
 | `etcd`
 | Stores data in a configured etcd cluster.
@@ -50,6 +53,7 @@ The `userlog` service persists information via the configured store in `USERLOG_
 1. Note that in-memory stores are by nature not reboot persistent.
 2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
 3. The `userlog` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `USERLOG_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuring Events
 

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -1,32 +1,78 @@
-// the attribute ext_name (mandatory) and no_yaml (not mandatory) will be handed over by the calling page.
-// if no_yaml is set, it will exclude rendering yaml files because it does not exist.
+////
+The attribute 'ext_name' (mandatory) and 'no_yaml' (not mandatory) will be handed over by the calling page.
+If no_yaml is set, it will exclude rendering yaml files because it does not exist.
 
-// print a dependent explanation line
-// no_yaml is not set = standard extension,
-// no_yaml is set = special scope envvars
+Print a dependent explanation line:
 
-// the included deprecation file just has an attribute necessary for rendering deprecations
-// this is necessary as attributes that are defined INSIDE a tabset will not get recognized,
-// attributes need to be defined OUTSIDE the tabset definition. example content:
-// :show-deprecation: true
-// the file contains the attribute too to be easy used outside of tabsets.
+* no_yaml is not set = standard service
+* no_yaml is set = special scope envvars
 
-// exclude a deprecation file if not wanted - like when the file will just not exist
-// manually unset the attribute if required via ':!no_deprecation:'
+Conditional tab printing, example:
 
+* no_second_tab = based on first appearance of the service
+  defined via the service, must overrule service tab. If there is no second, there is also no third
+* use_service_tab_2 = release based (defined in antora.yaml)
+
+The included deprecation file just has an attribute necessary for rendering deprecations.
+This is necessary as attributes that are defined INSIDE a tabset will not get recognized, attributes need to be defined OUTSIDE the tabset definition. example content:
+
+:show-deprecation: true
+
+The file contains the attribute too to be used outside of tabsets.
+
+To exclude a deprecation file if not wanted - like when the file will just not exist, manually unset the attribute if required via:
+
+* :!no_deprecation:
+////
+
+// preset all tab specific deprecations to false
+:show_deprecation_tab_1: false
+:show_deprecation_tab_2: false
+:show_deprecation_tab_3: false
+
+// check to evaluate deprecations and set an attribute per tab
 ifndef::no_deprecation[]
+
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+ifeval::["{show-deprecation}" == "true"]
+:show_deprecation_tab_1: true
 endif::[]
+
+////
+ifndef::no_second_tab[]
+ifdef::use_service_tab_2[]
+include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+ifeval::["{show-deprecation}" == "true"]
+:show_deprecation_tab_2: true
+endif::[]
+endif::use_service_tab_2[]
+
+ifndef::no_third_tab[]
+ifdef::use_service_tab_3[]
+include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+ifeval::["{show-deprecation}" == "true"]
+:show_deprecation_tab_3: true
+endif::[]
+endif::use_service_tab_3[]
+endif::no_third_tab[]
+endif::no_second_tab[]
+////
+
+endif::no_deprecation[]
+
+// conditionally render the variable entry text, either with or without section header
 
 ifndef::no_yaml[]
 === Environment Variables
 
 The `{ext_name}` service is configured via the following environment variables:
-endif::[]
+endif::no_yaml[]
 
 ifdef::no_yaml[]
 The `{ext_name}` variables are defined in the following way:
-endif::[]
+endif::no_yaml[]
+
+// create the tabs
 
 [tabs]
 ====
@@ -35,28 +81,24 @@ endif::[]
 --
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
 --
-// disable printing the second tab if not allowed (eg. if service is fresh created)
-// set this if required in the calling page!
 ifndef::no_second_tab[]
-ifdef::use_tab_2[]
+ifdef::use_service_tab_2[]
 {service_tab_2_tab_text}::
 +
 --
 include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
 --
-endif::[]
-// disable printing the third tab if not allowed (eg. if service is fresh created)
-// set this if required in the calling page!
+endif::use_service_tab_2[]
 ifndef::no_third_tab[]
-ifdef::use_tab_3[]
+ifdef::use_service_tab_3[]
 {service_tab_3_tab_text}::
 +
 --
 include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
 --
-endif::[]
-endif::[]
-endif::[]
+endif::use_service_tab_3[]
+endif::no_third_tab[]
+endif::no_second_tab[]
 ====
 
 ifndef::no_yaml[]
@@ -76,10 +118,8 @@ See the xref:deployment/general/general-info.adoc#configuration-file-naming[Conf
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}{ext_name}-config-example.yaml[]
 ----
 --
-// disable printing the second tab if not allowed (eg. if service is fresh created)
-// set this if required in the calling page!
 ifndef::no_second_tab[]
-ifdef::use_tab_2[]
+ifdef::use_service_tab_2[]
 {service_tab_2_tab_text}::
 +
 --
@@ -88,11 +128,9 @@ ifdef::use_tab_2[]
 include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}{ext_name}-config-example.yaml[]
 ----
 --
-endif::[]
-// disable printing the third tab if not allowed (eg. if service is fresh created)
-// set this if required in the calling page!
+endif::use_service_tab_2[]
 ifndef::no_third_tab[]
-ifdef::use_tab_3[]
+ifdef::use_service_tab_3[]
 {service_tab_3_tab_text}::
 +
 --
@@ -101,9 +139,9 @@ ifdef::use_tab_3[]
 include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}{ext_name}-config-example.yaml[]
 ----
 --
-endif::[]
-endif::[]
-endif::[]
+endif::use_service_tab_3[]
+endif::no_third_tab[]
+endif::no_second_tab[]
 ====
 
-endif::[]
+endif::no_yaml[]


### PR DESCRIPTION
Fixes: #431 (The proxy service description needs an update because of caching)

Though I wanted to have that PR split into two, it accidentially happend to be one, my bad.

* There was a a tab mismatch introduced by
 #434
Tabs in orchestration appeared where they shouldnt because the same attribute was used for both helm and services/compose. This is now fixed and tab appearance is based on different and independent attributes
* To make this more clear, I cleand up the `antora.yaml` file
I also prepared for ocis 3.0, but those tabs are not shown!
* Then I reviewed the envvar and yaml generating file. This is a first step but needs more work
* Finally, all services referenced via #431 are now updated accordingly