### PR TITLE
Update supported oCIS versions for helm charts

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -227,11 +227,11 @@ See the following table to match the Helm chart versions with Infinite Scale rel
 | Works with Infinite Scale Versions
 
 | {helm_tab_1_tab_text}
-| 3.0.0-alpha.1
+| 3.0.0-alpha.2
 
 ifdef::use_helm_tab_2[]
 | {helm_tab_2_tab_text}
-| 3.0.0-alpha
+| 3.0.0-alpha.1
 endif::[]
 
 ifdef::use_helm_tab_3[]


### PR DESCRIPTION
With https://github.com/owncloud/ocis-charts/pull/181 we also bump the version the oCIS chart will use by default. Thus the documentation has to be adjusted as well.