### PR TITLE
New metadata backend

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -7,7 +7,6 @@
 :systemd-url: https://systemd.io/
 :nginx-url: https://www.nginx.com/
 :apache-url: https://www.apache.org
-:xattr-url: https://en.wikipedia.org/wiki/Extended_file_attributes
 :certbot-url: https://certbot.eff.org
 :certbot-options-url: https://eff-certbot.readthedocs.io/en/stable/using.html#id36
 :ssl-labs-url: https://www.ssllabs.com/ssltest/

--- a/modules/ROOT/pages/maintenance/b-r/backup.adoc
+++ b/modules/ROOT/pages/maintenance/b-r/backup.adoc
@@ -36,7 +36,7 @@ Keep in mind that you always have to back up all data sets consistently:
 
 {empty}
 
-(2) ... For POSIX-only environments, the location for blobs and metadata is the same. When using S3, the location differs. Note when using the `extended attributes` (xattr) backend for metadata, see xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage], the backup process must include these attributes
+(2) ... For POSIX-only environments, the location for blobs and metadata is the same. When using S3, the location differs. The backup process must include the metadata, for details see xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage].
 
 As a rule of thumb, consider also to back up the Infinite Scale binary or the container used. This avoids difficulties when restoring the instance and possibly using an updated Infinite Scale version compared to the version used when backing up. Restoring and updating should always be different tasks.
 

--- a/modules/ROOT/pages/maintenance/b-r/restore.adoc
+++ b/modules/ROOT/pages/maintenance/b-r/restore.adoc
@@ -28,7 +28,7 @@ When it comes to restoring data, keep in mind that you always have to restore al
 
 {empty}
 
-(2) ... For POSIX-only environments, the location for blobs and metadata is the same. When using S3, the location differs. Note when using the `extended attributes` (xattr) backend for metadata, see xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage], the restore process must include these attributes.
+(2) ... For POSIX-only environments, the location for blobs and metadata is the same. When using S3, the location differs. The restore process must include the metadata, for details see xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage].
 
 Valid for all restore procedures:
 

--- a/modules/ROOT/pages/prerequisites/prerequisites.adoc
+++ b/modules/ROOT/pages/prerequisites/prerequisites.adoc
@@ -267,22 +267,31 @@ ____
 {what_is_apache_url}[Apache] In addition to being a "basic" web server and providing static and dynamic content to end-users, Apache httpd (as well as most other web servers) can also act as a reverse proxy server, also-known-as a "gateway" server.
 ____
 
-// fixme: describe the reason for the need
-// fixme: links to how to setup these things, maybe external links will work well too
-
 == Filesystems and Shared Storage
 
-Infinite Scale currently supports two different internal filesystem drivers which are `ocisfs` and `s3ng`.
+Infinite Scale defines drivers for filesystems to store blobs and metadata. The drivers can be configured via the xref:{s-path}/storage-users.adoc[Storage-Users Service Configuration].
 
-* When the `ocisfs` driver is used, data and metadata must be on a POSIX-compliant filesystem. This driver decomposes the metadata and persists it in a POSIX filesystem. Blobs are stored on the filesystem as well. The layout makes extensive use of symlinks and extended attributes. A filesystem like xfs or zfs without practical inode size limitations is recommended. A further integration with file systems like CephFS or GPFS is under investigation.
+=== Backend for Metadata
+
+With regards to metadata and independent of the filesystem driver used, the way how metadata is stored can be configured as .ini files (`ini`) or extended attributes (`xattrs`) which requires a filesystem supporting it. The `ini` backend is introduced with Infinite Scale 3.0 and is the default since then. Pre 3.0 installations will need to convert the `xattrs` backend to `ini` if required.
+
+When using the `xattrs` backend and when listing the extended attributes of an object, the available space is currently limited to 64kB. Assuming a 20 byte uuid, a grant has ~40 bytes, which would limit the number of attributes to ~1630 entries or ~1600 shares per extended attribute.
+
+=== Available Filesystem Drivers
+
+The oics filesystem driver::
+When the `ocis` driver is used, blobs and metadata must be on a POSIX-compliant filesystem. This driver decomposes the metadata and persists it in a POSIX filesystem. Blobs are stored on the filesystem as well. This layout makes extensive use of symlinks. A filesystem like xfs or zfs without practical inode size limitations is recommended. A further integration with file systems like CephFS or GPFS is under investigation.
 +
 NOTE: Ext4 limits the number of bytes that can be used for extended attribute names and their values to the size of a single block (by default 4k). This reduces the number of shares for a single file or folder to roughly 20-30, as grants have to share the available space with other metadata.
 
-* When the `s3ng` driver is used, data resides on a S3 bucket and the metadata will be stored on a POSIX-compliant filesystem which needs to be extra provisioned. As this POSIX-compliant filesystem usually needs to be mounted on several oCIS instances like when deploying with a xref:deployment/container/orchestration/orchestration.adoc[container orchestration], consider using NFSv4 for storing this metadata. This is necessary for performance reasons. When listing extended attributes of an object, the result is currently limited to 64kB. Assuming a 20 byte uuid, a grant has ~40 bytes, which would limit the number of extended attributes to ~1630 entries or ~1600 shares. With further development, this limitation may be removed.
+The s3ng filesystem driver::
+When the `s3ng` driver is used, blobs reside on a S3 bucket and the metadata will be stored on a POSIX-compliant filesystem which needs to be extra provisioned. As this POSIX-compliant filesystem usually needs to be mounted on several oCIS instances like when deploying with a xref:deployment/container/orchestration/orchestration.adoc[container orchestration], consider using NFS for storing this metadata. This splitting is necessary for performance reasons.
 
 Other drivers can be used too like for the Ceph or EOS filesystem, but no support can be given because they are not developed or maintained by ownCloud. 
 
-The currently supported Infinite Scale POSIX-compliant file systems are the following. Note that the default block size impacts the calculation example at xref:sample_environments[RAM Considerations], which is definable on some filesystems and if applicable, is for informational purposes only:
+=== Supported POSIX-compliant Filesystems
+
+The supported Infinite Scale POSIX-compliant filesystems are the following. Note that the default block size impacts the calculation example at xref:sample_environments[RAM Considerations], which is definable on some filesystems and if applicable, is for informational purposes only:
 
 [caption=]
 .Local Filesystems
@@ -315,9 +324,9 @@ The currently supported Infinite Scale POSIX-compliant file systems are the foll
 | The block size depends on the `rsize` parameter in the mount options. Defaults to 4K, usually set to 32K.
 |===
 
-Note the support for a Windows compatible filesystem like Samba will be available in a later release and separately announced.
-
-All POSIX-compliant supported filesystems, local or remote, must support extended attributes. You can check this with the following commands, change to a location in the mounted filesystem you want to check before:
+Check if extended attributes are supported if selected as metadata backend::
+--
+When selecting the `xattrs` backend for storing metadata, the used POSIX-compliant filesystem from the tables above must support it. You can check this with the following commands, change to a location in the mounted filesystem you want to check before:
 
 [source,bash]
 ----
@@ -345,13 +354,14 @@ bar
 ----
 rm foo.txt
 ----
+--
 
 [[nfs_notes_prerequisites]]
 NFS Notes::
 +
 [NOTE]
 ====
-When using NFS, you have to take care that the NFS server *AND* the NFS client provides `Extended Attributes`.
+When using NFS and the `xattrs` backend, you have to take care that the NFS server *AND* the NFS client provides `Extended Attributes`.
 
 NFS Storage Based on Linux Servers::
 When using a kernel version 5.9 or higher, extended attributes for the NFS server and the NFS client are part of the system. To check, run the command:

--- a/modules/ROOT/pages/prerequisites/prerequisites.adoc
+++ b/modules/ROOT/pages/prerequisites/prerequisites.adoc
@@ -281,13 +281,13 @@ If you have started to use Infinite Scale before version 3.0, metadata was store
 
 === Available Filesystem Drivers
 
-The oics filesystem driver::
+The ocis filesystem driver::
 When the `ocis` driver is used, blobs and metadata must be on a POSIX-compliant filesystem. This driver decomposes the metadata and persists it in a POSIX filesystem. Blobs are stored on the filesystem as well. This layout makes extensive use of symlinks. A filesystem like xfs or zfs without practical inode size limitations is recommended. A further integration with file systems like CephFS or GPFS is under investigation.
 +
 NOTE: Ext4 limits the number of bytes that can be used for extended attribute names and their values to the size of a single block (by default 4k). This reduces the number of shares for a single file or folder to roughly 20-30, as grants have to share the available space with other metadata.
 
 The s3ng filesystem driver::
-When the `s3ng` driver is used, blobs reside on a S3 bucket and the metadata will be stored on a POSIX-compliant filesystem which needs to be extra provisioned. As this POSIX-compliant filesystem usually needs to be mounted on several oCIS instances like when deploying with a xref:deployment/container/orchestration/orchestration.adoc[container orchestration], consider using NFS for storing this metadata. This splitting is necessary for performance reasons.
+When the `s3ng` driver is used, blobs reside on a S3 bucket and the metadata will be stored on a POSIX-compliant filesystem which needs to be provisioned. As this POSIX-compliant filesystem usually needs to be mounted on several Infinite Scale instances like when deploying with a xref:deployment/container/orchestration/orchestration.adoc[container orchestration], consider using NFS for storing this metadata. This splitting is necessary for performance reasons.
 
 Other drivers can be used too like for the Ceph or EOS filesystem, but no support can be given because they are not developed or maintained by ownCloud. 
 

--- a/modules/ROOT/pages/prerequisites/prerequisites.adoc
+++ b/modules/ROOT/pages/prerequisites/prerequisites.adoc
@@ -20,6 +20,8 @@
 :apache_rev_url: https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html
 :what_is_apache_url: https://www.apache.org/
 
+:messagepack: https://msgpack.org/index.html
+
 == Introduction
 
 {description}
@@ -273,9 +275,9 @@ Infinite Scale defines drivers for filesystems to store blobs and metadata. The 
 
 === Backend for Metadata
 
-With regards to metadata and independent of the filesystem driver used, the way how metadata is stored can be configured as .ini files (`ini`) or extended attributes (`xattrs`) which requires a filesystem supporting it. The `ini` backend is introduced with Infinite Scale 3.0 and is the default since then. Pre 3.0 installations will need to convert the `xattrs` backend to `ini` if required.
+Starting with Infinte Scale 3.0, metadata is stored as {messagepack}[messagepack] files. Messagepack files have as filetype `.mpk`, contain compressed JSON data, are compact and fast. There is also no limit in metadata stored for one mpk file which makes using messagepack futureproof. Using messagepack allows the use of standard filesystems, see the supported list below.
 
-When using the `xattrs` backend and when listing the extended attributes of an object, the available space is currently limited to 64kB. Assuming a 20 byte uuid, a grant has ~40 bytes, which would limit the number of attributes to ~1630 entries or ~1600 shares per extended attribute.
+If you have started to use Infinite Scale before version 3.0, metadata was stored in extended attributes (`xattrs`) and is converted with the upgrade automatically.
 
 === Available Filesystem Drivers
 
@@ -324,70 +326,13 @@ The supported Infinite Scale POSIX-compliant filesystems are the following. Note
 | The block size depends on the `rsize` parameter in the mount options. Defaults to 4K, usually set to 32K.
 |===
 
-Check if extended attributes are supported if selected as metadata backend::
---
-When selecting the `xattrs` backend for storing metadata, the used POSIX-compliant filesystem from the tables above must support it. You can check this with the following commands, change to a location in the mounted filesystem you want to check before:
-
-[source,bash]
-----
-touch foo.txt && attr -s mix -V bar foo.txt
-----
-
-[source,plaintext]
-----
-Attribute "mix" set to a 3 byte value for foo.txt:
-bar
-----
-
-[source,bash]
-----
-attr -g mix foo.txt
-----
-
-[source,plaintext]
-----
-Attribute "mix" had a 3 byte value for foo.txt:
-bar
-----
-
-[source,bash]
-----
-rm foo.txt
-----
---
-
-[[nfs_notes_prerequisites]]
-NFS Notes::
+Extended Attributes::
 +
-[NOTE]
+[IMPORTANT]
 ====
-When using NFS and the `xattrs` backend, you have to take care that the NFS server *AND* the NFS client provides `Extended Attributes`.
+Only when using Infinite Scale _before_ version 3.0.
 
-NFS Storage Based on Linux Servers::
-When using a kernel version 5.9 or higher, extended attributes for the NFS server and the NFS client are part of the system. To check, run the command:
-+
-[source,bash]
-----
-uname -r
-----
-+
-On the system providing the NFS server AND on the NFS client check the displayed version number.
-
-NFS Client::
-If you have an NFS server capable of extended attributes but you are unsure if your client accessing the server supports it, check the *nfs-utils* or *nfs-common* package version of your NFS client with the command:
-+
-[source,bash]
-----
-mount.nfs -V
-----
-+
-You need at minimum NFS version 2.6.1. For more details see the general {nfs-utils-url}[NFS Utils Release History] and the {ubuntu-nfs-url}[Ubuntu nfs-common Packages].
-
-NFS Servers Provided from Storage Vendors::
-A certification matrix will be provided when available.
-
-NFS Protocol Version::
-Note that if the kernel or the storage system supports extended attributes, you have to use *NFSv4* in order to use it.
+* See the documentation and notes about xref:prerequisites/xattrs.adoc[Extended Attributes] for metadata.  
 ====
 
 Ceph Notes::

--- a/modules/ROOT/pages/prerequisites/xattrs.adoc
+++ b/modules/ROOT/pages/prerequisites/xattrs.adoc
@@ -1,0 +1,75 @@
+= Extended Attributes (xattr)
+:toc: right
+:noindex:
+
+== Introduction
+
+IMPORTANT: This document is only valid when using Infinite Scale version 2.0. Starting with version 3.0, Infinite Scale has switched to the messagepack backend for metadata.
+
+== Check xattr Support
+
+Check if extended attributes are supported if selected as metadata backend::
+--
+When selecting the `xattrs` backend for storing metadata, the used POSIX-compliant filesystem from the tables above must support it. You can check this with the following commands, change to a location in the mounted filesystem you want to check before:
+
+[source,bash]
+----
+touch foo.txt && attr -s mix -V bar foo.txt
+----
+
+[source,plaintext]
+----
+Attribute "mix" set to a 3 byte value for foo.txt:
+bar
+----
+
+[source,bash]
+----
+attr -g mix foo.txt
+----
+
+[source,plaintext]
+----
+Attribute "mix" had a 3 byte value for foo.txt:
+bar
+----
+
+[source,bash]
+----
+rm foo.txt
+----
+--
+
+[[nfs_notes_prerequisites]]
+NFS Notes::
++
+[NOTE]
+====
+When using NFS and the `xattrs` backend, you have to take care that the NFS server *AND* the NFS client provides `Extended Attributes`.
+
+NFS Storage Based on Linux Servers::
+When using a kernel version 5.9 or higher, extended attributes for the NFS server and the NFS client are part of the system. To check, run the command:
++
+[source,bash]
+----
+uname -r
+----
++
+On the system providing the NFS server AND on the NFS client check the displayed version number.
+
+NFS Client::
+If you have an NFS server capable of extended attributes but you are unsure if your client accessing the server supports it, check the *nfs-utils* or *nfs-common* package version of your NFS client with the command:
++
+[source,bash]
+----
+mount.nfs -V
+----
++
+You need at minimum NFS version 2.6.1. For more details see the general {nfs-utils-url}[NFS Utils Release History] and the {ubuntu-nfs-url}[Ubuntu nfs-common Packages].
+
+NFS Servers Provided from Storage Vendors::
+A certification matrix will be provided when available.
+
+NFS Protocol Version::
+Note that if the kernel or the storage system supports extended attributes, you have to use *NFSv4* in order to use it.
+====


### PR DESCRIPTION
Fixes #415 (Add messagepack metadata backend)

This PR moves from the xattr to the messagepack backend.

The xattr description has been moved to its own page (with noindex) and got an Important note + link in prerequisites. This allows an easy removal of content when we have a post 3.0 release.

All locations where xattr were present are fixed.