### PR TITLE
Update the IDM limitations with regards to an LDAP server

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -26,7 +26,7 @@ Note that this guide expects that prerequisite of a computer with an installed L
 
 This guide was tested on a Debian 11 (bullseye) host but should work on any other modern Linux system with systemd.
 
-NOTE: The embedded IDM service provides a minimal LDAP Service for Infinite Scale and does not replace a LDAP server. See the xref:{s-path}/idm.adoc[IDM Service Configuration] for details.
+NOTE: The embedded IDM service provides a minimal LDAP service for Infinite Scale and does not replace a LDAP server. See the xref:{s-path}/idm.adoc[IDM Service Configuration] for details.
 
 == Requirements
 

--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -26,6 +26,8 @@ Note that this guide expects that prerequisite of a computer with an installed L
 
 This guide was tested on a Debian 11 (bullseye) host but should work on any other modern Linux system with systemd.
 
+NOTE: The embedded IDM service provides a minimal LDAP Service for Infinite Scale and does not replace a LDAP server. See the xref:{s-path}/idm.adoc[IDM Service Configuration] for details.
+
 == Requirements
 
 * A supported filesystem according the xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[ocis prerequisites,window=_blank].

--- a/modules/ROOT/pages/deployment/services/s-list/idm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idm.adoc
@@ -16,7 +16,7 @@
 
 [NOTE]
 ====
-The IDM service is per design limited in its functionality:
+The IDM service is by design limited in its functionality:
 
 * IDM only supports a subset of the LDAP operations +
 namely `BIND`, `SEARCH`, `ADD`, `MODIFY` and `DELETE`.

--- a/modules/ROOT/pages/deployment/services/s-list/idm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idm.adoc
@@ -16,13 +16,17 @@
 
 [NOTE]
 ====
-The IDM service is limited in its functionality:
+The IDM service is per design limited in its functionality:
 
 * IDM only supports a subset of the LDAP operations +
 namely `BIND`, `SEARCH`, `ADD`, `MODIFY` and `DELETE`.
 * IDM currently does not do any LDAP schema verification like +
-`structural vs. auxiliary object classes`, `require and option attributes`, `syntax checks`, …
-* Therefore the IDM service is not meant to replace a general purpose LDAP server.
+`structural vs. auxiliary object classes`, +
+`require and option attributes`, +
+`syntax checks`, …
+* IDM currently does not support features like 2FA and device management.
+
+Therefore the IDM service is **not** meant to replace a general purpose LDAP server.
 ====
 
 == Default Values


### PR DESCRIPTION
Fixes: #445 (More precision of the IDM limits)

References: https://github.com/owncloud/ocis/issues/5961 (2-Factor Authentication 2FA)

* The limitations of the IDM service compared to an LDAP server needs more details like that no 2FA or device management is possible.
* Added a link in the bare metal deployment document to the IDM service 