### PR TITLE
Update the proxy service for multiple matching roles

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -82,8 +82,8 @@ to the user. So if e.g. a user's `ocisRoles` claim has the values `myUserRole` a
 `mySpaceAdminRole` that user will get the ocis role `spaceadmin` assigned (because `spaceadmin`
 appears before `user` in the above sample configuration).
 
-If a user's claim values don't match any of the configured role mappings an error will be logged and
-the user will not be able to login.
+If a user's claim values don't match any of the configured role mappings, an error will be logged and
+the user will not be able to log in.
 ====
 
 The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The default `role_mapping` is:

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -57,10 +57,14 @@ role_assignment:
     oidc_role_mapper:
         role_claim: ocisRoles
         role_mapping:
-            admin: myAdminRole
-            user: myUserRole
-            spaceadmin: mySpaceAdminRole
-            guest: myGuestRole
+            - role_name: admin
+              claim_value: myAdminRole
+            - role_name: spaceadmin
+              claim_value: mySpaceAdminRole
+            - role_name: user
+              claim_value: myUserRole
+            - role_name: guest:
+              claim_value: myGuestRole
 ----
 
 This would assign the role `admin` to users with the value `myAdminRole` in the claim `ocisRoles`.
@@ -68,18 +72,32 @@ The role `user` to users with the values `myUserRole` in the claim `ocisRoles` a
 
 Claim values that are not mapped to a specific Infinite Scale role will be ignored.
 
-Note: An Infinite Scale user can only have a single role assigned. If the configured
-`role_mapping` and a user's claim values result in multiple possible roles for a user, an error
-will be logged and the user will not be able to log in.
+[NOTE]
+====
+An Infinite Scale user can only have a single role assigned. If the configured
+`role_mapping` and a user's claim values result in multiple possible roles for a user, the order in
+which the role mappings are defined in the configuration is important. The first role in the
+`role_mappings` where the `claim_value` matches a value from the user's roles claim will be assigned
+to the user. So if e.g. a user's `ocisRoles` claim has the values `myUserRole` and
+`mySpaceAdminRole` that user will get the ocis role `spaceadmin` assigned (because `spaceadmin`
+appears before `user` in the above sample configuration).
 
-The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The `role_mapping` is:
+If a user's claim values don't match any of the configured role mappings an error will be logged and
+the user will not be able to login.
+====
+
+The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The default `role_mapping` is:
 
 [source,yaml]
 ----
-admin: ocisAdmin
-user: ocisUser
-spaceadmin: ocisSpaceAdmin
-guest: ocisGuest
+- role_name: admin
+  claim_value: ocisAdmin
+- role_name: spaceadmin
+  claim_value: ocisSpaceAdmin
+- role_name: user
+  claim_value: ocisUser
+- role_name: guest:
+  claim_value: ocisGuest
 ----
 
 == Recommendations for Production Deployments


### PR DESCRIPTION
Fixes: #451 (proxy service: oidc role mapper to allow multiple matching roles)

Apply the changes from the ocis-repo proxy readme, see referenced issue.

Needs the referenced PR to be merged first, setting to draft therefore.