### PR TITLE
Add notification email template description

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -1,6 +1,7 @@
 = Notifications Service Configuration
 :toc: right
 :description: The notification service is responsible for sending emails to users informing them about events that happened.
+:github-master-url: https://github.com/owncloud/ocis/blob/master//services/notifications/pkg/email/templates
 
 :ext_name: notifications
 
@@ -11,6 +12,68 @@
 == Default Values
 
 * Notifications listens on port 9170 by default.
+
+== Email Notification Templates
+
+The `notifications` service has embedded email body templates. Email templates can use the placeholders `{{ .Greeting }}`, `{{ .MessageBody }}` and `{{ .CallToAction }}` which are replaced with translations when sent, see the xref:translations[Translations] section for more details. Depending on the email purpose, placeholders will contain different strings. An individual translatable string is available for each purpose, finally resolved by the placeholder. Though the email subject is also part of translations, it has no placeholder as it is a mandatory email component. The embedded templates are available for all deployment scenarios.
+
+[source,plaintext]
+----
+template 
+  placeholders
+    translated strings <-- source strings <-- purpose
+final output
+----
+
+In addition, the notifications service supports custom templates. Custom email templates take precedence over the embedded ones. If a custom email template exists, the embedded templates are not used. To configure custom email templates, the `NOTIFICATIONS_EMAIL_TEMPLATE_PATH` environment variable needs to point to a base folder that will contain the email templates. This path must be available from all instances of the notifications service, a shared storage is recommended. The source templates provided by Infinite Scale you can derive from are located in following base folder {github-master-url}[email / templates,window=_blank] with subfolders `shares` and `spaces`.
+
+-   {github-master-url}/shares/shareCreated.email.body.tmpl[shares / shareCreated.email.body.tmpl,window=_blank]
+-   {github-master-url}/shares/shareExpired.email.body.tmpl[shares / shareExpired.email.body.tmpl,window=_blank]
+-   {github-master-url}/spaces/membershipExpired.email.body.tmpl[spaces / membershipExpired.email.body.tmpl,window=_blank]
+-   {github-master-url}/spaces/sharedSpace.email.body.tmpl[spaces / sharedSpace.email.body.tmpl,window=_blank]
+-   {github-master-url}/spaces/unsharedSpace.email.body.tmpl[spaces / unsharedSpace.email.body.tmpl,window=_blank]
+
+[source,plaintext]
+----
+templates
+│
+└───shares
+│   │   shareCreated.email.body.tmpl
+│   │   shareExpired.email.body.tmpl
+│
+└───spaces
+    │   membershipExpired.email.body.tmpl
+    │   sharedSpace.email.body.tmpl
+    │   unsharedSpace.email.body.tmpl
+----
+
+Custom email templates referenced via `NOTIFICATIONS_EMAIL_TEMPLATE_PATH` must also be located in subfolders `shares` and `spaces` and must have the same names as the embedded templates. It is important that the names of these files and  folders match the embedded ones.
+
+== Translations
+
+The `notifications` service has embedded translations sourced via transifex to provide a basic set of translated languages. These embedded translations are available for all deployment scenarios. In addition, the service supports custom translations, though it is currently not possible to just add custom translations to embedded ones. If custom translations are configured, the embedded ones are not used. To configure custom translations, the `NOTIFICATIONS_TRANSLATION_PATH` environment variable needs to point to a base folder that will contain the translation files. This path must be available from all instances of the userlog service, a shared storage is recommended. Translation files must be of type https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#PO-Files[.po] or https://www.gnu.org/software/gettext/manual/html_node/Binaries.html[.mo]. For each language, the filename needs to be `userlog.po` (or `userlog.mo`) and stored in a folder structure defining the language code. In general the path/name pattern for a translation file needs to be:
+
+[source,plaintext]
+----
+{NOTIFICATIONS_TRANSLATION_PATH}/{language-code}/LC_MESSAGES/translations.po
+----
+
+The language code pattern is composed of `language[_territory]` where  `language` is the base language and `_territory` is optional and defines a country.
+
+For example, for the language `de`, one needs to place the corresponding translation files to
+
+[source,plaintext]
+----
+{NOTIFICATIONS_TRANSLATION_PATH}/de/LC_MESSAGES/translations.po
+----
+
+include::partial$deployment/services/webui_language_code.adoc[]
+
+=== Translation Rules
+
+*   If a requested language code is not available, the service tries to fall back to the base language if available. For example, if the requested language-code `de_DE` is not available, the service tries to fall back to translations in the `de` folder.
+*   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
+which is the source of the texts provided by the code.
 
 == Configuration
 


### PR DESCRIPTION
Fixes: #259 (Document eMail templating in ocis)

Adds a description about email templating in the notification service.