### PR TITLE
Add caching/storing info to services where missing

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -52,8 +52,8 @@ The `eventhistory` service stores each consumed event via the configured store i
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1. Note that in-memory stores are by nature not reboot-persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
 4. The `eventhistory` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 5.  When using `redis-sentinel`, the Redis master to use is configured via `EVENTHISTORY_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -59,13 +59,13 @@ The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INF
   -   `memory`: Basic in-memory store and the default.
   -   `ocmem`: Advanced in-memory store allowing max size.
   -   `redis`: Stores data in a configured redis cluster.
-  -   `redis-sentinel`: Stores data in a configured redis sentinel cluster.
+  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
   -   `etcd`: Stores data in a configured etcd cluster.
   -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
   -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
 
-1.  Note that in-memory stores are by nature not reboot persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1.  Note that in-memory stores are by nature not reboot-persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -47,11 +47,27 @@ Setting `FRONTEND_OCS_RESOURCE_INFO_CACHE_TTL=60` would cache the stat info for 
 
 == Scalability
 
-While the frontend service does not persist any data, it does cache `Stat()` responses and user information. Therefore, multiple instances of this service can be spawned in a bigger deployment like when using container orchestration with Kubernetes, when configuring `FRONTEND_OCS_RESOURCE_INFO_CACHE_TYPE=redis` and the related config options.
+While the frontend service does not persist any data, it does cache information about files and filesystem (`Stat()`) responses and user information. Therefore, multiple instances of this service can be spawned in a bigger deployment like when using container orchestration with Kubernetes, when configuring `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE` and the related config options.
 
 == Define Read-Only Attributes
 
 A lot of user management is done via the standardized LibreGraph API. Depending on how the system is configured, there might be some user attributes that an Infinite Scale instance admin can't change because of properties coming from an external LDAP server, or similar. This can be the case when the Infinite Scale admin is not the LDAP admin. To make life easier for admins, read-only attributes can be displayed differently, e.g. grayed out. To configure these hints for the frontend, use the environment variable `FRONTEND_READONLY_USER_ATTRIBUTES`, which takes a comma separated list of attributes. See the environment variable for supported values.
+
+== Caching
+
+The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`. Possible stores are:
+  -   `memory`: Basic in-memory store and the default.
+  -   `ocmem`: Advanced in-memory store allowing max size.
+  -   `redis`: Stores data in a configured redis cluster.
+  -   `redis-sentinel`: Stores data in a configured redis sentinel cluster.
+  -   `etcd`: Stores data in a configured etcd cluster.
+  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
+  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
+
+1.  Note that in-memory stores are by nature not reboot persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -17,25 +17,18 @@
 == Caching
 
 The `gateway` service can use a configured store via `GATEWAY_CACHE_STORE`. Possible stores are:
+  -   `memory`: Basic in-memory store and the default.
+  -   `ocmem`: Advanced in-memory store allowing max size.
+  -   `redis`: Stores data in a configured redis cluster.
+  -   `redis-sentinel`: Stores data in a configured redis sentinel cluster.
+  -   `etcd`: Stores data in a configured etcd cluster.
+  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
+  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
 
-[width=100%,cols="15%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-|===
-
-1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
-3. The `gateway` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+1.  Note that in-memory stores are by nature not reboot persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3.  The gateway service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `GATEWAY_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -19,14 +19,14 @@
 The `gateway` service can use a configured store via `GATEWAY_CACHE_STORE`. Possible stores are:
   -   `memory`: Basic in-memory store and the default.
   -   `ocmem`: Advanced in-memory store allowing max size.
-  -   `redis`: Stores data in a configured redis cluster.
-  -   `redis-sentinel`: Stores data in a configured redis sentinel cluster.
+  -   `redis`: Stores data in a configured Redis cluster.
+  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
   -   `etcd`: Stores data in a configured etcd cluster.
   -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
   -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
 
-1.  Note that in-memory stores are by nature not reboot persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1.  Note that in-memory stores are by nature not reboot-persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3.  The gateway service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `GATEWAY_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -57,8 +57,8 @@ The `graph` service can use a configured store via `GRAPH_STORE_TYPE`. Possible 
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1. Note that in-memory stores are by nature not reboot-persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3. The `graph` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `GRAPH_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 

--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -45,8 +45,8 @@ The `ocs` service can use a configured store via `GRAPH_STORE_TYPE`. Possible st
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1. Note that in-memory stores are by nature not reboot-persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3. The `ocs` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `OCS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -137,8 +137,8 @@ The `proxy` service can use a configured store via `GRAPH_STORE_TYPE`. Possible 
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1. Note that in-memory stores are by nature not reboot-persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3. The `proxy` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `PROXY_OIDC_USERINFO_CACHE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -107,6 +107,22 @@ The configuration for the `purge-expired` command is done by using the following
 
 * `STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE` has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `project space` trash-bin files.
 
+== Caching
+
+The `storage-users` service caches file metadata via the configured store in `STORAGE_USERS_CACHE_STORE` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE`. Possible stores are:
+  -   `memory`: Basic in-memory store and the default.
+  -   `ocmem`: Advanced in-memory store allowing max size.
+  -   `redis`: Stores data in a configured redis cluster.
+  -   `redis-sentinel`: Stores data in a configured redis sentinel cluster.
+  -   `etcd`: Stores data in a configured etcd cluster.
+  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
+  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
+
+1.  Note that in-memory stores are by nature not reboot persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+3.  The storage-users service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_CACHE_STORE_NODES` and in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -112,14 +112,14 @@ The configuration for the `purge-expired` command is done by using the following
 The `storage-users` service caches file metadata via the configured store in `STORAGE_USERS_CACHE_STORE` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE`. Possible stores are:
   -   `memory`: Basic in-memory store and the default.
   -   `ocmem`: Advanced in-memory store allowing max size.
-  -   `redis`: Stores data in a configured redis cluster.
-  -   `redis-sentinel`: Stores data in a configured redis sentinel cluster.
+  -   `redis`: Stores data in a configured Redis cluster.
+  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
   -   `etcd`: Stores data in a configured etcd cluster.
   -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
   -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
 
-1.  Note that in-memory stores are by nature not reboot persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1.  Note that in-memory stores are by nature not reboot-persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3.  The storage-users service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_CACHE_STORE_NODES` and in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -50,8 +50,8 @@ The `userlog` service persists information via the configured store in `USERLOG_
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-1. Note that in-memory stores are by nature not reboot persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store applies.
+1. Note that in-memory stores are by nature not reboot-persistent.
+2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3. The `userlog` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `USERLOG_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/6119 ([docs-only] Add caching/storing info to services where missing)

**DO NOT MERGE** before the referenced PR got merged !

Adds/corrects missing info in README.md for services with respect to caching/storing.
