### PR TITLE
Fix tables for caching in two services

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -56,13 +56,33 @@ A lot of user management is done via the standardized LibreGraph API. Depending 
 == Caching
 
 The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`. Possible stores are:
-  -   `memory`: Basic in-memory store and the default.
-  -   `ocmem`: Advanced in-memory store allowing max size.
-  -   `redis`: Stores data in a configured redis cluster.
-  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
-  -   `etcd`: Stores data in a configured etcd cluster.
-  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
-  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
+
+[width=100%,cols="25%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured Redis Sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in production environments.
+|===
 
 1.  Note that in-memory stores are by nature not reboot-persistent.
 2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -110,13 +110,33 @@ The configuration for the `purge-expired` command is done by using the following
 == Caching
 
 The `storage-users` service caches file metadata via the configured store in `STORAGE_USERS_CACHE_STORE` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE`. Possible stores are:
-  -   `memory`: Basic in-memory store and the default.
-  -   `ocmem`: Advanced in-memory store allowing max size.
-  -   `redis`: Stores data in a configured Redis cluster.
-  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
-  -   `etcd`: Stores data in a configured etcd cluster.
-  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
-  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
+
+[width=100%,cols="25%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured Redis Sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in production environments.
+|===
 
 1.  Note that in-memory stores are by nature not reboot-persistent.
 2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.


### PR DESCRIPTION
References: #468 (Add caching/storing info to services where missing)

Missed to make tables instead of text in two services.