### PR TITLE
Fix storage users cache envvars

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -109,7 +109,7 @@ The configuration for the `purge-expired` command is done by using the following
 
 == Caching
 
-The `storage-users` service caches file metadata via the configured store in `STORAGE_USERS_CACHE_STORE` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE`. Possible stores are:
+The `storage-users` service caches stat and metadata via the configured store in `STORAGE_USERS_STAT_CACHE_STORE` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE`. Possible stores are:
 
 [width=100%,cols="25%,85%",options=header]
 |===
@@ -141,7 +141,7 @@ The `storage-users` service caches file metadata via the configured store in `ST
 1.  Note that in-memory stores are by nature not reboot-persistent.
 2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
 3.  The storage-users service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_CACHE_STORE_NODES` and in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_STAT_CACHE_STORE_NODES` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES` in the form of `10.10.0.200:26379/mymaster`.
 
 == Configuration
 


### PR DESCRIPTION
References: #468

This fixes the envvars used for caching in the storage-users service and aligns it with the text in the ocis repo.