### PR TITLE
Changed host in the container orchestration section

### DIFF
--- a/modules/ROOT/examples/deployment/container/orchestration/nginx-ingress-tab-1.yaml
+++ b/modules/ROOT/examples/deployment/container/orchestration/nginx-ingress-tab-1.yaml
@@ -7,7 +7,7 @@ ingress:
     cert-manager.io/issuer: 'ocis-certificate-issuer'
   tls:
     - hosts:
-        - ocis.owncloud.test
+        - ocis.kube.owncloud.test
       secretName: ocis-tls-certificate
 
 extraResources:

--- a/modules/ROOT/examples/deployment/container/orchestration/nginx-ingress-tab-2.yaml
+++ b/modules/ROOT/examples/deployment/container/orchestration/nginx-ingress-tab-2.yaml
@@ -7,7 +7,7 @@ ingress:
     cert-manager.io/issuer: 'ocis-certificate-issuer'
   tls:
     - hosts:
-        - ocis.owncloud.test
+        - ocis.kube.owncloud.test
       secretName: ocis-tls-certificate
 
 extraResources:

--- a/modules/ROOT/examples/deployment/container/orchestration/nginx-ingress-tab-3.yaml
+++ b/modules/ROOT/examples/deployment/container/orchestration/nginx-ingress-tab-3.yaml
@@ -7,7 +7,7 @@ ingress:
     cert-manager.io/issuer: 'ocis-certificate-issuer'
   tls:
     - hosts:
-        - ocis.owncloud.test
+        - ocis.kube.owncloud.test
       secretName: ocis-tls-certificate
 
 extraResources:


### PR DESCRIPTION
changed host name in the NGINX Ingress Example: 
- https://doc.owncloud.com/ocis/next/deployment/container/orchestration/orchestration.html#kubernetes