### PR TITLE
update supported ocis version for latest helm chart

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -227,7 +227,7 @@ See the following table to match the Helm chart versions with Infinite Scale rel
 | Works with Infinite Scale Versions
 
 | {helm_tab_1_tab_text}
-| 3.0.0-alpha.2
+| 3.0.0-rc.1
 
 ifdef::use_helm_tab_2[]
 | {helm_tab_2_tab_text}


### PR DESCRIPTION
merge only after https://github.com/owncloud/ocis-charts/pull/211
