### PR TITLE
Fix disown command in binary setup

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -138,10 +138,19 @@ ocis server
 
 Note that this will bind `ocis` to the shell you are running. If you want to detach it and avoid it being stopped when closing the shell or the shell gets disconnected (SIGHUP), use the following command:
 
+.Bash
 [source,bash]
 ----
 ocis server & disown -h
 ----
+
+.ZSH
+[source,bash]
+----
+ocis server & disown $!
+----
+
+See the respective shell documentation for how to manage processes respectively detach and re-attach sessions.
 
 === List Running Infinite Scale Processes
 


### PR DESCRIPTION
Fixes: #473 (mention that disown -h is shell dependant)

The current disown command was bash specific.

Make an ZSH example too and a note to read the shell documentation for more info.