### PR TITLE
Fix the naming of the service envvar

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -54,14 +54,14 @@ endif::[]
 // https://github.com/owncloud/ocis/blob/master/docs/helpers/extended_vars.yaml
 // see the readme.md file in that folder
  
-:ext_name: extended
+:service_name: extended
 :no_deprecation: true
 
 include::partial$deployment/services/env-and-yaml.adoc[]
 
 == Global Environment Variables
 
-:ext_name: global
+:service_name: global
 :no_deprecation: true
 
 Note that the descriptions of these environment variables may differ depending on the service context.

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale antivirus service is responsible for scanning files for viruses.
 
-:ext_name: antivirus
+:service_name: antivirus
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/pages/deployment/services/s-list/app-provider.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/app-provider.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: App providers represent apps, if the app is not able to register itself. Currently there is only the CS3org WOPI server app provider.
 
-:ext_name: app-provider
+:service_name: app-provider
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/app-registry.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/app-registry.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale App-Registry service
 
-:ext_name: app-registry
+:service_name: app-registry
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/audit.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/audit.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The audit service logs all events of the system as an audit log. Per default, it will be logged to standard out, but can also be configured to a file output.
 
-:ext_name: audit
+:service_name: audit
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/auth-basic.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-basic.adoc
@@ -1,7 +1,7 @@
 = Auth Basic Service Configuration
 :toc: right
 
-:ext_name: auth-basic
+:service_name: auth-basic
 
 :description: The Infinite Scale Auth Basic service provides basic authentication for those clients who cannot handle OIDC. This is a rare case, is usually not necessary and mainly used for tests or development.
 

--- a/modules/ROOT/pages/deployment/services/s-list/auth-bearer.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-bearer.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Auth Bearer service authenticates OpenID Connect bearer tokens.
 
-:ext_name: auth-bearer
+:service_name: auth-bearer
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/auth-machine.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-machine.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Auth Machine service
 
-:ext_name: auth-machine
+:service_name: auth-machine
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale eventhistory service consumes all events from the configured event system like NATS, stores them and allows other services to retrieve them via an event ID.
 
-:ext_name: eventhistory
+:service_name: eventhistory
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The frontend service translates various ownCloud related HTTP APIs to CS3 requests.
 
-:ext_name: frontend
+:service_name: frontend
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Frontend service
 
-:ext_name: gateway
+:service_name: gateway
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Graph service provides a simple graph world API which can be used by clients or other services or extensions.
 
-:ext_name: graph
+:service_name: graph
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/groups.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/groups.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Group service
 
-:ext_name: groups
+:service_name: groups
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/idm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idm.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale IDM service provides a minimal LDAP Service for Infinite Scale. It is started as part of the runtime and serves as a central place for storing user and group information.
 
-:ext_name: idm
+:service_name: idm
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/idp.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idp.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale IDP service provides a built-in minimal OpenID Connect provider.
 
-:ext_name: idp
+:service_name: idp
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale invitations service provides an Invitation Manager that can be used to invite external users, aka guests, to an organization.
 
-:ext_name: invitations
+:service_name: invitations
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/pages/deployment/services/s-list/nats.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/nats.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The nats service is the event broker of the system. It distributes events among all other services and enables other services to communicate asynchronously.
 
-:ext_name: nats
+:service_name: nats
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -3,7 +3,7 @@
 :description: The notification service is responsible for sending emails to users informing them about events that happened.
 :github-master-url: https://github.com/owncloud/ocis/blob/master//services/notifications/pkg/email/templates
 
-:ext_name: notifications
+:service_name: notifications
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
@@ -5,7 +5,7 @@
 // references https://github.com/owncloud/ocis/pull/3864 ([docs-only] add PROPFIND sequence diagram examples)
 // also see: https://owncloud.dev/architecture/protocol-changes/ 
 
-:ext_name: ocdav
+:service_name: ocdav
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale OCS service provides the OCS API which is required by some ownCloud clients.
 
-:ext_name: ocs
+:service_name: ocs
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale policies service provides a new gRPC API which can be used to check whether a requested operation is allowed or not. To do so, Open Policy Agent (OPA) is used to define the set of rules of what is permitted and what is not.
 
-:ext_name: policies
+:service_name: policies
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale postprocessing service handles the coordination of asynchronous post-processing steps.
 
-:ext_name: postprocessing
+:service_name: postprocessing
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The proxy service is an API-Gateway for the ownCloud Infinite Scale microservices.
 
-:ext_name: proxy
+:service_name: proxy
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/search.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/search.adoc
@@ -4,7 +4,7 @@
 
 :tika-version: 2.7.0
 
-:ext_name: search
+:service_name: search
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Settings service
 
-:ext_name: settings
+:service_name: settings
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Sharing service
 
-:ext_name: sharing
+:service_name: sharing
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-publiclink.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-publiclink.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Storage-Publiclink service
 
-:ext_name: storage-publiclink
+:service_name: storage-publiclink
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-shares.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-shares.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Storage-Shares service
 
-:ext_name: storage-shares
+:service_name: storage-shares
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Storage-System service
 
-:ext_name: storage-system
+:service_name: storage-system
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -3,7 +3,7 @@
 :tus-url: https://tus.io
 :description: The Infinite Scale Storage-Users service
 
-:ext_name: storage-users
+:service_name: storage-users
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/store.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/store.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale Store service
 
-:ext_name: store
+:service_name: store
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The thumbnails service provides methods to generate thumbnails for various files and resolutions based on requests.
 
-:ext_name: thumbnails
+:service_name: thumbnails
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -4,7 +4,7 @@
 
 :oc10-api-url: https://doc.owncloud.com/server/next/developer_manual/core/apis/ocs-notification-endpoint-v1.html#get-user-notifications
 
-:ext_name: userlog
+:service_name: userlog
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/pages/deployment/services/s-list/users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/users.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The Infinite Scale User service
 
-:ext_name: users
+:service_name: users
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/web.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/web.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The web service embeds and serves the static files for the Infinite Scale Web Client.
 
-:ext_name: web
+:service_name: web
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/webdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/webdav.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: The webdav service, like the ocdav service, provides a HTTP API following the webdav protocol.
 
-:ext_name: webdav
+:service_name: webdav
 
 == Introduction
 

--- a/modules/ROOT/pages/deployment/services/s-list/webfinger.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/webfinger.adoc
@@ -3,7 +3,7 @@
 :description: The Infinite Scale webfinger service provides an RFC7033 WebFinger lookup of ownCloud instances relevant for a given user account.
 :webfinger-url: https://en.wikipedia.org/wiki/WebFinger
 
-:ext_name: webfinger
+:service_name: webfinger
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -1,5 +1,5 @@
 ////
-The attribute 'ext_name' (mandatory) and 'no_yaml' (not mandatory) will be handed over by the calling page.
+The attribute 'service_name' (mandatory) and 'no_yaml' (not mandatory) will be handed over by the calling page.
 If no_yaml is set, it will exclude rendering yaml files because it does not exist.
 
 Print a dependent explanation line:
@@ -29,14 +29,14 @@ To exclude a deprecation file if not wanted - like when the file will just not e
 // if set, it will show the deprecation table in all tabs, independent if that tab has one or not
 ifndef::no_deprecation[]
 
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 ifeval::["{show-deprecation}" == "true"]
 :has_deprecation_tab_1: true
 endif::[]
 
 ifndef::no_second_tab[]
 ifdef::use_service_tab_2[]
-include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 ifeval::["{show-deprecation}" == "true"]
 :has_deprecation_tab_2: true
 endif::[]
@@ -44,7 +44,7 @@ endif::use_service_tab_2[]
 
 ifndef::no_third_tab[]
 ifdef::use_service_tab_3[]
-include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{ext_name}_deprecation.adoc[]
+include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 ifeval::["{show-deprecation}" == "true"]
 :has_deprecation_tab_3: true
 endif::[]
@@ -64,11 +64,11 @@ endif::no_deprecation[]
 ifndef::no_yaml[]
 === Environment Variables
 
-The `{ext_name}` service is configured via the following environment variables:
+The `{service_name}` service is configured via the following environment variables:
 endif::no_yaml[]
 
 ifdef::no_yaml[]
-The `{ext_name}` variables are defined in the following way:
+The `{service_name}` variables are defined in the following way:
 endif::no_yaml[]
 
 // create the tabs. note that if no_second_tab is set, the third tab is also not shown
@@ -78,14 +78,14 @@ endif::no_yaml[]
 {service_tab_1_tab_text}::
 +
 --
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
+include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
 --
 ifndef::no_second_tab[]
 ifdef::use_service_tab_2[]
 {service_tab_2_tab_text}::
 +
 --
-include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
+include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
 --
 endif::use_service_tab_2[]
 ifndef::no_third_tab[]
@@ -93,7 +93,7 @@ ifdef::use_service_tab_3[]
 {service_tab_3_tab_text}::
 +
 --
-include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{ext_name}_configvars.adoc[]
+include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
 --
 endif::use_service_tab_3[]
 endif::no_third_tab[]
@@ -114,7 +114,7 @@ See the xref:deployment/general/general-info.adoc#configuration-file-naming[Conf
 --
 [source,yaml]
 ----
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}{ext_name}-config-example.yaml[]
+include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}{service_name}-config-example.yaml[]
 ----
 --
 ifndef::no_second_tab[]
@@ -124,7 +124,7 @@ ifdef::use_service_tab_2[]
 --
 [source,yaml]
 ----
-include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}{ext_name}-config-example.yaml[]
+include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}{service_name}-config-example.yaml[]
 ----
 --
 endif::use_service_tab_2[]
@@ -135,7 +135,7 @@ ifdef::use_service_tab_3[]
 --
 [source,yaml]
 ----
-include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}{ext_name}-config-example.yaml[]
+include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}{service_name}-config-example.yaml[]
 ----
 --
 endif::use_service_tab_3[]


### PR DESCRIPTION
This was a leftover from the early days, the envvar attribute name is now correct.

`ext_name` --> `service_name`

A local build runs fine