### PR TITLE
Update the proxy service and general info (PROXY_TLS)

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -479,7 +479,7 @@ If you have enabled demo users and groups and you want to manage or delete them,
 
 == Using the Embedded IDP Service
 
-When using the embedded IDP service, you must not set the environment variable `PROXY_TLS` to `false`. See the xref:{s-path}/proxy.adoc#special-settings[Special Settings] section in the Proxy servicefor more details.
+When using the embedded IDP service, you must not set the environment variable `PROXY_TLS` to `false`. See the xref:{s-path}/proxy.adoc#special-settings[Special Settings] section in the Proxy service for more details.
 
 == Default Ports
 

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -477,6 +477,10 @@ You can now login with one of the demo users created using the `OCIS_URL` in you
 
 If you have enabled demo users and groups and you want to manage or delete them, use the web UI, e.g. `\https://localhost:9200`.
 
+== Using the Embedded IDP Service
+
+When using the embedded IDP service, you must not set the environment variable `PROXY_TLS` to `false`. See the xref:{s-path}/proxy.adoc#special-settings[Special Settings] section in the Proxy servicefor more details.
+
 == Default Ports
 
 See xref:deployment/services/ports-used.adoc[Used Port Ranges] at the _Services_ description for details.

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -142,6 +142,10 @@ The `proxy` service can use a configured store via `GRAPH_STORE_TYPE`. Possible 
 3. The `proxy` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `PROXY_OIDC_USERINFO_CACHE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
+== Special Settings
+
+When using the Infinite Scale xref:{s-path}/idp.adoc[IDP service] instead of an external IDP, the `PROXY_TLS` environment variable must be set to `true` because the embedded `libreConnect` shipped with the IDP service has a hard check if the connection is on TLS and uses the HTTPS protocol. If this mismatches, an error will be logged.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/6193 ([docs-only] Update the PROXY_TLS envvar description)

`PROXY_TLS` needs clarification to avoid setup issues.