### PR TITLE
Add page alias to relink to old theming page in the webui repo

### DIFF
--- a/modules/ROOT/pages/deployment/webui/webui-theming.adoc
+++ b/modules/ROOT/pages/deployment/webui/webui-theming.adoc
@@ -1,7 +1,7 @@
 = ownCloud Web with Custom Theming
 :toc: right
 :toclevels: 2
-//:page-aliases: {latest-webui-version}@webui:owncloud_web:themed_webui.adoc
+:page-aliases: {latest-webui-version}@webui:owncloud_web:themed_webui.adoc
 :description: Just like with other clients (Desktop, Android, iOS), themes can be used with ownCloud Web.
 
 :example-theme-url: https://github.com/owncloud/web/tree/master/config


### PR DESCRIPTION
References: #486 (Add WebUI to the admin documentation)

Adding a page alias after the relocated page got removed from the source repo.

Locally tested, alias works. 