### PR TITLE
Add a note to not use xattrs anymore

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -14,6 +14,46 @@
 
 * Storage-System listens on port 9215 by default.
 
+== Caching
+
+The `frontend` service can use a configured store via `STORAGE_SYSTEM_CACHE_STORE`. Possible stores are:
+
+[width=100%,cols="25%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured Redis Sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in production environments.
+|===
+
+1.  Note that in-memory stores are by nature not reboot-persistent.
+2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
+3.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_SYSTEM_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
+== Deprecated Metadata Backend
+
+Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -52,7 +52,7 @@ The `frontend` service can use a configured store via `STORAGE_SYSTEM_CACHE_STOR
 
 == Deprecated Metadata Backend
 
-Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+Starting with Infinite Scale version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_SYSTEM_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -143,6 +143,10 @@ The `storage-users` service caches stat and metadata via the configured store in
 3.  The storage-users service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_STAT_CACHE_STORE_NODES` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES` in the form of `10.10.0.200:26379/mymaster`.
 
+== Deprecated Metadata Backend
+
+Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_USERS_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -145,7 +145,7 @@ The `storage-users` service caches stat and metadata via the configured store in
 
 == Deprecated Metadata Backend
 
-Starting with ocis version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_USERS_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
+Starting with Infinite Scale version 3.0.0, the default backend for metadata switched to messagepack. If the setting `STORAGE_USERS_OCIS_METADATA_BACKEND` has not been defined manually, the backend will be migrated to `messagepack` automatically. Though still possible to manually configure `xattrs`, this setting should not be used anymore as it will be removed in a later version.
 
 == Configuration
 


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/6224 ([docs-only] Add readme.md note to not use xattrs anymore)

* Adding a note that xattrs should not be used anymore
* Fixed that the storage-system service is missing the caching description