### PR TITLE
Add more WebUI config descriptions

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/web.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/web.adoc
@@ -20,9 +20,9 @@ The web service also provides a minimal API for branding functionality like chan
 
 If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See https://owncloud.dev/clients/web/getting-started/[ownCloud Web / Getting Started] and https://owncloud.dev/clients/web/backend-ocis/[ownCloud Web / Setup with oCIS] in the developer documentation for more details.
 
-== Customize the WebUI Configuration
+== Customize the Web UI Configuration
 
-See the xref:deployment/webui/webui.adoc[WebUI] documentation for how to configure theming and customisation.
+See the xref:deployment/webui/webui.adoc[Web UI] documentation for how to configure theming and customization.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/web.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/web.adoc
@@ -20,6 +20,10 @@ The web service also provides a minimal API for branding functionality like chan
 
 If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See https://owncloud.dev/clients/web/getting-started/[ownCloud Web / Getting Started] and https://owncloud.dev/clients/web/backend-ocis/[ownCloud Web / Setup with oCIS] in the developer documentation for more details.
 
+== Customize the WebUI Configuration
+
+See the xref:deployment/webui/webui.adoc[WebUI] documentation for how to configure theming and customisation.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/webui/webui-customisation.adoc
+++ b/modules/ROOT/pages/deployment/webui/webui-customisation.adoc
@@ -6,6 +6,16 @@
 
 {description}
 
-== Custom Configuration
+== Web UI Configuration
 
-Behavior customization can be achieved by setting environment variables in the xref:{s-path}/web.adoc[web service]. Look for environment variables starting with `WEB_OPTION_xxx` for more details.
+* Single configuration settings of the embedded web UI can be defined via `WEB_OPTION_xxx` environment variables.
+* A json based configuration file can be used via the `WEB_UI_CONFIG_FILE` environment variable.
+* A configuration file takes precedence over single options set.
+
+=== Web UI Options
+
+Beside theming, the behavior of the web UI can be configured via options. Behavior customization can be achieved by setting environment variables in the xref:{s-path}/web.adoc[Web service]. Look for environment variables starting with `WEB_OPTION_xxx` for more details.
+
+=== Web UI Config File
+
+When defined via the `WEB_UI_CONFIG_FILE` xref:{s-path}/web.adoc[environment variable], the configuration of the web UI can be made with a json based file. See the https://github.com/owncloud/web/tree/master/config[link,window=_blank] for examples.


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/6229 ([docs-only] Deprecate some web envvars)

This completes the WebUI documentation (for the time being) based on changes in the referenced ocis PR.

Only merge when the referenced PR got merged.