### PR TITLE
Fix Caching Setup

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -25,38 +25,10 @@ The `eventhistory` services consumes all events from the configured event system
 
 The `eventhistory` service stores each consumed event via the configured store in `EVENTHISTORY_STORE_TYPE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1. Note that in-memory stores are by nature not reboot-persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3. Events stay in the store for 2 weeks by default. Use `EVENTHISTORY_RECORD_EXPIRY` to adjust this value.
-4. The `eventhistory` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
-5.  When using `redis-sentinel`, the Redis master to use is configured via `EVENTHISTORY_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+. The `eventhistory` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
+.  When using `redis-sentinel`, the Redis master to use is configured via `EVENTHISTORY_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -57,37 +57,9 @@ A lot of user management is done via the standardized LibreGraph API. Depending 
 
 The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1.  Note that in-memory stores are by nature not reboot-persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -17,18 +17,10 @@
 == Caching
 
 The `gateway` service can use a configured store via `GATEWAY_CACHE_STORE`. Possible stores are:
-  -   `memory`: Basic in-memory store and the default.
-  -   `ocmem`: Advanced in-memory store allowing max size.
-  -   `redis`: Stores data in a configured Redis cluster.
-  -   `redis-sentinel`: Stores data in a configured Redis Sentinel cluster.
-  -   `etcd`: Stores data in a configured etcd cluster.
-  -   `nats-js`: Stores data using key-value-store feature of [nats jetstream](https://docs.nats.io/nats-concepts/jetstream/key-value-store)
-  -   `noop`: Stores nothing. Useful for testing. Not recommended in production environments.
 
-1.  Note that in-memory stores are by nature not reboot-persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3.  The gateway service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `GATEWAY_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `GATEWAY_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -28,39 +28,11 @@ image::deployment/services/graph/mermaid-graph.svg[width=600]
 
 == Caching
 
-The `graph` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
+The `graph` service can use a configured store via `GRAPH_CACHE_STORE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1. Note that in-memory stores are by nature not reboot-persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3. The `graph` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `GRAPH_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `GRAPH_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Keycloak Configuration for the Personal Data Export
 

--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -14,42 +14,6 @@
 
 * OCS listens on port 9110 by default.
 
-== Caching
-
-The `ocs` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
-
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1. Note that in-memory stores are by nature not reboot-persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3. The `ocs` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `OCS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
-
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -108,39 +108,11 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
 
 == Caching
 
-The `proxy` service can use a configured store via `GRAPH_STORE_TYPE`. Possible stores are:
+The `proxy` service can use a configured store via `PROXY_OIDC_USERINFO_CACHE_STORE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1. Note that in-memory stores are by nature not reboot-persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3. The `proxy` service can be scaled if it's not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `PROXY_OIDC_USERINFO_CACHE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `PROXY_OIDC_USERINFO_CACHE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Special Settings
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -18,37 +18,9 @@
 
 The `frontend` service can use a configured store via `STORAGE_SYSTEM_CACHE_STORE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1.  Note that in-memory stores are by nature not reboot-persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_SYSTEM_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_SYSTEM_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Deprecated Metadata Backend
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -111,37 +111,9 @@ The configuration for the `purge-expired` command is done by using the following
 
 The `storage-users` service caches stat and metadata via the configured store in `STORAGE_USERS_STAT_CACHE_STORE` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `Redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1.  Note that in-memory stores are by nature not reboot-persistent.
-2.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3.  The storage-users service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_STAT_CACHE_STORE_NODES` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES` in the form of `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_STAT_CACHE_STORE_NODES` and `STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES` in the form of `10.10.0.200:26379/mymaster`.
 
 == Deprecated Metadata Backend
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -23,37 +23,9 @@ Running the `userlog` service without running the xref:{s-path}/eventhistory.ado
 
 The `userlog` service persists information via the configured store in `USERLOG_STORE_TYPE`. Possible stores are:
 
-[width=100%,cols="25%,85%",options=header]
-|===
-| Store Type
-| Description
-
-| `memory`
-| Basic in-memory store and the default.
-
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `redis`
-| Stores data in a configured Redis cluster.
-
-| `redis-sentinel`
-| Stores data in a configured Redis Sentinel cluster.
-
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
-
-| `noop`
-| Stores nothing. Useful for testing. Not recommended in production environments.
-|===
-
-1. Note that in-memory stores are by nature not reboot-persistent.
-2. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally, this does not apply to stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-3. The `userlog` service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-4.  When using `redis-sentinel`, the Redis master to use is configured via `USERLOG_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+.  When using `redis-sentinel`, the Redis master to use is configured via `USERLOG_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuring Events
 

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -1,6 +1,6 @@
 ////
-This partial contains the commonly used list if cache stores plus notes.
-It is used as partial so when there is a change, we only need to do it on one place
+This partial contains the commonly used list of cache stores plus notes.
+It is used as partial so when there is a change, we only need to do it in one place
 When including, there must be at the top and the bottom a line manually added describing service dependent stuff, see below.
 ////
 

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -1,0 +1,42 @@
+////
+This partial contains the commonly used list if cache stores plus notes.
+It is used as partial so when there is a change, we only need to do it on one place
+When including, there must be at the top and the bottom a line manually added describing service dependent stuff, see below.
+////
+
+// to be added manually like:
+// The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`. Possible stores are:
+
+[width=100%,cols="25%,85%",options=header]
+|===
+| Store Type
+| Description
+
+| `memory`
+| Basic in-memory store and the default.
+
+| `ocmem`
+| Advanced in-memory store allowing max size.
+
+| `Redis`
+| Stores data in a configured Redis cluster.
+
+| `redis-sentinel`
+| Stores data in a configured Redis Sentinel cluster.
+
+| `etcd`
+| Stores data in a configured etcd cluster.
+
+| `nats-js`
+| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+
+| `noop`
+| Stores nothing. Useful for testing. Not recommended in production environments.
+|===
+
+.  Note that in-memory stores are by nature not reboot-persistent.
+.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
+.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+// no blank lines here, this will break continuous numbering!!
+// to be added manually like:
+// .  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.


### PR DESCRIPTION
This PR fixes the following:

* Make the main part of the caching and persistence table a partial.
This eliminates rewriting stuff again and again which is error prone and eases changes
* Fix wrongly used envvars in caching descriptions (graph and proxy)
* Remove caching from the ocs service as it is no longer present

Needs a PR in the ocis repo too for fix and remove things. 