### PR TITLE
Fix not using a attribute in caching partial

### DIFF
--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -36,7 +36,7 @@ When including, there must be at the top and the bottom a line manually added de
 
 .  Note that in-memory stores are by nature not reboot-persistent.
 .  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-.  The frontend service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+.  The {service_name} service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 // no blank lines here, this will break continuous numbering!!
 // to be added manually like:
 // .  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.


### PR DESCRIPTION
References: #493 (Fix Caching Setup)

When creating the caching partial, I have overseen to replace the static service name with an attribute defined in the calling page.