### PR TITLE
Add content and caching to settings

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -10,6 +10,14 @@
 
 // fixme: source description is still missing, and a better description is needed
 
+== Caching
+
+The `settings` service caches the results of filesystem lookups to provide faster responses. The store used for the cache can be configured using the `SETTINGS_CACHE_STORE` environment variable. Possible stores are:
+
+include::partial$multi-location/caching-list.adoc[]
+// you must not have one or more blank lines here as it breaks continuous numbering!
+. When using `redis-sentinel`, the Redis master to use is configured via `SETTINGS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
 == Default Values
 
 * Settings listens on port 9190 by default.

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -1,6 +1,6 @@
 = Settings Service Configuration
 :toc: right
-:description: The Infinite Scale Settings service
+:description: The Infinite Scale Settings service provides functionality for other services to register new settings as well as storing and retrieving the respective settings' values.
 
 :service_name: settings
 
@@ -8,19 +8,37 @@
 
 {description}
 
-// fixme: source description is still missing, and a better description is needed
+== Default Values
+
+* Settings listens on port 9190 by default.
+
+== Settings Managed
+
+The settings service is currently used for managing the:
+
+* users' `profile` settings like the language and the email notification settings,
+* possible user roles and their respective permissions,
+* assignment of roles to users.
+
+As an example, user profile settings that can be changed in the Web UI must be persistent.  
+
+The settings service supports two different backends for persisting the data. The backend can be set via the `SETTINGS_STORE_TYPE` environment variable. Supported values are:
+
+* `metadata`: The default. This backend persists the settings data via the `storage-system` service.
+* `filesystem`: This backend persists the settings data in a directory on the local filesystem.
+  The directory can be configured with `SETTINGS_DATA_PATH`. This backend is **not** suitable for running
+  multiple intances of the `settings` service in a scale-out deployment and should be therefore considered
+  deprecated.
 
 == Caching
 
-The `settings` service caches the results of filesystem lookups to provide faster responses. The store used for the cache can be configured using the `SETTINGS_CACHE_STORE` environment variable. Possible stores are:
+When using `SETTINGS_STORE_TYPE=metadata`, the `settings` service caches the results of queries against the storage backend to provide faster responses. The content of this cache is independent of the cache used in the `storage-system` service as it caches directory listing and settings content stored in files.
+
+The store used for the cache can be configured using the `SETTINGS_CACHE_STORE` environment variable. Possible stores are:
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!
 . When using `redis-sentinel`, the Redis master to use is configured via `SETTINGS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
-
-== Default Values
-
-* Settings listens on port 9190 by default.
 
 == Configuration
 

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -34,9 +34,9 @@ When including, there must be at the top and the bottom a line manually added de
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-.  Note that in-memory stores are by nature not reboot-persistent.
-.  Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-.  The {service_name} service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
+. Note that in-memory stores are by nature not reboot-persistent.
+. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
+. The {service_name} service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
 // no blank lines here, this will break continuous numbering!!
 // to be added manually like:
-// .  When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+// . When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/6274 ([docs-only] Create README for settings service)

Adding the following to the settings service description:

* Content what the service is about
* Caching

Plus a small cleanup in the caching partial.