### PR TITLE
Add ocis overview presentation to introduction

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -12,8 +12,10 @@
 
 {description}
 
+// IMPORTANT: this permalink origins to: https://cloud.owncloud.com/index.php/apps/files/?dir=/Shared/owncloud/Product%20Management/Presentations/2023-05-22_Infinite%20Scale%20current%20state&fileid=6005441
+
 See the following PDF document for a brief 
-link:{attachmentsdir}/2023-05-22_Infinite_Scale_Overview.pdf[overview of Infinite Scale,window=_blank].
+https://cloud.owncloud.com/index.php/s/S7W9NPfKSHAoEYB[overview of Infinite Scale,window=_blank].
 
 === Target Audience
 

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -12,6 +12,9 @@
 
 {description}
 
+See the following PDF document for a brief 
+link:{attachmentsdir}/2023-05-22_Infinite_Scale_Overview.pdf[overview of Infinite Scale,window=_blank].
+
 === Target Audience
 
 This documentation addresses administrators and technically-oriented management:


### PR DESCRIPTION
This adds a pdf version of a slide deck describing infinite Scale created by @tbsbdr at the most prominent location - the introduction section of the ocis main page.

I have slightly adapted to pages:

* Page 1:
Only showing `May 2023` instead of `May 2023 (current)`
* Page 13:
Aligning image and text
