### PR TITLE
Make the redis config value starting with a lower letter

### DIFF
--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -18,7 +18,7 @@ When including, there must be at the top and the bottom a line manually added de
 | `ocmem`
 | Advanced in-memory store allowing max size.
 
-| `Redis`
+| `redis`
 | Stores data in a configured Redis cluster.
 
 | `redis-sentinel`


### PR DESCRIPTION
As the title says, all caching config values are lower case.