### PR TITLE
apache proxy instructins should not use ssl on port 9200

### DIFF
--- a/modules/ROOT/partials/deployment/apache_full_example.adoc
+++ b/modules/ROOT/partials/deployment/apache_full_example.adoc
@@ -22,8 +22,8 @@
     SSLProxyCheckPeerName off
     SSLProxyCheckPeerExpire off
 
-    ProxyPass / https://localhost:{ocis_port}/
-    ProxyPassReverse / https://localhost:{ocis_port}/
+    ProxyPass / http://localhost:{ocis_port}/
+    ProxyPassReverse / http://localhost:{ocis_port}/
 
     #important, otherwise 400 errors from idp
     ProxyPreserveHost on


### PR DESCRIPTION
Nginx proxy config says that we can connect to ocis via http://localhost:9200  Apache proxy config showed https. This is wrong. and leads to an error message: AH02003: SSL Proxy connect failed Library Error: error:0A00010B:SSL routines::wrong version number

Note: this 'apache_full_example' is actually the setup for a reverse proxy. Mabye rename the file to apache_proxy_example.adoc ?