### PR TITLE
Document metadata CLI command

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -27,3 +27,30 @@ This command is about purging old trash-bin items of `project` spaces (spaces th
 == Reindex a Space for Search
 
 In rare circumstances, it can be necessary to initiate indexing manually for a given space or user. Though the search service handles exception cases automatically, it can happen that the search service was not able to complete indexing due to a dirty shut-down of the service or because of a bug. Re-indexing should *only* be run on explicit request and supervision by ownCloud support. See the xref:{s-path}/search.adoc#manually-trigger-re-indexing-a-space[Manually Trigger Re-Indexing a Space] section at the _Search_ service for details.
+
+== Inspect and Manipulate Node Metadata
+
+Infinite Scale provides a CLI command where you can inspect and manipulate node metadata.
+
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request of ownCloud support. 
+
+[source,bash]
+----
+ocis decomposedfs metadata
+NAME:
+   ocis decomposedfs metadata - cli tools to inspect and manipulate node metadata
+
+USAGE:
+   ocis decomposedfs metadata command [command options] [arguments...]
+
+COMMANDS:
+   dump     print the metadata of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.
+   get      print a specific attribute of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.
+   set      manipulate metadata of the given node. Binary attributes can be given hex encoded (prefix by '0x') or base64 encoded (prefix by '0s').
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --root value, -r value  Path to the decomposedfs
+   --node value, -n value  Path to or ID of the node to inspect
+   --help, -h              show help
+----


### PR DESCRIPTION
Fixes: #413 (New ocis commands for metadata)

Add a new metadata manipulating CLI command to the list of commands.

Note that the printout is at is is and comes from running the command.