### PR TITLE
Remove double present note

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -73,8 +73,6 @@ NOTE: We highly recommend reading the xref:deployment/general/general-info.adoc[
 
 Configuration of Infinite Scale might be quite different to what you are used to but it's very simple. It works with environment variables and optional configuration files for you to create depending on your specific needs. The settings in configuration files can always be overruled by setting the respective environment variables manually on the command line.
 
-NOTE: In configuration variables and comments, you'll often come across the word oCIS or ocis, short for "ownCloud Infinite Scale", while the product is simply called Infinite Scale.
-
 == Try Online
 
 You can try Infinite Scale before you install it locally to get hands-on experience and a feeling for how things work and integrate. Our development provides several instances with different setups to test. The instances are reset on a regular basis. See our https://owncloud.dev/ocis/deployment/continuous_deployment/[Continuous Deployment,window=_blank] page for more details.


### PR DESCRIPTION
The removed note was double present. First appearance is on top in section "Brief Overview".