### PR TITLE
Update search service content extraction file size limit

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/search.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/search.adoc
@@ -64,6 +64,8 @@ As soon as Tika is installed and accessible, the search service must be configur
 
 When the search service can reach Tika, it begins to read out the content on demand. Note that files must be downloaded during the process, which can lead to delays with larger documents.
 
+NOTE: Content extraction and handling the extracted content can be very resource intensive. Content extraction is therefore limited to files with a certain file size. The default limit is 20MB and can be configured using the `SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT` variable.
+
 When using the Tika container and docker-compose, consider the following:
 
 * See the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples] (ocis_wopi) for details.


### PR DESCRIPTION
Fixes: #514 (New setting: Do not try to fulltext-index large files (search service))

Add envvar limiting content extraction file size.