### PR TITLE
prepare ocis chart 0.3.0 release with ocis 3.0.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -57,7 +57,7 @@ asciidoc:
     # note that tab 2 always contains the actual release and tab 3 the former
     helm_tab_1_tab_text: 'latest'
     helm_tab_2_tab_text: '0.3.0'
-    helm_tab_3_tab_text: '0.1.0'
+    helm_tab_3_tab_text: '0.2.0'
 
     # set attributes defining path components which will be assembled in the document
     secrets: 'deployment/container/orchestration/orchestration.adoc#define-secrets'

--- a/antora.yml
+++ b/antora.yml
@@ -56,7 +56,7 @@ asciidoc:
     # helm_tab_x_tab_text will be used as tab text shown for tab_x
     # note that tab 2 always contains the actual release and tab 3 the former
     helm_tab_1_tab_text: 'latest'
-    helm_tab_2_tab_text: '0.2.0'
+    helm_tab_2_tab_text: '0.3.0'
     helm_tab_3_tab_text: '0.1.0'
 
     # set attributes defining path components which will be assembled in the document

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -229,11 +229,11 @@ See the following table to match the Helm chart versions with Infinite Scale rel
 | Works with Infinite Scale Versions
 
 | {helm_tab_1_tab_text}
-| 3.0.0-rc.4
+| 3.0.0
 
 ifdef::use_helm_tab_2[]
 | {helm_tab_2_tab_text}
-| 3.0.0-alpha.1
+| 3.0.0
 endif::[]
 
 ifdef::use_helm_tab_3[]


### PR DESCRIPTION
to be merged after https://github.com/owncloud/ocis-charts/pull/303 and when 0.3.0 tag is created on the helm chart repo
