### PR TITLE
Fixes Helm Charts Part ONE

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -50,14 +50,14 @@ asciidoc:
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
     # note that tab 2 always contains the actual release and tab 3 the former
     helm_tab_1: 'master'
-    helm_tab_2: 'v0.2.0'
+    helm_tab_2: 'v0.3.0'
     helm_tab_3: 'v0.1.0'
 
     # helm_tab_x_tab_text will be used as tab text shown for tab_x
     # note that tab 2 always contains the actual release and tab 3 the former
     helm_tab_1_tab_text: 'latest'
     helm_tab_2_tab_text: '0.3.0'
-    helm_tab_3_tab_text: '0.2.0'
+    helm_tab_3_tab_text: '0.1.0'
 
     # set attributes defining path components which will be assembled in the document
     secrets: 'deployment/container/orchestration/orchestration.adoc#define-secrets'

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -242,7 +242,7 @@ ifdef::use_helm_tab_3[]
 endif::[]
 |===
 
-Note that Helm Chart Version `0.2.0` was a necessary intermediate for Infinite Scale `3.0.0-alpha.1` only and is not listed with a working Infinite Scale version therefore.
+Note that Helm Chart Version `0.2.0` was a necessary intermediate for Infinite Scale `3.0.0-alpha.1` only and is therefore not listed with a working Infinite Scale version.
 
 === Breaking Changes
 

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -223,7 +223,7 @@ See the following table to match the Helm chart versions with Infinite Scale rel
 
 // this table needs manual update on the "works" rows when a new Helm chart release is published
 
-[width="65%",cols="~,~",options="header"]
+[width="60%",cols="~,~",options="header"]
 |===
 | Helm Chart Version
 | Works with Infinite Scale Versions
@@ -241,6 +241,8 @@ ifdef::use_helm_tab_3[]
 | 2.0.0
 endif::[]
 |===
+
+Note that Helm Chart Version `0.2.0` was a necessary intermediate for Infinite Scale `3.0.0-alpha.1` only and is not listed with a working Infinite Scale version therefore.
 
 === Breaking Changes
 

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/breaking-changes.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/breaking-changes.adoc
@@ -1,5 +1,6 @@
 = Helm Chart Breaking Changes
 :toc: right
+:description: Here you will find all breaking changes that come along with different Helm Chart releases. Note that all changes apply when going from one release to another.
 
 ////
 Note that there is only this one master file for all breaking changes.
@@ -12,8 +13,29 @@ For each breaking changes block you need:
 ** Double check the orchestration.adoc file if things need to be adapted (in section breaking changes)
 ////
 
+== Introduction
+
+{description}
+
+[id=0.3.0]
+== Chart Version: 0.3.0
+
+* `services.storageusers.storageBackend.driverConfig.s3ng.secretKey` and +
+ `services.storageusers.storageBackend.driverConfig.s3ng.accessKey` +
+have been deprecated. +
+Please set them via the `secretRefs.s3CredentialsSecretRef` secret instead.
+
+* If you had set `services.web.config.disableFeedbackLink` = `true`, you need to replace it by + 
+`services.web.config.feedbackLink.enabled` = `false`
+
+* In order to persist the instance logo that can be changed via the Web UI, +
+`services.web.persistence.enabled` must be set to `false`. +
+In prior releases the web frontend did not have any persistence.
+
 [id=0.2.0]
 == Chart Version: 0.2.0
+
+Note that Helm Chart Version `0.2.0` was a necessary intermediate for Infinite Scale `3.0.0-alpha.1` only and is listed for completion of breaking changes.
 
 Version 0.2.0 of the Helm Chart introduces some changes compared to version 0.1.0 with respect to the value names which align the service/app names at various places (values file, YAML files, directories).
 


### PR DESCRIPTION
References: #521 (Add Helm Chart Breaking changes (if any) )

THIS IS PART ONE OF (at least) TWO or more and fixes the following:

* Set the correct HC version (0.1.0 instead of 0.2.0, falsly changed in #519 by me)
* Add a description why 0.2.0 is in breaking changes but not available as supported release
* Add a Breaking Change section for 0.3.0
* Add some content for 0.3.0 <-- This is not finished but the rest of the PR needs merging

To finish Helm Charts, we need to wait until all available breaking changes are known which is WIP atm, see the referenced issue.

@wkloucek @micbar fyi