### PR TITLE
Release Infinite Scale 3.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -15,7 +15,7 @@ asciidoc:
     # used in partials/env-and-yaml.adoc for all services, based on releases
     # define to use tabs, the first tab is always active (master)
     use_service_tab_2: true  # set to any value if tab 2 should be shown
-    use_service_tab_3:       # set to any value if tab 3 should be shown
+    use_service_tab_3: true  # set to any value if tab 3 should be shown
 
     # used in orchestration.adoc for helm charts
     # define to use tabs, the first tab is always active (master)
@@ -25,27 +25,27 @@ asciidoc:
     # service_tab_x will be used to assemble the url accessing the link for the services
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1: 'docs' # do not change, the docs branch contains changes of master
-    service_tab_2: 'docs-stable-2.0'
-    service_tab_3: 'docs-stable-3.0'
+    service_tab_2: 'docs-stable-3.0'
+    service_tab_3: 'docs-stable-2.0'
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
     # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1_tab_text: 'latest'
-    service_tab_2_tab_text: '2.0.0'
-    service_tab_3_tab_text: '3.0.0'
+    service_tab_2_tab_text: '3.0.0'
+    service_tab_3_tab_text: '2.0.0'
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1: 'master'
-    compose_tab_2: 'v2.0.0'
-    compose_tab_3: 'v3.0.0'
+    compose_tab_2: 'v3.0.0'
+    compose_tab_3: 'v2.0.0'
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1_tab_text: 'latest'
-    compose_tab_2_tab_text: '2.0.0'
-    compose_tab_3_tab_text: '3.0.0'
+    compose_tab_2_tab_text: '3.0.0'
+    compose_tab_3_tab_text: '2.0.0'
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
     # note that tab 2 always contains the actual release and tab 3 the former

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -103,9 +103,9 @@ ifdef::use_service_tab_2[]
 {composer-url}{compose_tab_2}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
 
 Using git version name: `{compose_tab_2}`
---
 endif::[]
-ifdef::use_servicetab_3[]
+--
+ifdef::use_service_tab_3[]
 {compose_tab_3_tab_text}::
 +
 --

--- a/modules/ROOT/pages/deployment/services/_special-envvar.adoc
+++ b/modules/ROOT/pages/deployment/services/_special-envvar.adoc
@@ -1,6 +1,6 @@
 ////
 special envvar are maintained manually as they cant be gathered by a automated process in the ocis repo.
-these envvars are rarely changed
+these envvars are rarely changed.
 when a new ocis version is set, we only need to change the reference (tag) at the caller but not the content
 when a content is created, we can fix this here and in env-vars-special-scope.adoc
 ////
@@ -35,6 +35,9 @@ tag::service_tab_2[]
 
 | `OCIS_EXCLUDE_RUN_SERVICES`
 | A comma-separated list of service names. Will start all default services except of the ones listed. Has no effect when `OCIS_RUN_SERVICES` is set.
+
+| `OCIS_ADD_RUN_SERVICES`
+| A comma-separated list of service names. Will add the listed services to the default configuration. Has no effect when `OCIS_RUN_SERVICES` is set. Note that one can add services not started by the default list and exclude services from the default list by using both envvars at the same time.
 |===
 
 Note to get the current list of services started by default, you need to run `ocis server` without restriction which services to load and afterwards `ocis list`.

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -6,7 +6,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -6,7 +6,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
@@ -6,7 +6,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -6,7 +6,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -6,7 +6,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -8,7 +8,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/s-list/webfinger.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/webfinger.adoc
@@ -7,7 +7,7 @@
 
 // remember to REMOVE the corresponding tab if a new ocis release will be published
 
-:no_second_tab: true
+// :no_second_tab: true
 :no_third_tab: true
 
 == Introduction

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -9,9 +9,12 @@ Print a dependent explanation line:
 
 Conditional tab printing, example:
 
-* no_second_tab = based on first appearance of the service
-  defined via the service, must overrule service tab. If there is no second, there is also no third
+* no_second_tab = based on first appearance of the service (defined in a service),
+  must overrule service tab. If there is no second, there is also no third.
+
 * use_service_tab_2 = release based (defined in antora.yaml)
+
+*   Note to make a tab hidden by no_xxx_tab showing up again, just comment it.
 
 The included deprecation file just has an attribute necessary for rendering deprecations.
 This is necessary as attributes that are defined INSIDE a tabset will not get recognized, attributes need to be defined OUTSIDE the tabset definition. example content:


### PR DESCRIPTION
This PR makes the documentation 3.0.0 ready.

Note that an additional PR is in work in the ocis repo to fix content in adoc tables.

@micbar fyi

Note that there is more or less no content change but definitions or comments only.
Content added is copy/paste from an existing one.

A language review is technicall not necessary.
A local build renders fine.