### PR TITLE
Migration: add Automatic Role Assignments to the list

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -39,17 +39,11 @@ configured in different ways. The `PROXY_ROLE_ASSIGNMENT_DRIVER` environment var
 setting in the `role_assignment` section of the configuration file) selects which mechanism to use for
 the automatic role assignment.
 
-When set to `default`, all users that do not have a role assigned at the time of their first login will
-get the role 'user' assigned. (This is also the default behavior if `PROXY_ROLE_ASSIGNMENT_DRIVER`
-is unset.
+* When `PROXY_ROLE_ASSIGNMENT_DRIVER` is set to `default`, all users that do not have a role assigned at the time of their first login will get the role 'user' assigned. (This is also the default behavior if `PROXY_ROLE_ASSIGNMENT_DRIVER` is unset.
 
-When `PROXY_ROLE_ASSIGNMENT_DRIVER` is set to `oidc` the role assignment for a user will happen
-based on the values of an OpenID Connect Claim of that user. The name of the OpenID Connect Claim to
-be used for the role assignment can be configured via the `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`
-environment variable. It is also possible to define a mapping of claim values to role names defined
-in ownCloud Infinite Scale via a `yaml` configuration. See the following `proxy.yaml` snippet for an
-example.
-
+* When `PROXY_ROLE_ASSIGNMENT_DRIVER` is set to `oidc`, the role assignment for a user will happen based on the values of an OpenID Connect Claim of that user. The name of the OpenID Connect Claim to be used for the role assignment can be configured via the `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM` environment variable. It is also possible to define a mapping of claim values to role names defined in ownCloud Infinite Scale via a `yaml` configuration. See the following `proxy.yaml` snippet for an example.
++
+--
 [source,yaml]
 ----
 role_assignment:
@@ -99,6 +93,7 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
 - role_name: guest
   claim_value: ocisGuest
 ----
+--
 
 == Recommendations for Production Deployments
 

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -52,7 +52,7 @@ graph:
     id: <your UUID4 string>
 ----
 
-- OR setting `GRAPH_APPLICATION_ID` as an xref:deployment/general/general-info.adoc#configuration-rules[ENV variable,window=_blank].
+- or by setting `GRAPH_APPLICATION_ID` as an xref:deployment/general/general-info.adoc#configuration-rules[ENV variable,window=_blank].
 
 NOTE: This environment variable will be defined automatically when installing a fresh instance and running xref:deployment/general/ocis-init.adoc[ocis init] to initialize it.
 --

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -18,6 +18,7 @@ IMPORTANT: Before starting any upgrade, make a xref:maintenance/b-r/backup.adoc[
 === Notable Changes Requiring Manual Intervention
 
 * A new `GRAPH_APPLICATION_ID` environment variable has been added that must be populated.
+* Automatic Role Assignments have been introduced that need a settings review.
 * The search index needs to be deleted as the layout has been changed.
 * The xref:prerequisites/prerequisites.adoc#backend-for-metadata[metadata backend] has changed.
 * The xref:deployment/container/orchestration/orchestration.adoc#using-helm-charts-with-infinite-scale[Helm Chart] has been upgraded.
@@ -55,6 +56,8 @@ graph:
 
 NOTE: This environment variable will be defined automatically when installing a fresh instance and running xref:deployment/general/ocis-init.adoc[ocis init] to initialize it.
 --
+
+. xref:deployment/services/s-list/proxy.adoc#automatic-role-assignments[Automatic Role Assignments] have been introduced that need a settings review. All users that do not have a role assigned at the time of their first login will get the role 'user' assigned if the default of the environment variable `PROXY_ROLE_ASSIGNMENT_DRIVER` is used. The assignment can be changed based to the values of an OpenID Connect Claim of that user using a different setting. See the referenced documentation for more details.
 
 . Delete the full search index. For details about the used path see:  xref:deployment/general/general-info.adoc#default-paths[OCIS_BASE_DATA_PATH,window=_blank]:
 +

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -42,7 +42,7 @@ docker pull owncloud/ocis:3.0.0
 . Manually add the xref:{s-path}/graph.adoc#environment-variables[GRAPH_APPLICATION_ID,window=_blank] to the config. The value can be any text string using characters defined by the https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID definition] and is preferably a UUID4 string.
 +
 --
-- Either edit the xref:deployment/general/general-info.adoc#configuration-file-naming[ocis.yaml] (preferred and recommended) by adding:
+- Either edit the xref:deployment/general/general-info.adoc#configuration-file-naming[ocis.yaml,window=_blank] (preferred and recommended) by adding:
 +
 [source,yaml]
 ----
@@ -52,12 +52,12 @@ graph:
     id: <your UUID4 string>
 ----
 
-- OR setting `GRAPH_APPLICATION_ID` as an xref:deployment/general/general-info.adoc#configuration-rules[ENV variable].
+- OR setting `GRAPH_APPLICATION_ID` as an xref:deployment/general/general-info.adoc#configuration-rules[ENV variable,window=_blank].
 
 NOTE: This environment variable will be defined automatically when installing a fresh instance and running xref:deployment/general/ocis-init.adoc[ocis init] to initialize it.
 --
 
-. xref:deployment/services/s-list/proxy.adoc#automatic-role-assignments[Automatic Role Assignments] have been introduced that need a settings review. All users that do not have a role assigned at the time of their first login will get the role 'user' assigned if the default of the environment variable `PROXY_ROLE_ASSIGNMENT_DRIVER` is used. The assignment can be changed based to the values of an OpenID Connect Claim of that user using a different setting. See the referenced documentation for more details.
+. xref:deployment/services/s-list/proxy.adoc#automatic-role-assignments[Automatic Role Assignments,window=_blank] have been introduced that need a settings review. All users that do not have a role assigned at the time of their first login will get the role 'user' assigned if the default of the environment variable `PROXY_ROLE_ASSIGNMENT_DRIVER` is used. The assignment can be changed based to the values of an OpenID Connect Claim of that user using a different setting. See the referenced documentation for more details.
 
 . Delete the full search index. For details about the used path see:  xref:deployment/general/general-info.adoc#default-paths[OCIS_BASE_DATA_PATH,window=_blank]:
 +
@@ -71,7 +71,7 @@ NOTE: The empty search index will be recreated space by space when something cha
 --
 
 . Changes in the Helm Charts +
-For any breaking changes that come along with Helm Charts, see the xref:deployment/container/orchestration/orchestration.adoc#breaking-changes[Breaking Changes] documentation.
+For any breaking changes that come along with Helm Charts, see the xref:deployment/container/orchestration/orchestration.adoc#breaking-changes[Breaking Changes,window=_blank] documentation.
 
 . Messagepack Readme First
 +


### PR DESCRIPTION
Referencing: https://github.com/owncloud/ocis/pull/6475 (OIDC authentication using authelia fails with no roles)

The referenced issue highlighted that `Automatic Role Assignments` need a review when upgrading to 3.0

* Add `Automatic Role Assignments` to the upgrade list
* Open linked documents in new tabs
* Improve readbility in the referenced proxy document

Note that no change is necessary in the doc release notes as we already point to this migration guide.

@micbar @rhafer fyi  