### PR TITLE
CLI Resume Postprocessing

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -63,9 +63,9 @@ Once the custom service has finished its work, it should send an event of the ty
 
 == CLI Commands
 
-=== Resume Postprocessing
+=== Resume Post-Processing
 
-If postprocessing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system admin can instead run a CLI command to retry the failed upload which is a two step process:
+If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system administrator can instead run a CLI command to retry the failed upload which is a two step process:
 
 * First, find the upload ID of the failed upload.
 +
@@ -74,7 +74,7 @@ If postprocessing fails in one step due to an unforseen error, current uploads w
 ocis storage-users uploads list
 ----
 
-* Then use the restart command to resume postprocessing of the ID selected.
+* Then use the restart command to resume post-processing of the ID selected.
 +
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -61,6 +61,26 @@ Once the custom service has finished its work, it should send an event of the ty
 * `abort` (abort post-processing, keep the file) and 
 * `continue` (continue post-processing, this is the success case).
 
+== CLI Commands
+
+=== Resume Postprocessing
+
+If postprocessing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system admin can instead run a CLI command to retry the failed upload which is a two step process:
+
+* First, find the upload ID of the failed upload.
++
+[source,bash]
+----
+ocis storage-users uploads list
+----
+
+* Then use the restart command to resume postprocessing of the ID selected.
++
+[source,bash]
+----
+ocis postprocessing restart -u <uploadID>
+----
+
 == Storing
 
 The `postprocessing` service needs to store some metadata about uploads to be able to orchestrate post-processing. When running in single binary mode, the default in-memory implementation will be just fine. In distributed deployments it is recommended to use a persistent store, see below for more details.

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -55,6 +55,6 @@ OPTIONS:
    --help, -h              show help
 ----
 
-== Resume Postprocessing
+== Resume Post-Processing
 
-If postprocessing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system admin can instead run a xref:{s-path}/postprocessing.adoc#resume-postprocessing[CLI command] to retry the failed upload.
+If post-processing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system administrator can instead run a xref:{s-path}/postprocessing.adoc#resume-postprocessing[CLI command] to retry the failed upload.

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -54,3 +54,7 @@ OPTIONS:
    --node value, -n value  Path to or ID of the node to inspect
    --help, -h              show help
 ----
+
+== Resume Postprocessing
+
+If postprocessing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system admin can instead run a xref:{s-path}/postprocessing.adoc#resume-postprocessing[CLI command] to retry the failed upload.

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -57,4 +57,4 @@ OPTIONS:
 
 == Resume Post-Processing
 
-If post-processing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system administrator can instead run a xref:{s-path}/postprocessing.adoc#resume-postprocessing[CLI command] to retry the failed upload.
+If post-processing fails in one step due to an unforseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system administrator can instead run a xref:{s-path}/postprocessing.adoc#resume-post-processing[CLI command] to retry the failed upload.


### PR DESCRIPTION
Fixes: #534 (ResumePostprocessing Event (CLI) )

Adding a new CLI command that allows to resume an errored postprocessing step.
