### PR TITLE
Fix a broken link

### DIFF
--- a/modules/ROOT/pages/deployment/services/deployment-considerations.adoc
+++ b/modules/ROOT/pages/deployment/services/deployment-considerations.adoc
@@ -3,7 +3,7 @@
 :description: When using container orchestration, some considerations should be taken into account when deploying services with respect to scaling.
 
 :nats-clustering-url: https://docs.nats.io/running-a-nats-service/configuration/clustering
-:nats-helm-url: https://docs.nats.io/running-a-nats-service/nats-kubernetes/helm-chart
+:nats-helm-url: https://docs.nats.io/running-a-nats-service/nats-kubernetes/helm-charts
 
 == Introduction
 


### PR DESCRIPTION
The link was missing a character... 🤦‍♂️ 

So far the only broken link in the docs-ocis repo found using a broken link checker 😃
