### PR TITLE
Some service text cleanups

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/app-provider.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/app-provider.adoc
@@ -1,6 +1,6 @@
 = App Provider Service Configuration
 :toc: right
-:description: App providers represent apps, if the app is not able to register itself. Currently there is only the CS3org WOPI server app provider.
+:description: App providers represent apps that are not able to register themselves. Currently there is only the CS3org WOPI server app provider.
 
 :service_name: app-provider
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -1,6 +1,6 @@
 = Frontend Service Configuration
 :toc: right
-:description: The frontend service translates various ownCloud related HTTP APIs to CS3 requests.
+:description: The frontend service translates various ownCloud-related HTTP APIs to CS3 requests.
 
 :service_name: frontend
 

--- a/modules/ROOT/pages/deployment/services/s-list/idm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idm.adoc
@@ -1,6 +1,6 @@
 = IDM Service Configuration
 :toc: right
-:description: The Infinite Scale IDM service provides a minimal LDAP Service for Infinite Scale. It is started as part of the runtime and serves as a central place for storing user and group information.
+:description: The Infinite Scale IDM service provides a minimal LDAP service for Infinite Scale. It is started as part of the runtime and serves as a central place for storing user and group information.
 
 :service_name: idm
 

--- a/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
@@ -1,6 +1,6 @@
 = Invitations Service Configuration
 :toc: right
-:description: The Infinite Scale invitations service provides an Invitation Manager that can be used to invite external users, aka guests, to an organization.
+:description: The Infinite Scale invitations service provides an invitation manager that can be used to invite external users, aka guests, to an organization.
 
 :service_name: invitations
 

--- a/modules/ROOT/pages/deployment/services/s-list/nats.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/nats.adoc
@@ -1,6 +1,6 @@
 = NATS Service Configuration
 :toc: right
-:description: The nats service is the event broker of the system. It distributes events among all other services and enables other services to communicate asynchronously.
+:description: The NATS service is the event broker of the system. It distributes events among all other services and enables other services to communicate asynchronously.
 
 :service_name: nats
 

--- a/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocdav.adoc
@@ -1,6 +1,6 @@
 = OCDAV Service Configuration
 :toc: right
-:description: The ocDAV service is responsible for translating ownCloud flavoured WebDAV into CS3 API calls. Note that previews (thumbnails) are provided by the xref:{s-path}/webdav.adoc[WebDAV service].
+:description: The ocDAV service is responsible for translating ownCloud-flavored WebDAV into CS3 API calls. Note that previews (thumbnails) are provided by the xref:{s-path}/webdav.adoc[WebDAV service].
 
 // references https://github.com/owncloud/ocis/pull/3864 ([docs-only] add PROPFIND sequence diagram examples)
 // also see: https://owncloud.dev/architecture/protocol-changes/ 

--- a/modules/ROOT/pages/deployment/services/s-list/web.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/web.adoc
@@ -1,6 +1,6 @@
 = Web Service Configuration
 :toc: right
-:description: The web service embeds and serves the static files for the Infinite Scale Web Client.
+:description: The web service embeds and serves the static files for the Infinite Scale web client.
 
 :service_name: web
 

--- a/modules/ROOT/pages/deployment/services/s-list/webdav.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/webdav.adoc
@@ -1,6 +1,6 @@
 = WebDAV Service Configuration
 :toc: right
-:description: The webdav service, like the ocdav service, provides a HTTP API following the webdav protocol.
+:description: The WebDAV service, like the ocdav service, provides a HTTP API following the WebDAV protocol.
 
 :service_name: webdav
 

--- a/modules/ROOT/pages/deployment/services/services.adoc
+++ b/modules/ROOT/pages/deployment/services/services.adoc
@@ -20,7 +20,7 @@ The following services have been introduced with the releases listed:
 
 === Infinite Scale 3.0.0
 
-[width="100%",cols="20%,~",options="header"]
+[width="100%",cols="25%,~",options="header"]
 |===
 | Service
 | Description
@@ -55,7 +55,7 @@ The following services have been introduced with the releases listed:
 
 === Infinite Scale 2.0.0
 
-[width="100%",cols="20%,~",options="header"]
+[width="100%",cols="25%,~",options="header"]
 |===
 | Service
 | Description


### PR DESCRIPTION
References: #546 (Add table with service per release)

* Some service texts have been corrected in the summary page (see referenced PR) but not in the service pages. This is now in sync again, taking the corrections of course 😄
* The first table column in listing the services needed to be extended a bit to avoid line breaks