### PR TITLE
Add apache req-resp limits

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -241,6 +241,8 @@ Open a web browser, navigate to your Infinite Scale URL `\https://{ocis_url}` an
 
 == Apache as Reverse Proxy
 
+Note that you need to have the modules `mod_rewrite`, `mod_ssl` and `mod_Proxy` enabled.
+
 Always run a configuration test when updating your Apache configuration with:
 
 [source,bash]

--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -241,7 +241,7 @@ Open a web browser, navigate to your Infinite Scale URL `\https://{ocis_url}` an
 
 == Apache as Reverse Proxy
 
-Note that you need to have the modules `mod_rewrite`, `mod_ssl` and `mod_Proxy` enabled.
+Note that you need to have the modules `mod_rewrite`, `mod_ssl` and `mod_proxy` enabled.
 
 Always run a configuration test when updating your Apache configuration with:
 

--- a/modules/ROOT/partials/deployment/apache_proxy_example.adoc
+++ b/modules/ROOT/partials/deployment/apache_proxy_example.adoc
@@ -16,14 +16,17 @@
   <VirtualHost *:443>
     ServerName {ocis_url}
 
+    # OIDC Tokens in headers are quite large and can exceed default limits of reverse proxies
+    LimitRequestFieldSize 131072 # 128k
+
     SSLProxyEngine on
     SSLProxyVerify none
     SSLProxyCheckPeerCN off
     SSLProxyCheckPeerName off
     SSLProxyCheckPeerExpire off
 
-    ProxyPass / http://localhost:{ocis_port}/
-    ProxyPassReverse / http://localhost:{ocis_port}/
+    ProxyPass / http://localhost:{ocis_port}/ responsefieldsize=131072 # 128k
+    ProxyPassReverse / http://localhost:{ocis_port}/ responsefieldsize=131072 #128k
 
     #important, otherwise 400 errors from idp
     ProxyPreserveHost on


### PR DESCRIPTION
This adds configuration to the apache config to cover large headers for reverse proxying.

We have done the same for nginx, see [Finalize the nginx Configuration](https://doc.owncloud.com/ocis/next/depl-examples/bare-metal.html#finalize-the-nginx-configuration).

Setting this to draft as I would like to get a review if the settings are correct. If there is an unmentioned apache specialist that could do a review pls invite.