### PR TITLE
Add Server-Sent Events to userlog service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -37,7 +37,7 @@ The `userlog` service provides an API to retrieve configured events. For now, th
 
 == Subscribing
 
-The `userlog` service provides an `/sse` (Server-Sent Events) endpoint to be informed by the server when an event happens. See https://medium.com/yemeksepeti-teknoloji/what-is-server-sent-events-sse-and-how-to-implement-it-904938bffd73[What is Server-Sent Events, window=_blank] for a simple introduction and examples to server sent events. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that SSE have the limitation of six open connections per browser which can be reached if one has opened various tabs of the WebUI pointing to the same Infinite Scale Instance.
+The `userlog` service provides an `/sse` (Server-Sent Events) endpoint to be informed by the server when an event happens. See https://medium.com/yemeksepeti-teknoloji/what-is-server-sent-events-sse-and-how-to-implement-it-904938bffd73[What is Server-Sent Events, window=_blank] for a simple introduction and examples to server-sent events. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that SSE have the limitation of six open connections per browser which can be reached if one has opened various tabs of the Web UI pointing to the same Infinite Scale instance.
 
 == Deleting
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -35,6 +35,10 @@ Currently, the configuration which user-related events are of interest is hard-c
 
 The `userlog` service provides an API to retrieve configured events. For now, this API is mostly following the {oc10-api-url}[ownCloud Server notification GET API, window=_blank].
 
+== Subscribing
+
+The `userlog` service provides an `/sse` (Server-Sent Events) endpoint to be informed by the server when an event happens. See https://medium.com/yemeksepeti-teknoloji/what-is-server-sent-events-sse-and-how-to-implement-it-904938bffd73[What is Server-Sent Events, window=_blank] for a simple introduction and examples to server sent events. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that SSE have the limitation of six open connections per browser which can be reached if one has opened various tabs of the WebUI pointing to the same Infinite Scale Instance.
+
 == Deleting
 
 To delete events for an user, use a `DELETE` request to:


### PR DESCRIPTION
Fixes: #553 (Add SSE in the userlog service)

Add a description to the userlog service for Server-Sent Events (SSE).

