### PR TITLE
Adding warnings for messagepack migration and third party Helm Charts

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -207,15 +207,13 @@ helm version
 ----
 --
 
-== Using Helm Charts with Infinite Scale
+== Using Our Helm Charts with Infinite Scale
 
 NOTE: The Helm chart is still in an experimental phase and has not yet been published on a Helm chart repository. For your convenience, ownCloud provides an {ocis-helm-charts-url}[ocis-charts] git repository.
 
 NOTE: ownCloud will publish updated data when new Helm chart releases become available. This information will be available in additional tabs in corresponding sections. Note that two Helm chart stable versions will be documented beside the development version.
 
 NOTE: When defining your own Helm charts, consider that, if you're using config overrides in your yaml definitions, a service does not get redefined in the override again. Multiple definitions can cause chart issues that are hard to identify.
-
-WARNING: There may be Helm Charts provided by other sources than ownCloud. These third party Helm Charts may or may not work and ownCloud can and will not give any hints, notes, tips or support.
 
 The `values.yaml` file provided by ownCloud uses generic configuration. You can customize this configuration with your own values, for example for different setups or sizings. This should be done by using your own `values.yaml` file at a different location which will _overwrite_ or _add_ content to the provided one. While not mandatory, the identical file name of `values.yaml` follows the convention of Helm. When it comes to security sensitive data like secrets, such data is usually _not_ added in the overwrite-values file for security reasons. In such a case, you apply secrets via command from a secrets file.
 

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -215,6 +215,8 @@ NOTE: ownCloud will publish updated data when new Helm chart releases become ava
 
 NOTE: When defining your own Helm charts, consider that, if you're using config overrides in your yaml definitions, a service does not get redefined in the override again. Multiple definitions can cause chart issues that are hard to identify.
 
+WARNING: There may be Helm Charts provided by other sources than ownCloud. These third party Helm Charts may or may not work and ownCloud can and will not give any hints, notes, tips or support.
+
 The `values.yaml` file provided by ownCloud uses generic configuration. You can customize this configuration with your own values, for example for different setups or sizings. This should be done by using your own `values.yaml` file at a different location which will _overwrite_ or _add_ content to the provided one. While not mandatory, the identical file name of `values.yaml` follows the convention of Helm. When it comes to security sensitive data like secrets, such data is usually _not_ added in the overwrite-values file for security reasons. In such a case, you apply secrets via command from a secrets file.
 
 === Supported Infinite Scale Versions

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -97,6 +97,8 @@ IMPORTANT: Though you can stay at the xattrs backend, it is highly recommended t
 To enable migration, remove any of the manually configured environment variables listed above. This can be also done in a later step but it is highly recommended to migrate now.
 
 NOTE: If you want to prevent the migration for now, set `OCIS_DECOMPOSEDFS_METADATA_BACKEND=xattrs`.
+
+IMPORTANT: Note that the migration of the metadata backend to messagepack is a one way process and can not be reverted except via a full restore. 
 --
 
 . Migrate Metadata to Messagepack: +

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -98,7 +98,7 @@ To enable migration, remove any of the manually configured environment variables
 
 NOTE: If you want to prevent the migration for now, set `OCIS_DECOMPOSEDFS_METADATA_BACKEND=xattrs`.
 
-IMPORTANT: Note that the migration of the metadata backend to messagepack is a one way process and can not be reverted except via a full restore. 
+IMPORTANT: Note that the migration of the metadata backend to messagepack is a one-way process and can not be reverted except via a full restore. 
 --
 
 . Migrate Metadata to Messagepack: +


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/issues/6722 (Infinite loop when trying to login)

* Adding an explicit warning that messagepack migration is one way. Note that we have a statement on top of the document stating that upgrades are always forward only, adding this makes this more prominent for this case. Backwards only with a full restore.
* ~Added an explicit warning that third party Helm Charts are outside of any ownCloud support or responisibility.~
--> adapted the section headline instead