### PR TITLE
Add CORS to Knowledgebase

### DIFF
--- a/modules/ROOT/pages/additional-information/knowledge-base.adoc
+++ b/modules/ROOT/pages/additional-information/knowledge-base.adoc
@@ -39,4 +39,4 @@ When looking to the xref:deployment/container/orchestration/orchestration.adoc#d
 ],
 ----
 
-To complete this setup, you also must do adaptions in Keycloak. See the Keykloak https://www.keycloak.org/docs/latest/server_admin/index.html#con-basic-settings_server_administration_guide[Server Administration Guide] in paragraph btn:[Web Origins] for more details.
+To complete this setup, you also must configure Keycloak. See the Keykloak https://www.keycloak.org/docs/latest/server_admin/index.html#con-basic-settings_server_administration_guide[Server Administration Guide] in paragraph btn:[Web Origins] for more details.

--- a/modules/ROOT/pages/additional-information/knowledge-base.adoc
+++ b/modules/ROOT/pages/additional-information/knowledge-base.adoc
@@ -30,7 +30,7 @@ If two-factor authentication is needed for Infinite Scale, you can use Keycloak 
 
 == CORS Settings with Keycloak
 
-When looking to the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples], in particular the file `ocis_keycloak/config/keycloak/ocis-realm.dist.json`, you will find the follfowing setting responsible for CORS inside Infnite Scale:
+When looking at the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples], in particular the file `ocis_keycloak/config/keycloak/ocis-realm.dist.json`, you will find the following setting responsible for CORS inside Infnite Scale:
 
 [source,yaml]
 ----

--- a/modules/ROOT/pages/additional-information/knowledge-base.adoc
+++ b/modules/ROOT/pages/additional-information/knowledge-base.adoc
@@ -27,3 +27,16 @@ If two-factor authentication is needed for Infinite Scale, you can use Keycloak 
 * See https://www.keycloak.org/docs/latest/server_admin/#one-time-password-otp-policies[Two-Factor Authentication via OTP Policies,window=_blank] for more details and guidance.
 * For use with email, refer to https://medium.com/@mesutpiskin/two-factor-authentication-via-email-in-keycloak-custom-auth-spi-935bbb3952a8[Two-Factor Authentication via Email,window=_blank].
 * See https://www.n-k.de/2020/12/keycloak-2fa-sms-authentication.html[Two-Factor Authentication with SMS,window=_blank] for more details and guidance on usage with SMS.
+
+== CORS Settings with Keycloak
+
+When looking to the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples], in particular the file `ocis_keycloak/config/keycloak/ocis-realm.dist.json`, you will find the follfowing setting responsible for CORS inside Infnite Scale:
+
+[source,yaml]
+----
+"webOrigins": [ 
+  "https://ocis.owncloud.test" 
+],
+----
+
+To complete this setup, you also must do adaptions in Keycloak. See the Keykloak https://www.keycloak.org/docs/latest/server_admin/index.html#con-basic-settings_server_administration_guide[Server Administration Guide] in paragraph btn:[Web Origins] for more details.


### PR DESCRIPTION
Fixes: https://github.com/owncloud/ocis/issues/5466 CORS policy while getting token information from Keycloak

This adds info that CORS also needs to be configured in Keycloak.

@micbar FYI