### PR TITLE
Mini fix to repair a link

### DIFF
--- a/modules/ROOT/pages/additional-information/kb-documents/fail2ban-protect-login.adoc
+++ b/modules/ROOT/pages/additional-information/kb-documents/fail2ban-protect-login.adoc
@@ -7,7 +7,7 @@
 
 {description} Setting up {fail2ban_url}[Fail2ban] parsing logs can be a possibility but is subject to a concrete setup. Note that this document gives an overview and assumes that you are familiar with Fail2ban.
 
-NOTE: The content has been extracted and adapted from xref:{oc-central-url}[Central], our community page, and is without any claim for correctness and eligibility for support, though feedback is welcomed.
+NOTE: The content has been extracted and adapted from {oc-central-url}[Central], our community page, and is without any claim for correctness and eligibility for support, though feedback is welcomed.
 
 == Prerequisites
 


### PR DESCRIPTION
This is a mini fix in the fail2ban documentation to fix a link.
`xref` was accidentially assigned and is now removed to make the link working.