### PR TITLE
Fix ZSH shell command

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -147,7 +147,7 @@ ocis server & disown -h
 .ZSH
 [source,bash]
 ----
-ocis server & disown $!
+ocis server & disown %%
 ----
 
 See the respective shell documentation for how to manage processes respectively detach and re-attach sessions.


### PR DESCRIPTION
Fixes: #570 (Change the command for running the ocis in detached mode in case of ZSH shell for binary setup)

`disown` in zsh takes `job id` not the `process id` and `$!` gives `process id` so it does not work.
The system also logouts if the shell is terminated.
`%%` gives the `current job id` so this is used instead of `$!`