### PR TITLE
CLI command to roll back and roll forward decomposedFS migrations

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -36,16 +36,16 @@ If post-processing fails in one step due to an unforeseen error, current uploads
 
 Infinite Scale provides a xref:maintenance/commands/node-metadata.adoc[CLI command] with which you can inspect and manipulate node metadata.
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
 == Inspect and Repair Node Tree Sizes
 
 Infinite Scale provides a xref:maintenance/commands/node-tree-size.adoc[CLI command] with which you can inspect and repair node tree sizes. This command can be necessary in very rare cases where spaces or files are shown in the Web UI with a size not matching reality. For the repair option Infinite Scale must be shut down.
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
 == Roll Back / Roll Forward Decomposedfs Migrations
 
 Starting with Infinite Scale 3.1, a xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -34,49 +34,18 @@ If post-processing fails in one step due to an unforeseen error, current uploads
 
 == Inspect and Manipulate Node Metadata
 
-Infinite Scale provides a CLI command with which you can inspect and manipulate node metadata.
+Infinite Scale provides a xref:maintenance/commands/node-metadata.adoc[CLI command] with which you can inspect and manipulate node metadata.
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request of ownCloud support. 
-
-[source,bash]
-----
-ocis decomposedfs metadata
-NAME:
-   ocis decomposedfs metadata - cli tools to inspect and manipulate node metadata
-
-USAGE:
-   ocis decomposedfs metadata command [command options] [arguments...]
-
-COMMANDS:
-   dump     print the metadata of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.
-   get      print a specific attribute of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.
-   set      manipulate metadata of the given node. Binary attributes can be given hex encoded (prefix by '0x') or base64 encoded (prefix by '0s').
-   help, h  Shows a list of commands or help for one command
-
-OPTIONS:
-   --root value, -r value  Path to the decomposedfs
-   --node value, -n value  Path to or ID of the node to inspect
-   --help, -h              show help
-----
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
 
 == Inspect and Repair Node Tree Sizes
 
-Infinite Scale provides a CLI command with which you can inspect and repair node tree sizes. This command can be necessary in very rare cases where spaces or files are shown in the Web UI with a size not matching reality. For the repair option Infinite Scale must be shut down.
+Infinite Scale provides a xref:maintenance/commands/node-tree-size.adoc[CLI command] with which you can inspect and repair node tree sizes. This command can be necessary in very rare cases where spaces or files are shown in the Web UI with a size not matching reality. For the repair option Infinite Scale must be shut down.
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
 
-[source,bash]
-----
-NAME:
-   ocis decomposedfs check-treesize - cli tool to check the treesize metadata of a Space
+== Roll Back / Roll Forward Decomposedfs Migrations
 
-USAGE:
-   ocis decomposedfs check-treesize [command options] [arguments...]
+Starting with Infinite Scale 3.1, a xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
 
-OPTIONS:
-   --root value, -r value  Path to the root directory of the decomposedfs
-   --node value, -n value  Space ID of the Space to inspect
-   --repair                Try to repair nodes with incorrect treesize metadata. IMPORTANT: Only use this while ownCloud Infinite Scale is not running. (default: false)
-   --force                 Do not prompt for confirmation when running in repair mode. (default: false)
-   --help, -h              show help
-----
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 

--- a/modules/ROOT/pages/maintenance/commands/node-metadata.adoc
+++ b/modules/ROOT/pages/maintenance/commands/node-metadata.adoc
@@ -1,6 +1,6 @@
 = Inspect and Manipulate Node Metadata
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/maintenance/commands/node-metadata.adoc
+++ b/modules/ROOT/pages/maintenance/commands/node-metadata.adoc
@@ -1,0 +1,24 @@
+= Inspect and Manipulate Node Metadata
+
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+
+[source,bash]
+----
+ocis decomposedfs metadata
+NAME:
+   ocis decomposedfs metadata - cli tools to inspect and manipulate node metadata
+
+USAGE:
+   ocis decomposedfs metadata command [command options] [arguments...]
+
+COMMANDS:
+   dump     print the metadata of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.
+   get      print a specific attribute of the given node. String attributes will be enclosed in quotes. Binary attributes will be returned encoded as base64 with their value being prefixed with '0s'.
+   set      manipulate metadata of the given node. Binary attributes can be given hex encoded (prefix by '0x') or base64 encoded (prefix by '0s').
+   help, h  Shows a list of commands or help for one command
+
+OPTIONS:
+   --root value, -r value  Path to the decomposedfs
+   --node value, -n value  Path to or ID of the node to inspect
+   --help, -h              show help
+----

--- a/modules/ROOT/pages/maintenance/commands/node-tree-size.adoc
+++ b/modules/ROOT/pages/maintenance/commands/node-tree-size.adoc
@@ -1,6 +1,6 @@
 = Inspect and Repair Node Tree Sizes
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/maintenance/commands/node-tree-size.adoc
+++ b/modules/ROOT/pages/maintenance/commands/node-tree-size.adoc
@@ -1,0 +1,19 @@
+= Inspect and Repair Node Tree Sizes
+
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+
+[source,bash]
+----
+NAME:
+   ocis decomposedfs check-treesize - cli tool to check the treesize metadata of a Space
+
+USAGE:
+   ocis decomposedfs check-treesize [command options] [arguments...]
+
+OPTIONS:
+   --root value, -r value  Path to the root directory of the decomposedfs
+   --node value, -n value  Space ID of the Space to inspect
+   --repair                Try to repair nodes with incorrect treesize metadata. IMPORTANT: Only use this while ownCloud Infinite Scale is not running. (default: false)
+   --force                 Do not prompt for confirmation when running in repair mode. (default: false)
+   --help, -h              show help
+----

--- a/modules/ROOT/pages/maintenance/commands/rolling-back-and-forward.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rolling-back-and-forward.adoc
@@ -1,6 +1,6 @@
 = Roll Back / Roll Forward Decomposedfs Migrations
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
 It is important to disable clients and users logging in while any migration is in progress. To do so, start Infinite Scale with only two necessary services. The example uses the binary as base:
 

--- a/modules/ROOT/pages/maintenance/commands/rolling-back-and-forward.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rolling-back-and-forward.adoc
@@ -1,0 +1,88 @@
+= Roll Back / Roll Forward Decomposedfs Migrations
+
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and supervision of ownCloud support. 
+
+It is important to disable clients and users logging in while any migration is in progress. To do so, start Infinite Scale with only two necessary services. The example uses the binary as base:
+
+[source,bash]
+----
+OCIS_RUN_SERVICES="storage-users,nats" \
+ocis server
+----
+
+[source,bash]
+----
+NAME:
+   ocis migrate decomposedfs - run a decomposedfs migration
+
+USAGE:
+   ocis migrate decomposedfs [command options] [arguments...]
+
+OPTIONS:
+   --direction value, -d value  direction of the migration to run ('up' or 'down') (default: "up")
+   --migration value, -m value  ID of the migration to run
+   --root value, -r value       Path to the root directory of the decomposedfs
+   --list, -l                   Print a list of migrations incl. their state (default: false)
+   --help, -h                   show help
+----
+
+Example Command 1::
+
+[source,bash]
+----
+ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -l
+
++-----------+-----------+---------+
+| Migration |   State   | Message |
++-----------+-----------+---------+
+|      0001 | succeeded |         |
+|      0002 | succeeded |         |
+|      0003 | runagain  |         |
+|      0004 | succeeded |         |
+|      0005 | succeeded |         |
++-----------+-----------+---------+
+----
+
+Example Command 2::
+
+[source,bash]
+----
+ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -d down -m 0005
+
+2023-07-27T09:23:38+02:00 INF Running migration 0005... (down) line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:119 service=migrate
+2023-07-27T09:23:38+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/personal.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:78 root=/home/andre/.ocis/storage/users/ service=migrate
+2023-07-27T09:23:38+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/project.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:78 root=/home/andre/.ocis/storage/users/ service=migrate
+2023-07-27T09:23:38+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-user-id/some-admin-user-id-0000-000000000000.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:78 root=/home/andre/.ocis/storage/users/ service=migrate
+2023-07-27T09:23:38+02:00 INF done. line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:105 service=migrate
+2023-07-27T09:23:38+02:00 INF done line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:139 service=migrate
+----
+
+Example Command 3::
+
+[source,bash]
+----
+$ ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -l
+
++-----------+-----------+---------+
+| Migration |   State   | Message |
++-----------+-----------+---------+
+|      0001 | succeeded |         |
+|      0002 | succeeded |         |
+|      0003 | runagain  |         |
+|      0004 | succeeded |         |
+|      0005 | down      |         |
++-----------+-----------+---------+
+----
+
+Example Command 4::
+
+[source,bash]
+----
+ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -d up -m 0005
+
+2023-07-27T09:24:12+02:00 INF Running migration 0005... line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/migrator.go:119 service=migrate
+2023-07-27T09:24:12+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/personal.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:37 root=/home/andre/.ocis/storage/users/ service=migrate
+2023-07-27T09:24:12+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-type/project.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:37 root=/home/andre/.ocis/storage/users/ service=migrate
+2023-07-27T09:24:12+02:00 INF Fixing index format of /home/andre/.ocis/storage/users/indexes/by-user-id/some-admin-user-id-0000-000000000000.mpk line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:37 root=/home/andre/.ocis/storage/users/ service=migrate
+2023-07-27T09:24:12+02:00 INF done. line=/home/andre/src/owncloud/reva/pkg/storage/utils/decomposedfs/migrator/0005_fix_messagepack_space_index_format.go:66 service=migrate
+----


### PR DESCRIPTION
Fixes #574 (New ocis decomposedfs command)

* Add the new CLI command with an own page for the details
* Create for similar commands an own page that get linked, makes it easer to read

Note though I tried to make the pages themselves invisible to the content catalog (no clickable url) which could be done using an underscore in front of the filename, those files can only be included correctly but not xref'ed. We need xref to point to them...