### PR TITLE
Update userlog description

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -41,7 +41,14 @@ The `userlog` service provides an `/sse` (Server-Sent Events) endpoint to be inf
 
 == Posting
 
-The userlog service is able to store global messages that will be displayed in the Web UI to all users. These messages can only be activated and deleted by users with the `admin` role but not by ordinary users. If a user deletes the message in the Web UI, it reappears on reload. Global messages use the endpoint `/ocs/v2.php/apps/notifications/api/v1/notifications/global` and are activated by sending a `POST` request. Note that sending another `POST` request of the same type overwrites the previous one. For the time being, only the type `deprovision` is supported.
+The userlog service is able to store global messages that will be displayed in the Web UI to all users. If a user deletes the message in the Web UI, it reappears on reload. Global messages use the endpoint `/ocs/v2.php/apps/notifications/api/v1/notifications/global` and are activated by sending a `POST` request. Note that sending another `POST` request of the same type overwrites the previous one. For the time being, only the type `deprovision` is supported.
+
+=== Authentication
+
+`POST` and `DELETE` endpoints provide notifications to all users. Therefore only certain users can configure them. Two authentication methods for this endpoint are provided:
+
+* Users with the `admin` role can always access these endpoints.
+* Additionally, a static secret via the `USERLOG_GLOBAL_NOTIFICATIONS_SECRET` can be defined to enable access for users knowing this secret, which has to be sent with the header containing the request.
 
 === Deprovisioning
 
@@ -51,14 +58,27 @@ Also see the xref:{s-path}/graph.adoc#configuration[GRAPH_LDAP_SCHOOL_TERMINATIO
 
 == Deleting
 
-To delete events for an user, use a `DELETE` request to:
-
+* To delete events for an *user*, use a `DELETE` request to:
++
+--
 [source,plaintext]
 ----
 https://<your-ocis-instance>/ocs/v2.php/apps/notifications/api/v1/notification
 ----
 
-containing the IDs to delete.
+containing the IDs to delete. 
+--
+
+* Sending a `DELETE` request to the *global* endpoint:
++
+--
+[source,plaintext]
+----
+https://<your-ocis-instance>/ocs/v2.php/apps/notifications/api/v1/notifications/global
+----
+
+to remove a global message is a restricted action, see the xref:authentication[Authentication] section for more details.
+--
 
 == Translations
 


### PR DESCRIPTION
Fixes: #578 (Update userlog description)

The userlog description needs an update according the refrenced issue/PR.

Setting to draft to avoid accidentially merging until the ocis PR gets merged.