### PR TITLE
Fix using the wrong envvar in policies

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -177,7 +177,7 @@ The path to that file can be provided via a yaml configuration or an environment
 
 [source,bash]
 ----
-OCIS_MACHINE_AUTH_API_KEY=OCIS_CONFIG_DIR/mime.types
+POLICIES_ENGINE_MIMES=OCIS_CONFIG_DIR/mime.types
 ----
 
 [source,yaml]


### PR DESCRIPTION
References: #581 and https://github.com/owncloud/ocis/pull/6965 (fix: fix readme and changelog env var)

Accidentially using the wrong envvar - corrected.