### PR TITLE
Changes for 4.0 to render content properly

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -25,27 +25,27 @@ asciidoc:
     # service_tab_x will be used to assemble the url accessing the link for the services
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1: 'docs' # do not change, the docs branch contains changes of master
-    service_tab_2: 'docs-stable-3.0'
-    service_tab_3: 'docs-stable-2.0'
+    service_tab_2: 'docs-stable-3.1' # latest stable
+    service_tab_3: 'docs-stable-3.0' # former stable
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
     # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1_tab_text: 'latest'
-    service_tab_2_tab_text: '3.0.0'
-    service_tab_3_tab_text: '2.0.0'
+    service_tab_2_tab_text: '3.1.0' # latest stable
+    service_tab_3_tab_text: '3.0.0' # former stable
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1: 'master'
-    compose_tab_2: 'v3.0.0'
-    compose_tab_3: 'v2.0.0'
+    compose_tab_2: 'v3.1.0' # latest stable
+    compose_tab_3: 'v3.0.0' # former stable
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1_tab_text: 'latest'
-    compose_tab_2_tab_text: '3.0.0'
-    compose_tab_3_tab_text: '2.0.0'
+    compose_tab_2_tab_text: '3.1.0' # latest stable
+    compose_tab_3_tab_text: '3.0.0' # former stable
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
     # note that tab 2 always contains the actual release and tab 3 the former

--- a/antora.yml
+++ b/antora.yml
@@ -25,26 +25,26 @@ asciidoc:
     # service_tab_x will be used to assemble the url accessing the link for the services
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1: 'docs' # do not change, the docs branch contains changes of master
-    service_tab_2: 'docs-stable-3.1' # latest stable
+    service_tab_2: 'docs-stable-4.0' # latest stable
     service_tab_3: 'docs-stable-3.0' # former stable
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
     # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1_tab_text: 'latest'
-    service_tab_2_tab_text: '3.1.0' # latest stable
+    service_tab_2_tab_text: '4.0.0' # latest stable
     service_tab_3_tab_text: '3.0.0' # former stable
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1: 'master'
-    compose_tab_2: 'v3.1.0' # latest stable
+    compose_tab_2: 'v4.0.0' # latest stable
     compose_tab_3: 'v3.0.0' # former stable
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1_tab_text: 'latest'
-    compose_tab_2_tab_text: '3.1.0' # latest stable
+    compose_tab_2_tab_text: '4.0.0' # latest stable
     compose_tab_3_tab_text: '3.0.0' # former stable
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)

--- a/modules/ROOT/pages/conf-examples/office/office-integration.adoc
+++ b/modules/ROOT/pages/conf-examples/office/office-integration.adoc
@@ -61,7 +61,7 @@ Installing the Docker stacks only requires a few steps. Take care to use the rel
 . Get the deployment example:
 +
 --
-Follow the xref:deployment/wopi/wopi.html#wopi-configuration-examples[WOPI Configuration Examples,window=_blank] to download the example files.
+Follow the xref:deployment/wopi/wopi.adoc#wopi-configuration-examples[WOPI Configuration Examples,window=_blank] to download the example files.
 
 After all resources have been downloaded, change into the directory:
 

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -4,11 +4,6 @@
 
 :service_name: antivirus
 
-// remember to REMOVE the corresponding tab if a new ocis release will be published
-
-// :no_second_tab: true
-:no_third_tab: true
-
 == Introduction
 
 {description} 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -4,11 +4,6 @@
 
 :service_name: eventhistory
 
-// remember to REMOVE the corresponding tab if a new ocis release will be published
-
-// :no_second_tab: true
-:no_third_tab: true
-
 == Introduction
 
 {description} 

--- a/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
@@ -4,11 +4,6 @@
 
 :service_name: invitations
 
-// remember to REMOVE the corresponding tab if a new ocis release will be published
-
-// :no_second_tab: true
-:no_third_tab: true
-
 == Introduction
 
 {description} See the https://learn.microsoft.com/en-us/graph/api/invitation-post?view=graph-rest-1.0&tabs=http[Invitation Manager] for more details.

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -4,11 +4,6 @@
 
 :service_name: policies
 
-// remember to REMOVE the corresponding tab if a new ocis release will be published
-
-// :no_second_tab: true
-:no_third_tab: true
-
 == Introduction
 
 {description} 
@@ -145,7 +140,6 @@ The policies service contains a set of preconfigured example policies. See the d
 
 Using git version name: `{compose_tab_1}`
 --
-ifndef::no_second_tab[]
 {compose_tab_2_tab_text}::
 +
 --
@@ -153,8 +147,6 @@ ifndef::no_second_tab[]
 
 Using git version name: `{compose_tab_2}`
 --
-endif::[]
-ifndef::no_third_tab[]
 {compose_tab_3_tab_text}::
 +
 --
@@ -162,7 +154,6 @@ ifndef::no_third_tab[]
 
 Using git version name: `{compose_tab_3}`
 --
-endif::[]
 ====
 
 == Extend Mime Type File Extension Mapping

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -6,11 +6,6 @@
 
 :service_name: userlog
 
-// remember to REMOVE the corresponding tab if a new ocis release will be published
-
-// :no_second_tab: true
-:no_third_tab: true
-
 == Introduction
 
 {description} 

--- a/modules/ROOT/pages/deployment/wopi/wopi.adoc
+++ b/modules/ROOT/pages/deployment/wopi/wopi.adoc
@@ -9,7 +9,7 @@
 :wopi-wiki-url: https://en.wikipedia.org/wiki/Web_Application_Open_Platform_Interface
 :wopi-ms-url: https://learn.microsoft.com/en-us/openspecs/office_protocols/ms-wopi/6a8bb410-68ad-47e4-9dc3-6cf29c6b046b
 
-// since ocis 4.0 we can use teh second tab
+// since ocis 4.0 we can use the second tab
 :use_tab_2: true
 
 == Introduction

--- a/modules/ROOT/pages/deployment/wopi/wopi.adoc
+++ b/modules/ROOT/pages/deployment/wopi/wopi.adoc
@@ -9,6 +9,9 @@
 :wopi-wiki-url: https://en.wikipedia.org/wiki/Web_Application_Open_Platform_Interface
 :wopi-ms-url: https://learn.microsoft.com/en-us/openspecs/office_protocols/ms-wopi/6a8bb410-68ad-47e4-9dc3-6cf29c6b046b
 
+// since ocis 4.0 we can use teh second tab
+:use_tab_2: true
+
 == Introduction
 
 {description} For more details on possible configuration values see the xref:conf-examples/office/office-integration.adoc[Office Integration] document at the configuration examples. More information about the WOPI protocol can be found on {wopi-wiki-url}[Wikipedia,window=_blank] or {wopi-ms-url}[Microsoft,window=_blank].
@@ -75,7 +78,6 @@ image::deployment/wopi/wopi-overview.svg[WOPI Overview Diagram]
 
 Using git version name: `{compose_tab_1}`
 --
-ifdef::use_tab_2[]
 {compose_tab_2_tab_text}::
 +
 --
@@ -83,8 +85,6 @@ ifdef::use_tab_2[]
 
 Using git version name: `{compose_tab_2}`
 --
-endif::[]
-ifdef::use_tab_3[]
 {compose_tab_3_tab_text}::
 +
 --
@@ -92,7 +92,6 @@ ifdef::use_tab_3[]
 
 Using git version name: `{compose_tab_3}`
 --
-endif::[]
 ====
 +
 --

--- a/modules/ROOT/pages/deployment/wopi/wopi.adoc
+++ b/modules/ROOT/pages/deployment/wopi/wopi.adoc
@@ -9,9 +9,6 @@
 :wopi-wiki-url: https://en.wikipedia.org/wiki/Web_Application_Open_Platform_Interface
 :wopi-ms-url: https://learn.microsoft.com/en-us/openspecs/office_protocols/ms-wopi/6a8bb410-68ad-47e4-9dc3-6cf29c6b046b
 
-// since ocis 4.0 we can use the second tab
-:use_tab_2: true
-
 == Introduction
 
 {description} For more details on possible configuration values see the xref:conf-examples/office/office-integration.adoc[Office Integration] document at the configuration examples. More information about the WOPI protocol can be found on {wopi-wiki-url}[Wikipedia,window=_blank] or {wopi-ms-url}[Microsoft,window=_blank].

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -26,12 +26,14 @@ The file contains the attribute too to be used outside of tabsets.
 To exclude a deprecation file if not wanted - like when the file will just not exist, manually unset the attribute if required via:
 
 * :!no_deprecation:
+
 ////
 
-// evaluate deprecations if set in any tab, but only if no_deprecation is not set
-// if set, it will show the deprecation table in all tabs, independent if that tab has one or not
-ifndef::no_deprecation[]
+// read the xxx_deprecation.adoc file from ocis to evaluate deprecations but only if 'no_deprecation' is not set
+// see the deprecation evaluation in the next block how it gets handled 
 
+ifndef::no_deprecation[]
+// deprecation test tab 1, uncomment for testing
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 ifeval::["{show-deprecation}" == "true"]
 :has_deprecation_tab_1: true
@@ -39,6 +41,7 @@ endif::[]
 
 ifndef::no_second_tab[]
 ifdef::use_service_tab_2[]
+// deprecation test tab 2, uncomment for testing
 include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 ifeval::["{show-deprecation}" == "true"]
 :has_deprecation_tab_2: true
@@ -47,6 +50,7 @@ endif::use_service_tab_2[]
 
 ifndef::no_third_tab[]
 ifdef::use_service_tab_3[]
+// deprecation test tab 3, uncomment for testing
 include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 ifeval::["{show-deprecation}" == "true"]
 :has_deprecation_tab_3: true
@@ -55,7 +59,12 @@ endif::use_service_tab_3[]
 endif::no_third_tab[]
 endif::no_second_tab[]
 
-// if one tab deprecation is set to true, set it generally. ifdef with comma uses or (with + uses and)
+////
+if one tab deprecation is set to true, set it generally. ifdef with comma uses or (with + uses and).
+this will show the deprecation table in *all* tabs if one is true, independent if that tab has one or not.
+this is because attributes are only evaluated OUTSIDE a tab definition.
+////
+
 ifdef::has_deprecation_tab_1,has_deprecation_tab_2,has_deprecation_tab_3[]
 :show-deprecation: true
 endif::[]

--- a/site.yml
+++ b/site.yml
@@ -79,8 +79,8 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-actual-version: '3.0.0'
-    ocis-compiled: '2023-06-07 00:00:00 +0000 UTC'
+    ocis-actual-version: '4.0.0'
+    ocis-compiled: '2023-08-23 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   desktop
     latest-desktop-version: 'next'


### PR DESCRIPTION
References: #576 (ocis 3.1 upgrade) and #593 (Make the version 4.0.0 instead of 3.1)

These are the changes necessary to render 4.0 properly.
With the referenced PR, the upgrade procedure has been merged already.

Note that though `docs-stable-4.0` is already set in `antora.yml`, it does currently not exist in the ocis repo. When testing, you will therefore get not all content rendered properly.

**Merge only** after testing when the necessary ocis doc branch has been created.

**Important**, the [Helm Chart part](https://github.com/owncloud/docs-ocis/issues/538) is NOT covered here and must be done in a separate PR.

@micbar fyi