### PR TITLE
Add Repair and Migrate jsoncs3 Indexes command

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -49,3 +49,9 @@ WARNING: Use this command with absolute care. It is not intended to play around 
 Starting with Infinite Scale 3.1, a xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
+
+== Repair and Migrate jsoncs3 Indexes
+
+Starting with Infinite Scale 3.1, a xref:maintenance/commands/rebuild-jsoncs3-indexes.adoc[CLI command] is provided to repair and migrate jsoncs3 indexes. In rare circumstances the data for shares from the "Shared with others" and "Shared with me" index can be corrupted though no data is lost. When using this command, you can recreate that index and migrate it to a new layout which fixes the issue.
+
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 

--- a/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
@@ -1,0 +1,12 @@
+= Rebuild jsoncs3 Indexes
+
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
+
+[source,bash]
+----
+NAME:
+   ocis ocis migrate rebuild-jsoncs3-indexes - repair and migrate jsoncs3 indexes
+
+USAGE:
+   ocis ocis migrate rebuild-jsoncs3-indexes
+----

--- a/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
@@ -5,8 +5,8 @@ WARNING: Use this command with absolute care. It is not intended to play around 
 [source,bash]
 ----
 NAME:
-   ocis ocis migrate rebuild-jsoncs3-indexes - repair and migrate jsoncs3 indexes
+   ocis migrate rebuild-jsoncs3-indexes - repair and migrate jsoncs3 indexes
 
 USAGE:
-   ocis ocis migrate rebuild-jsoncs3-indexes
+   ocis migrate rebuild-jsoncs3-indexes
 ----

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_3.1.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_3.1.0.adoc
@@ -95,6 +95,24 @@ Depending on the number of steps to process, you will see an output like the fol
 ----
 --
 
+. Run the "repair and migrate jsoncs3 indexes" command
++
+--
+[source,bash]
+----
+ocis migrate rebuild-jsoncs3-indexes
+----
+
+When finished, you will see an output like this:
+
+[source,plaintext]
+----
+Scanning storage storage-users-1 (1/1)
+  Rebuilding space 1/1...  done
+done
+----
+--
+
 . Finally, either start the Infinite Scale instance as usual or re-enable the reverse proxy.
 
 . Check your Instance +


### PR DESCRIPTION
Fixes: #585 (New command: ocis migrate rebuild-jsoncs3-indexes)

* Add a new `ocis migrate command` to the maintenance commands documentation
* Add that command also to the upgrade documentation

Locally rendering is fine.

@aduffeck fyi as discussed