### PR TITLE
Make the version 4.0.0 instead of 3.1

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -171,7 +171,7 @@ In the extended set of the rego query language, it is possible to get a list of 
 
 The list of mappings is restricted by default and is provided by the host system Infinite Scale is installed on.
 
-Starting with Infinite Scale 3.1, you can extend this list. To do so, Infinite Scale must be provided with the path to a custom `mime.types` file that maps mime types to extensions. The location of the file must be accessible by all instances of the policy service. As a rule of thumb, use the directory where the Infinite Scale configuration files are stored. Note that existing mappings from the host are extended by the definitions from the mime types file, but not replaced.
+Starting with Infinite Scale release 4.0.0, you can extend this list. To do so, Infinite Scale must be provided with the path to a custom `mime.types` file that maps mime types to extensions. The location of the file must be accessible by all instances of the policy service. As a rule of thumb, use the directory where the Infinite Scale configuration files are stored. Note that existing mappings from the host are extended by the definitions from the mime types file, but not replaced.
 
 The path to that file can be provided via a yaml configuration or an environment variable. Make sure to replace the `OCIS_CONFIG_DIR` string by an existing path. See the documentation of the xref:deployment/general/general-info.adoc#configuration-directory[Configuration Directory] and the xref:deployment/services/env-vars-special-scope.adoc#extended-environment-variables[Extended Environment Variables] for predefined or manually defined config paths.
 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -65,7 +65,7 @@ Once the custom service has finished its work, it should send an event of the ty
 
 === Resume Post-Processing
 
-If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system administrator can instead run a CLI command to retry the failed upload which is a two step process:
+If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 4.0.0, a system administrator can instead run a CLI command to retry the failed upload which is a two step process:
 
 * First, find the upload ID of the failed upload.
 +

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -21,7 +21,7 @@ Starting with Infinite Scale version 3.0.0, the default backend for metadata swi
 
 == Graceful Shutdown
 
-Starting with Infinite Scale version 3.1, you can define a graceful shutdown period for the `storage-users` service.
+Starting with Infinite Scale version 4.0.0, you can define a graceful shutdown period for the `storage-users` service.
 
 IMPORTANT: The graceful shutdown period is only applicable if the `storage-users` service runs as standalone service. It does not apply if the `storage-users` service runs as part of the single binary or as single Docker environment. To build an environment where the `storage-users` service runs as a standalone service, you must start two instances, one _without_ the `storage-users` service and one _only with_ the the `storage-users` service. Note that both instances must be able to communicate on the same network. 
 

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -30,7 +30,7 @@ In rare circumstances, it can be necessary to initiate indexing manually for a g
 
 == Resume Post-Processing
 
-If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 3.1, a system administrator can instead run a xref:{s-path}/postprocessing.adoc#resume-post-processing[CLI command] to retry the failed upload.
+If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. Starting with Infinite Scale release 4.0.0, a system administrator can instead run a xref:{s-path}/postprocessing.adoc#resume-post-processing[CLI command] to retry the failed upload.
 
 == Inspect and Manipulate Node Metadata
 
@@ -46,12 +46,12 @@ WARNING: Use this command with absolute care. It is not intended to play around 
 
 == Roll Back / Roll Forward Decomposedfs Migrations
 
-Starting with Infinite Scale 3.1, a xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
+Starting with Infinite Scale release 4.0.0, a xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
 == Repair and Migrate jsoncs3 Indexes
 
-Starting with Infinite Scale 3.1, a xref:maintenance/commands/rebuild-jsoncs3-indexes.adoc[CLI command] is provided to repair and migrate jsoncs3 indexes. In rare circumstances the data for shares from the "Shared with others" and "Shared with me" index can be corrupted though no data is lost. When using this command, you can recreate that index and migrate it to a new layout which fixes the issue.
+Starting with Infinite Scale release 4.0.0, a xref:maintenance/commands/rebuild-jsoncs3-indexes.adoc[CLI command] is provided to repair and migrate jsoncs3 indexes. In rare circumstances the data for shares from the "Shared with others" and "Shared with me" index can be corrupted though no data is lost. When using this command, you can recreate that index and migrate it to a new layout which fixes the issue.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -15,7 +15,7 @@ IMPORTANT: If not explicitly mentioned, any upgrade is forward only and a backst
 
 IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrade steps from each release must be taken in order and none can be skipped.  
 
-== Version 3.0.0 to 3.1.0
+== Version 3.0.0 to 4.0.0
 
 === Notable Changes Requiring Manual Intervention
 
@@ -24,7 +24,7 @@ IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrad
 
 === Upgrade Steps
 
-For a detailed description of the steps to upgrade see the xref:migration/upgrading_3.0.0_3.1.0.adoc[Upgrading from 3.0.0 to 3.1.0] documentation.
+For a detailed description of the steps to upgrade see the xref:migration/upgrading_3.0.0_4.0.0.adoc[Upgrading from 3.0.0 to 4.0.0] documentation.
 
 == Version 2.0.0 to 3.0.0
 

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -1,6 +1,6 @@
-= Upgrading from 3.0.0 to 3.1.0
+= Upgrading from 3.0.0 to 4.0.0
 :toc: right
-:description: This document describes the necessary steps when upgrading Infinite Scale from release 3.0.0 to 3.1.0.
+:description: This document describes the necessary steps when upgrading Infinite Scale from release 3.0.0 to 4.0.0.
 
 == Introduction
 
@@ -18,7 +18,7 @@ IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#in
 +
 [source,bash]
 ----
-docker pull owncloud/ocis:3.1.0
+docker pull owncloud/ocis:4.0.0
 ----
 
 * or get the binary from {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank].


### PR DESCRIPTION
This renames the ocis release from 3.1 to 4.0.0 as discussed with @micbar 
(Additional migration steps to the already written will follow in a separate PR) 