### PR TITLE
Add migration and Breaking Changes

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -943,7 +943,3 @@ helm delete ocis
 ----
 
 This command removes all the Kubernetes components associated with the chart and deletes the deployment.
-
-=== Upgrading an Existing Release to a New Major Version
-
-A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change which needs manual actions.

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -21,6 +21,11 @@ IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrad
 
 * The space index of the decomposedFS will be automatically migrated from symlinks to messagepack. This migration needs preparation to run successfully.
 * The xref:deployment/container/orchestration/orchestration.adoc#using-our-helm-charts-with-infinite-scale[Helm Chart] has been upgraded.
+* Environment variables marked for deprication have been removed
+
+=== Breaking Changes Requiring Manual Intervention
+
+* Client pool selectors have changed from IP addesses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`
 
 === Upgrade Steps
 

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -21,11 +21,11 @@ IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrad
 
 * The space index of the decomposedFS will be automatically migrated from symlinks to messagepack. This migration needs preparation to run successfully.
 * The xref:deployment/container/orchestration/orchestration.adoc#using-our-helm-charts-with-infinite-scale[Helm Chart] has been upgraded.
-* Environment variables marked for deprication have been removed
+* Environment variables marked for deprecation have been removed
 
 === Breaking Changes Requiring Manual Intervention
 
-* Client pool selectors have changed from IP addesses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`
+* Client pool selectors have changed from IP addresses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`
 
 === Upgrade Steps
 

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -120,16 +120,26 @@ When the instance has started successfully, check the logs for any unusual entri
 
 == Manage Breaking Changes
 
-Client pool selectors have changed from IP addresses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`. This was necessary to improve distributed installations for Infinite Scale like with Kubernetes. With the usage of service names, which are free definable strings, inter-service communication is greatly improved including multiple Infinite Scale instances on the same network.
+Client pool selectors have changed from IP addresses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`. There is no need to configure them at the moment.
 
 === How to Identify if You Are Affected
 
-1. If you have changed the default configuration for inter-service communication.
-2. If you have distributed services via multiple servers and therefore needed to change (1).
-3. If you run multiple Infinite Scale instances on the same network and therefore needed to change (1).
+* If you have changed the default configuration for the xref:deployment/services/env-vars-special-scope.adoc#global-environment-variables[OCIS_REVA_GATEWAY] environment variable.
 
-In all other cases, there is nothing that needs to be done as the new defaults will be used automatically.
+In all other cases, there is nothing that needs to be done as the new default will be used automatically.
 
-=== How to Manage the Changes
+=== How to Manage the Change
 
-Check all manually changed config variables for inter-service communication and replace the current IP based values with a text based string. As a guideline for naming the string and how the defaults are set in the old and new format, see the environment variable documentation for the xref:deployment/services/services.adoc[services] and the xref:deployment/services/env-vars-special-scope.adoc#global-environment-variables[Global Environment Variables] page.
+Manually reconfigure the environment variable to the new namespace:
+
+[width="100%",cols="35%,40%,20%"]
+|===
+3+^h| Default used value, new and old
+^h| Global envvar
+^h| Namespace (new)
+^h| IP (old)
+
+| xref:deployment/services/env-vars-special-scope.adoc#global-environment-variables[OCIS_REVA_GATEWAY]
+| com.owncloud.api.gateway
+| 127.0.0.1:9142
+|===

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -120,11 +120,11 @@ When the instance has started successfully, check the logs for any unusual entri
 
 == Manage Breaking Changes
 
-Client pool selectors have changed from IP addesses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`. This was necessary to improve distributed installations for Infinite Scale like with Kubernetes. With the usage of service names, which are free definable strings, interservice communication is greatly improved including multiple Infinite Scale instances on the same network.
+Client pool selectors have changed from IP addresses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`. This was necessary to improve distributed installations for Infinite Scale like with Kubernetes. With the usage of service names, which are free definable strings, inter-service communication is greatly improved including multiple Infinite Scale instances on the same network.
 
 === How to Identify if You Are Affected
 
-1. If you have changed the default configuration for interservice communication.
+1. If you have changed the default configuration for inter-service communication.
 2. If you have distributed services via multiple servers and therefore needed to change (1).
 3. If you run multiple Infinite Scale instances on the same network and therefore needed to change (1).
 
@@ -132,4 +132,4 @@ In all other cases, there is nothing that needs to be done as the new defaults w
 
 === How to Manage the Changes
 
-Check all manually changed config variables for interservice communication and replace the current IP based values with a text based string. As guideline for naming the string and how the defaults are set in the old and new format, see the environment variable documentation for the xref:deployment/services/services.adoc[services] and the xref:deployment/services/env-vars-special-scope.adoc#global-environment-variables[Global Environment Variables] page.
+Check all manually changed config variables for inter-service communication and replace the current IP based values with a text based string. As a guideline for naming the string and how the defaults are set in the old and new format, see the environment variable documentation for the xref:deployment/services/services.adoc[services] and the xref:deployment/services/env-vars-special-scope.adoc#global-environment-variables[Global Environment Variables] page.

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -117,3 +117,19 @@ done
 
 . Check your Instance +
 When the instance has started successfully, check the logs for any unusual entries.
+
+== Manage Breaking Changes
+
+Client pool selectors have changed from IP addesses `127.0.0.1:9xxx` to service names `com.owncloud.api.*`. This was necessary to improve distributed installations for Infinite Scale like with Kubernetes. With the usage of service names, which are free definable strings, interservice communication is greatly improved including multiple Infinite Scale instances on the same network.
+
+=== How to Identify if You Are Affected
+
+1. If you have changed the default configuration for interservice communication.
+2. If you have distributed services via multiple servers and therefore needed to change (1).
+3. If you run multiple Infinite Scale instances on the same network and therefore needed to change (1).
+
+In all other cases, there is nothing that needs to be done as the new defaults will be used automatically.
+
+=== How to Manage the Changes
+
+Check all manually changed config variables for interservice communication and replace the current IP based values with a text based string. As guideline for naming the string and how the defaults are set in the old and new format, see the environment variable documentation for the xref:deployment/services/services.adoc[services] and the xref:deployment/services/env-vars-special-scope.adoc#global-environment-variables[Global Environment Variables] page.


### PR DESCRIPTION
This is an addon to the migration guide for 4.0 for the breaking change.

You can see the rendered changes on staging in the migration section in:
`ocis/next/migration/upgrading-ocis.html` and the subsequent page.

The removal of the text block in `orchestration.adoc` was necessary as already described above.

@phil-davis language review welcomed.

@tbsbdr FYI