### PR TITLE
Add a task info section when there is a new ocis release

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ yarn serve
 
 When a *staging* build was created and pushed to the [staging site](https://doc.staging.owncloud.com), you can share the preview of the build. Note that staging is accessible via ownCloud SSO only.
 
+## Important New Infinite Scale Releas Info
+
+Please refer to the [New Infinite Scale Releas Info](https://github.com/owncloud/docs-ocis/blob/master/docs/new-infinite-scale-release-info.md) or more information.
+
 ## Target Branch and Backporting
 
 See the [following section](https://github.com/owncloud/docs#target-branch-and-backporting) as the same rules and notes apply.

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ yarn serve
 
 When a *staging* build was created and pushed to the [staging site](https://doc.staging.owncloud.com), you can share the preview of the build. Note that staging is accessible via ownCloud SSO only.
 
-## Important New Infinite Scale Releas Info
+## Important New Infinite Scale Release Info
 
-Please refer to the [New Infinite Scale Releas Info](https://github.com/owncloud/docs-ocis/blob/master/docs/new-infinite-scale-release-info.md) or more information.
+Please refer to the [New Infinite Scale Release Info](https://github.com/owncloud/docs-ocis/blob/master/docs/new-infinite-scale-release-info.md) for more information.
 
 ## Target Branch and Backporting
 

--- a/docs/new-infinite-scale-release-info.md
+++ b/docs/new-infinite-scale-release-info.md
@@ -1,19 +1,19 @@
-# New Infinite Scale Releas Info
+# New Infinite Scale Release Info
 
-If there is a new Infinite Scale release on the way, there are some things to know respectively to check:
+If there is a new Infinite Scale release on the way, there are some things to check:
 
 **Relevant for docs:**
 
-* The docs relevant releasing process in the `ocis` repo works the following:
-  * Based on a release tag like `v4.0.0`, a new `stable-x` branch is created.
-  * A new and empty `docs-stable-x` branch is created.
+* The docs relevant releasing process in the `ocis` repo works the following way:
+  * Based on a release tag like `v4.0.0`, a new `stable-x` branch is created. For example, `stable-4.0`.
+  * A new and empty `docs-stable-x` branch is created. For example, `docs-stable-4.0`.
   * The pipeline of the `stable-x` branch gets adapted to write to the `docs-stable-x` branch.
   * The `stable-x` branch gets added to the nightly cron jobs in drone which populates new and changed content to `docs-stable-x`.
   * Any merge in the `stable-x` branch also triggers the pipeline as usual.
 
-* **IMPORTANT** For any changes necessary that effect the output of the `docs-stable-x`, these must be done in `stable-x` and take effect in `docs-stable-x` when the `stable-x` pipeline ran. Manual commits to `docs-stable-x` will get overwritten at least daily.
+* **IMPORTANT** For any changes necessary that effect the output of the `docs-stable-x` branch, these must be done in `stable-x` and take effect in `docs-stable-x` when the `stable-x` pipeline runs. Manual commits to `docs-stable-x` will get overwritten at least daily.
 
-* **IMPORTANT**: Any changes neccessary in `stable-x` are based on a 6-eye principle and need 2 approvals therefore.
+* **IMPORTANT**: Any changes neccessary in `stable-x` are based on a 6-eye principle and therefore need 2 approvals.
 
 **Actions for docs:**
 

--- a/docs/new-infinite-scale-release-info.md
+++ b/docs/new-infinite-scale-release-info.md
@@ -1,0 +1,33 @@
+# New Infinite Scale Releas Info
+
+If there is a new Infinite Scale release on the way, there are some things to know respectively to check:
+
+**Relevant for docs:**
+
+* The docs relevant releasing process in the `ocis` repo works the following:
+  * Based on a release tag like `v4.0.0`, a new `stable-x` branch is created.
+  * A new and empty `docs-stable-x` branch is created.
+  * The pipeline of the `stable-x` branch gets adapted to write to the `docs-stable-x` branch.
+  * The `stable-x` branch gets added to the nightly cron jobs in drone which populates new and changed content to `docs-stable-x`.
+  * Any merge in the `stable-x` branch also triggers the pipeline as usual.
+
+* **IMPORTANT** For any changes necessary that effect the output of the `docs-stable-x`, these must be done in `stable-x` and take effect in `docs-stable-x` when the `stable-x` pipeline ran. Manual commits to `docs-stable-x` will get overwritten at least daily.
+
+* **IMPORTANT**: Any changes neccessary in `stable-x` are based on a 6-eye principle and need 2 approvals therefore.
+
+**Actions for docs:**
+
+* Separate the `antora.yml` updates into the ocis and Helm Chart part. This eases testing.
+
+* You can prepare the changes, but testing can only start when the `release tag` and the `docs-stable-x` branch is available.
+* For ocis, the attributes used for assembling paths and printed names in `antora.yml` need to be adapted accordingly:  
+Path building: `service_tab_x`, `compose_tab_x`  
+Naming: `service_tab_x_tab_text` and `compose_tab_x_tab_text`
+
+* For Helm Charts, the attributes used for assembling paths and printed names in `antora.yml` need to be adapted accordingly:  
+Path building: `helm_tab_x`  
+Naming: `helm_tab_x_tab_text`
+
+* Make a build and check validity of the
+  * tabs + content in the envvar tab in services and
+  * links (paths) used in eg. `deployment/container/orchestration/orchestration.html#docker-compose-examples`.


### PR DESCRIPTION
We were lacking an info about the background and tasks to do when a new ocis release gets released.