### PR TITLE
Updating the ocis migrate rebuild-jsoncs3-indexes command

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
@@ -1,6 +1,12 @@
 = Rebuild jsoncs3 Indexes
 
-WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
+WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support.
+
+* Note, run this comand only if there are shares present.
+* If you run this command and no shares are present, an error will be printed like the following: +
+`error: not found: list container: error: not found: jsoncs3-share-manager-metadata/storages` +
+This error has no impact and can be neglected.
+
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
@@ -2,7 +2,7 @@
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support.
 
-* Note, run this comand only if there are shares present.
+* Note, run this command only if there are shares present.
 * If you run this command and no shares are present, an error will be printed like the following: +
 `error: not found: list container: error: not found: jsoncs3-share-manager-metadata/storages` +
 This error has no impact and can be neglected.

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -103,7 +103,7 @@ Depending on the number of steps to process, you will see an output like the fol
 . Run the "repair and migrate jsoncs3 indexes" command:
 +
 --
-* Note, run this comand only if there are shares present.
+* Note, run this command only if there are shares present.
 * If you run this command and no shares are present, an error will be printed like the following: +
 `error: not found: list container: error: not found: jsoncs3-share-manager-metadata/storages` +
 This error has no impact and can be neglected.

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -32,7 +32,7 @@ It is important to disable clients and users logging in while the space index mi
 +
 [source,bash]
 ----
-OCIS_RUN_SERVICES="storage-users,nats" \
+OCIS_RUN_SERVICES="gateway,nats,storage-system,storage-users" \
 ocis server
 ----
 
@@ -100,9 +100,16 @@ Depending on the number of steps to process, you will see an output like the fol
 ----
 --
 
-. Run the "repair and migrate jsoncs3 indexes" command
+. Run the "repair and migrate jsoncs3 indexes" command:
 +
 --
+* Note, run this comand only if there are shares present.
+* If you run this command and no shares are present, an error will be printed like the following: +
+`error: not found: list container: error: not found: jsoncs3-share-manager-metadata/storages` +
+This error has no impact and can be neglected.
+
+{empty}
+
 [source,bash]
 ----
 ocis migrate rebuild-jsoncs3-indexes


### PR DESCRIPTION
Based on a user feedback, we needed to sharpen the `ocis migrate rebuild-jsoncs3-indexes` command.

In addition, the upgrade guide needed an update which services need to be started mandatory.