### PR TITLE
Adapted socket description to software

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -15,7 +15,7 @@
 The antivirus service currently supports https://tools.ietf.org/html/rfc3507[ICAP] and http://www.clamav.net/index.html[clamAV] as antivirus scanners. The `ANTIVIRUS_SCANNER_TYPE` environment variable is used to select the scanner. The detailed configuration for each scanner heavily depends on the scanner type selected. See the environment variables for more details.
 
   -   For `icap`, only scanners using the `X-Infection-Found` header are currently supported.
-  -   For `clamav`, only local sockets can currently be configured.
+  -   For `clamav`, local Unix Domain Sockets and remote network sockets can be configured either by pointing to a file like `/tmp/clamd.socket` or with a stream socket like `tcp://host.docker.internal:3310`.
 
 === Maximum Scan Size
 

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -14,8 +14,10 @@
 
 The antivirus service currently supports https://tools.ietf.org/html/rfc3507[ICAP] and http://www.clamav.net/index.html[clamAV] as antivirus scanners. The `ANTIVIRUS_SCANNER_TYPE` environment variable is used to select the scanner. The detailed configuration for each scanner heavily depends on the scanner type selected. See the environment variables for more details.
 
-  -   For `icap`, only scanners using the `X-Infection-Found` header are currently supported.
-  -   For `clamav`, local Unix Domain Sockets and remote network sockets can be configured either by pointing to a file like `/tmp/clamd.socket` or with a stream socket like `tcp://host.docker.internal:3310`.
+* For `icap`, only scanners using the `X-Infection-Found` header are currently supported.
+* For `clamav`, local Unix Domain Sockets and remote network sockets can be configured either by:
+** pointing to a file like `/tmp/clamd.socket` or
+** with a stream socket like `tcp://host.docker.internal:3310`.
 
 === Maximum Scan Size
 


### PR DESCRIPTION
As outlined (and tested by myself) `ANTIVIRUS_CLAMAV_SOCKET` can take local and remote sockets, see also https://owncloud.dev/ocis/development/testing/#running-test-suite-with-antivirus-service-antivirus.

This PR adapts the documentation to reflect this.