### PR TITLE
Add "Restrict Username Patterns"

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -14,6 +14,22 @@
 
 * Graph listens on port 9120 by default.
 
+== Restrict Username Patterns
+
+Usernames can be restricted to follow certain patterns. Such patterns can be neccessary when using the xref:{s-path}/idm.adoc[internal IDM] like to align with local Unix username restrictions. Username restrictions can also be handled with the external IDM like Keycloak. The environment variable `GRAPH_USERNAME_MATCH` can be set to the following values to define where and how these restriction are handled:
+
+* `none` +
+There is no internal username checking. Restrictions, if any, are defined in the _external_ IDM like Keycloak.
+
+* `default` +
+Usernames are restricted by following criterias:
+** ASCII standard charset, no UTF-8
+** The username _must_ start with either
+*** an `_` (underscore) or
+*** a letter where there is no distinction between lower- and uppercase.
+** More characters from the ASCII charset including numbers, aligning to the Unix user namespace. 
+** optionally an `@` character followed by a domain name 
+
 == Manual Filters
 
 Using the API, you can manually filter like for users. See the https://owncloud.dev/libre-graph-api/#/users/ListUsers[Libre Graph API] for examples in the https://owncloud.dev[developer documentation]. Note that you can use `and` and `or` to refine results.

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -16,13 +16,13 @@
 
 == Restrict Username Patterns
 
-Usernames can be restricted to follow certain patterns. Such patterns can be neccessary when using the xref:{s-path}/idm.adoc[internal IDM] like to align with local Unix username restrictions. Username restrictions can also be handled with the external IDM like Keycloak. The environment variable `GRAPH_USERNAME_MATCH` can be set to the following values to define where and how these restriction are handled:
+Usernames can be restricted to follow certain patterns. Such patterns can be neccessary when using the xref:{s-path}/idm.adoc[internal IDM] for example to align with local Unix username restrictions. Username restrictions can also be handled with an external IDM like Keycloak. The environment variable `GRAPH_USERNAME_MATCH` can be set to the following values to define where and how these restriction are handled:
 
 * `none` +
 There is no internal username checking. Restrictions, if any, are defined in the _external_ IDM like Keycloak.
 
 * `default` +
-Usernames are restricted by following criterias:
+Usernames are restricted by the following criteria:
 ** ASCII standard charset, no UTF-8
 ** The username _must_ start with either
 *** an `_` (underscore) or

--- a/modules/ROOT/pages/deployment/services/s-list/idm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idm.adoc
@@ -25,6 +25,7 @@ namely `BIND`, `SEARCH`, `ADD`, `MODIFY` and `DELETE`.
 `require and option attributes`, +
 `syntax checks`, …
 * IDM currently does not support features like 2FA and device management.
+* Check the xref:{s-path}/graph.adoc#restrict-username-patterns[Restrict Username Patterns] documentation.
 
 Therefore the IDM service is **not** meant to replace a general purpose LDAP server.
 ====


### PR DESCRIPTION
We have a envvar that can define the behaviour restricting username patterns. Though this envvvar is described in the envvar docs, it did not contain all relevant info about the current behaviour making it hard to understand what it is about and its impact. In addition, the envvar is not in IDM but in graph making it even more complicated to find. This PR fixes this issue.

A language review is welcomed.