### PR TITLE
Make the source of Kubernetes versions supported part of this repo

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -62,7 +62,6 @@ asciidoc:
     # set attributes defining path components which will be assembled in the document
     secrets: 'deployment/container/orchestration/orchestration.adoc#define-secrets'
     ocis-charts-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis-charts/'
-    kube-versions-url: '/charts/ocis/docs/kube-versions.adoc'
     values-versions-url: '/charts/ocis/docs/values.adoc.yaml'
     values-desc-versions-url: '/charts/ocis/docs/values-desc-table.adoc'
     composer-url: 'https://github.com/owncloud/ocis/tree/'

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -278,41 +278,47 @@ xref:deployment/container/orchestration/tab-pages/breaking-changes.adoc#{helm_ta
 endif::[]
 ====
 
-=== Get the Chart
+=== Supported Kubernetes Versions
 
-As the Helm chart has currently not been published to a Helm repository, you need to clone ownCloud's Helm chart git repository named {ocis-helm-charts-url}[ocis-charts].
+////
+note to adapt the _kube-versions-tab-x files
+1. when a new kubernetes version is added to the list or
+2. when a new ocis release gets published and the tab names change !!
 
-// note the sources for the include are on GitHub at ocis-charts.
+for (1), just add the version to the relevant tab-x file
+for (2), you need to "rotate" the content of the files.
 
-* Check the supported Kubernetes versions before you download the chart.
-+
---
-** The `~` represents all patch releases for that particular version.
-** The `-0` represents subversions of that particular version.
---
-+
+tab-2 -> tab-3
+tab-1 -> tab-2
+tab-1 gets new or adapted content based on former tab-1 content
+////
+
 [tabs]
 ====
 {helm_tab_1_tab_text}::
 +
 --
-include::{ocis-charts-raw-url}{helm_tab_1}{kube-versions-url}[]
+include::./tab-pages/_kube-versions-tab-1.adoc[]
 --
 ifdef::use_helm_tab_2[]
 {helm_tab_2_tab_text}::
 +
 --
-include::{ocis-charts-raw-url}{helm_tab_2}{kube-versions-url}[]
+include::./tab-pages/_kube-versions-tab-2.adoc[]
 --
 endif::[]
 ifdef::use_helm_tab_3[]
 {helm_tab_3_tab_text}::
 +
 --
-include::{ocis-charts-raw-url}{helm_tab_3}{kube-versions-url}[]
+include::./tab-pages/_kube-versions-tab-3.adoc[]
 --
 endif::[]
 ====
+
+=== Get the Chart
+
+As the Helm chart has currently not been published to a Helm repository, you need to clone ownCloud's Helm chart git repository named {ocis-helm-charts-url}[ocis-charts].
 
 === Start minikube
 
@@ -320,7 +326,7 @@ endif::[]
 +
 [source,bash]
 ----
-minikube start --kubernetes-version=v1.25.0
+minikube start --kubernetes-version=v1.28.1
 ----
 
 . Enable the minikube ingress plugin, which acts like a reverse proxy for your cluster:

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-1.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-1.adoc
@@ -1,4 +1,4 @@
-We only list non EOL versions as of the Chart release date from here: https://kubernetes.io/releases/[window=_blank]
+We only list non EOL versions as of the chart release date from here: https://kubernetes.io/releases/[window=_blank]
 
 Note that some EOL versions still might be API compatible.
 

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-1.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-1.adoc
@@ -1,0 +1,40 @@
+We only list non EOL versions as of the Chart release date from here: https://kubernetes.io/releases/[window=_blank]
+
+Note that some EOL versions still might be API compatible.
+
+{empty}
+
+[width="100%",cols="~,^~,^~",options="header"]
+|===
+| Version
+| Covered by tests
+| Tested by developers
+
+a| [subs=-attributes]
++1.28+
+a| [subs=-attributes]
++yes+
+a| [subs=-attributes]
++yes+
+
+a| [subs=-attributes]
++1.27+
+a| [subs=-attributes]
++yes+
+a| [subs=-attributes]
++yes+
+
+a| [subs=-attributes]
++1.26+
+a| [subs=-attributes]
++yes+
+a| [subs=-attributes]
++no+
+
+a| [subs=-attributes]
++1.25+
+a| [subs=-attributes]
++yes+
+a| [subs=-attributes]
++no+
+|===

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-2.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-2.adoc
@@ -1,0 +1,17 @@
+* Check the supported Kubernetes versions before you download the chart.
+** The `~` represents all patch releases for that particular version.
+** The `-0` represents subversions of that particular version.
+
++
+[width="100%",cols="~",options="header"]
+|===
+| Version
+a| [subs=-attributes]
++~1.27.0-0+
+a| [subs=-attributes]
++~1.26.0-0+
+a| [subs=-attributes]
++~1.25.0-0+
+a| [subs=-attributes]
++~1.24.0-0+
+|===

--- a/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-3.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/tab-pages/_kube-versions-tab-3.adoc
@@ -1,0 +1,15 @@
+* Check the supported Kubernetes versions before you download the chart.
+** The `~` represents all patch releases for that particular version.
+** The `-0` represents subversions of that particular version.
+
++
+[width="100%",cols="~",options="header"]
+|===
+| Version
+a| [subs=-attributes]
++~1.25.0+
+a| [subs=-attributes]
++~1.24.0+
+a| [subs=-attributes]
++~1.23.0+
+|===


### PR DESCRIPTION
References: https://github.com/owncloud/ocis-charts/pull/392 (drop Kubernetes version enforcment and test Kubernetes 1.18)

If the referenced PR gets merged, there are no more "automatic" updates of the supported kubernetes versions coming from ocis-charts.

To make that situation future proof, I migrated all the version tables into this repo eleminating the dependency. If there are any changes necessary, they can now be done here. There is also a small description text as comment what to do in which case.

Note that in ocis-chart issue: https://github.com/owncloud/ocis-charts/issues/338, an additional column is shown: `api compatible` - this can be added on demand quite easily, also as later step.

The new layout can be seen online on staging: https://doc.staging.owncloud.com/ocis/next/deployment/container/orchestration/orchestration.html#supported-kubernetes-versions 