### PR TITLE
Add denied info response to policies service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -46,7 +46,7 @@ The gRPC API can be used by any other internal service. It can also be used for 
 
 The xref:{s-path}/proxy.adoc[proxy service] already includes a middleware which uses the internal xref:grpc-service[gRPC api] to evaluate the policies. Since the proxy is in heavy use and every HTTP request is processed here, only simple and quick decisions should be evaluated. More complex queries such as file content evaluation are _strongly_ discouraged.
 
-When the evaluation in the proxy results in a `denied` outcome, the response will return a `403 Permission Denied` with the following response body:
+If the evaluation in the proxy results in a `denied` outcome, the response will return a `403 Permission Denied` with the following response body:
 
 [source,json]
 ----

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -46,7 +46,7 @@ The gRPC API can be used by any other internal service. It can also be used for 
 
 The xref:{s-path}/proxy.adoc[proxy service] already includes a middleware which uses the internal xref:grpc-service[gRPC api] to evaluate the policies. Since the proxy is in heavy use and every HTTP request is processed here, only simple and quick decisions should be evaluated. More complex queries such as file content evaluation are _strongly_ discouraged.
 
-When the evaluation in the proxy results in a `denied` outcome, the response will return a `403 Permission Denied` with the following response body
+When the evaluation in the proxy results in a `denied` outcome, the response will return a `403 Permission Denied` with the following response body:
 
 [source,json]
 ----

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -46,6 +46,27 @@ The gRPC API can be used by any other internal service. It can also be used for 
 
 The xref:{s-path}/proxy.adoc[proxy service] already includes a middleware which uses the internal xref:grpc-service[gRPC api] to evaluate the policies. Since the proxy is in heavy use and every HTTP request is processed here, only simple and quick decisions should be evaluated. More complex queries such as file content evaluation are _strongly_ discouraged.
 
+When the evaluation in the proxy results in a `denied` outcome, the response will return a `403 Permission Denied` with the following response body
+
+[source,json]
+----
+{
+    "error":
+    {
+        "code": "deniedByPolicy",
+        "message": "Operation denied due to security policies",
+        "innererror":
+        {
+            "date": "2023-09-19T13:22:20Z",
+            "filename": "File",
+            "method": "POST",
+            "path": "/dav/spaces/some-space-id/Folder/",
+            "request-id": "9CFCE925-F9D9-4F26-AB3B-2C1C40A9CD0C"
+        }
+    }
+}
+----
+
 === Event Service (Postprocessing)
 
 This layer is event-based and part of the xref:{s-path}/postprocessing.adoc[postprocessing service]. Since processing at this point is asynchronous, the operations can also take longer and be more expensive, like evaluating the contents of a file.


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/7311 ([docs-only] Add denied error body to docs)

Adding the referenced info to the admin docs.