### PR TITLE
Add info when defining ciphers for Nginx with Letsencrypt

### DIFF
--- a/modules/ROOT/partials/deployment/nginx_harden_ssl.adoc
+++ b/modules/ROOT/partials/deployment/nginx_harden_ssl.adoc
@@ -1,9 +1,14 @@
 [source,nginx]
 ----
         # protocol, session timout, server cipers
-        # and ssl cache is handled by certbot
+        # NOTE: ssl cache is handled by certbot
+        # also see: https://github.com/certbot/certbot/blob/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf
 
         # restrict ciphers
+        #
+        # IMPORTANT: depending on your setup, it is possible that certbot will also define the ciphers used.
+        # this can lead to a nginx error about already defined ciphers. in such a case, you can comment out
+        # the cipher definition here.
         ssl_ciphers "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-ECDSA-AES128-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES256-SHA256:!SHA1:!SHA256:!SHA384:!RC4:!aNULL:!eNULL:!Medium:!LOW:!3DES:!MD5:!EXP:!PSK:!SRP:!DSS:!SEED";
 
         # use multiple curves  (only if dhparams file is used)


### PR DESCRIPTION
Supercedes: #626 (Update nginx_harden_ssl.adoc)

Adding a note to avoid a nginx config error when certbot has its own defined ciphers.
