### PR TITLE
Add Clientlog service

### DIFF
--- a/modules/ROOT/pages/deployment/services/ports-used.adoc
+++ b/modules/ROOT/pages/deployment/services/ports-used.adoc
@@ -55,5 +55,8 @@ The following port ranges are used by services:
 | 9240-9244  | xref:{s-path}/app-registry.adoc[app-registry]
 | 9245-9249  | FREE
 | 9250-9254  | https://github.com/owncloud/ocis/tree/master/ocis/pkg/runtime[ocis server (runtime)]
+| 9255-9259  | xref:{s-path}/postprocessing.adoc[postprocessing]
+| 9260-9264  | xref:{s-path}/clientlog.adoc[clientlog]
+| 9270-9274  | xref:{s-path}/eventhistory.adoc[eventhistory]
 | 9460-9464  | xref:{s-path}/store.adoc[store]
 |===

--- a/modules/ROOT/pages/deployment/services/s-list/clientlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/clientlog.adoc
@@ -5,7 +5,7 @@
 :no_second_tab: true
 //:no_third_tab: true
 
-:description: The Infinite Scale Clientlog service is responsible for composing machine readable notifications for clients. Clients are apps and web interfaces.
+:description: The Infinite Scale clientlog service is responsible for composing machine-readable notifications for clients. Clients are apps and web interfaces.
 
 == Introduction
 
@@ -13,13 +13,13 @@
 
 == Default Values
 
-* The Clientlog service listens on port 9260 by default.
+* The clientlog service listens on port 9260 by default.
 
 include::partial$deployment/services/log-service-ecosystem.adoc[]
 
 == Clientlog Events
 
-The messages the `clientlog` service sends are intended for the use by clients, _not by users_. The client might for example be informed that a file has finished post-processing. With that, the client can make the file available to the user without additional server queries.
+The messages the `clientlog` service sends are intended for use by clients, _not by users_. The client might for example be informed that a file has finished post-processing. With that, the client can make the file available to the user without additional server queries.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/clientlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/clientlog.adoc
@@ -1,0 +1,26 @@
+= Clientlog Configuration
+:toc: right
+
+:service_name: clientlog
+:no_second_tab: true
+//:no_third_tab: true
+
+:description: The Infinite Scale Clientlog service is responsible for composing machine readable notifications for clients. Clients are apps and web interfaces.
+
+== Introduction
+
+{description}
+
+== Default Values
+
+* The Clientlog service listens on port 9260 by default.
+
+include::partial$deployment/services/log-service-ecosystem.adoc[]
+
+== Clientlog Events
+
+The messages the `clientlog` service sends are intended for the use by clients, _not by users_. The client might for example be informed that a file has finished post-processing. With that, the client can make the file available to the user without additional server queries.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -10,7 +10,7 @@
 
 == Default Values
 
-* The Eventhistory Service listens on port 9174 by default.
+* The eventhistory service listens on port 9174 by default.
 
 == Prerequisites
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -8,6 +8,10 @@
 
 {description} 
 
+== Default Values
+
+* The Eventhistory Service listens on port 9174 by default.
+
 == Prerequisites
 
 Running the `eventhistory` service without an event system like NATS is not possible.

--- a/modules/ROOT/pages/deployment/services/s-list/store.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/store.adoc
@@ -12,7 +12,7 @@
 
 == Default Values
 
-* The Store service listens on port 9460 by default.
+* The store service listens on port 9460 by default.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/store.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/store.adoc
@@ -12,7 +12,7 @@
 
 == Default Values
 
-* Store listens on port 9460 by default.
+* The Store service listens on port 9460 by default.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -12,7 +12,7 @@
 
 == Default Values
 
-* The Userlog service listens on port 9210 by default.
+* The userlog service listens on port 9210 by default.
 
 include::partial$deployment/services/log-service-ecosystem.adoc[]
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -10,6 +10,12 @@
 
 {description} 
 
+== Default Values
+
+* The Userlog service listens on port 9210 by default.
+
+include::partial$deployment/services/log-service-ecosystem.adoc[]
+
 == Prerequisites
 
 Running the `userlog` service without running the xref:{s-path}/eventhistory.adoc[eventhistory] service is not possible.

--- a/modules/ROOT/partials/deployment/services/log-service-ecosystem.adoc
+++ b/modules/ROOT/partials/deployment/services/log-service-ecosystem.adoc
@@ -1,0 +1,19 @@
+== The Log Service Ecosystem
+
+Log services like the `userlog`, `clientlog` and `sse` are responsible for composing notifications for a certain audience.
+
+{empty} +
+
+[width=80%,cols="20%,80%",options="header"]
+|====
+2+^| Log services and their tasks
+| xref:{s-path}/userlog.adoc[userlog]
+| This service *translates and adjusts messages* to be human readable.
+
+| xref:{s-path}/clientlog.adoc[clientlog]
+| This service *composes machine readable messages*, so clients can act without the need to query the server.
+
+| xref:{s-path}/sse.adoc[sse]
+| This service is only responsible for *sending these messages*. It does not care about their form or language.
+
+|====

--- a/modules/ROOT/partials/deployment/services/log-service-ecosystem.adoc
+++ b/modules/ROOT/partials/deployment/services/log-service-ecosystem.adoc
@@ -8,10 +8,10 @@ Log services like the `userlog`, `clientlog` and `sse` are responsible for compo
 |====
 2+^| Log services and their tasks
 | xref:{s-path}/userlog.adoc[userlog]
-| This service *translates and adjusts messages* to be human readable.
+| This service *translates and adjusts messages* to be human-readable.
 
 | xref:{s-path}/clientlog.adoc[clientlog]
-| This service *composes machine readable messages*, so clients can act without the need to query the server.
+| This service *composes machine-readable messages*, so clients can act without the need to query the server.
 
 | xref:{s-path}/sse.adoc[sse]
 | This service is only responsible for *sending these messages*. It does not care about their form or language.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -34,6 +34,7 @@
 **** xref:deployment/services/s-list/auth-bearer.adoc[Auth Bearer]
 **** xref:deployment/services/s-list/auth-machine.adoc[Auth Machine]
 **** xref:deployment/services/s-list/auth-service.adoc[Auth Service]
+**** xref:deployment/services/s-list/clientlog.adoc[Clientlog]
 **** xref:deployment/services/s-list/eventhistory.adoc[Eventhistory]
 **** xref:deployment/services/s-list/frontend.adoc[Frontend]
 **** xref:deployment/services/s-list/gateway.adoc[Gateway]


### PR DESCRIPTION
Fixes: #612 (New service: Clientlog)

Add the `Clientlog` service.

Note that we already have a reference to the upcoming SSE service which will be added with the next PR. 