### PR TITLE
Add the password policy to the frontend service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -50,7 +50,7 @@ When setting the `FRONTEND_AUTO_ACCEPT_SHARES` to `true`, all incoming shares wi
 
 == The password policy
 
-Note that the password policy currently impacts _only_ public link password validation.
+Note that the password policy currently impacts only *public link password validation*.
 
 With the password policy, mandatory criteria for the password can be defined via the environment variables listed below.
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -48,7 +48,7 @@ The `frontend` service contains an eventhandler for handling `ocs` related event
 
 When setting the `FRONTEND_AUTO_ACCEPT_SHARES` to `true`, all incoming shares will be accepted automatically. Users can overwrite this setting individually in their profile.
 
-== The password policy
+== The Password Policy
 
 Note that the password policy currently impacts only *public link password validation*.
 
@@ -58,7 +58,7 @@ Generally, a password can contain any UTF-8 characters, however some characters 
 
 The validation against the banned passwords list can be configured via a text file with words separated by new lines. If a user tries to set a password listed in the banned passwords list, the password can not be used (is invalid) even if the other mandatory criteria are passed. The admin can define the path of the banned passwords list file. If the file doesn't exist in a location, Infinite Scale tries to load a file from the `OCIS_CONFIG_DIR/FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`. An option will be enabled when the file has been loaded successfully.
 
-Following environment variables can be set to define the password policy behaviour:
+The following environment variables can be set to define the password policy behavior:
 
 * `FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS` +
 Define the minimum password length.

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -48,6 +48,33 @@ The `frontend` service contains an eventhandler for handling `ocs` related event
 
 When setting the `FRONTEND_AUTO_ACCEPT_SHARES` to `true`, all incoming shares will be accepted automatically. Users can overwrite this setting individually in their profile.
 
+== The password policy
+
+Note that the password policy currently impacts _only_ public link password validation.
+
+With the password policy, mandatory criteria for the password can be defined via the environment variables listed below.
+
+Generally, a password can contain any UTF-8 characters, however some characters are regarded as special since they are not used in ordinary texts. Which characters should be treated as special is defined by "The OWASP® Foundation" https://owasp.org/www-community/password-special-characters[password-special-characters] (between double quotes): " !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"
+
+The validation against the banned passwords list can be configured via a text file with words separated by new lines. If a user tries to set a password listed in the banned passwords list, the password can not be used (is invalid) even if the other mandatory criteria are passed. The admin can define the path of the banned passwords list file. If the file doesn't exist in a location, Infinite Scale tries to load a file from the `OCIS_CONFIG_DIR/FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`. An option will be enabled when the file has been loaded successfully.
+
+Following environment variables can be set to define the password policy behaviour:
+
+* `FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS` +
+Define the minimum password length.
+* `FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS` +
+Define the minimum number of uppercase letters.
+* `FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS` +
+Define the minimum number of lowercase letters.
+* `FRONTEND_PASSWORD_POLICIY_MIN_DIGITS` +
+Define the minimum number of digits.
+* `FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS` +
+Define the minimum number of special characters.
+* `FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST` +
+Path to the 'banned passwords list' file.
+
+NOTE: A password can have a *maximum length* of **72 bytes**. Depending on the alphabet used, a character is encoded by 1 to 4 bytes, defining the maximum length of a password indirectly. While US-ASCII will only need one byte, Latin alphabets and also Greek or Cyrillic ones need two bytes. Three bytes are needed for characters in Chinese, Japanese and Korean etc.
+
 === Sharing
 
 Aggregating share information is one of the most time consuming operations in OCIS. The service fetches a list of either received or created shares and has to stat every resource individually. While stats are fast, the default behavior scales linearly with the number of shares.


### PR DESCRIPTION
Fixes: #609 (PWD policy (frontend service) for public link password validation)

The password policy description for public link password validation is now added to the frontend service.

Note that the text used was already reviewed in ocis, though improvements can always be found.