### PR TITLE
Add thumbnail processors

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
@@ -80,6 +80,17 @@ Various resolutions can be defined via `THUMBNAILS_RESOLUTIONS`. A requestor can
 | 15x10  
 |===
 
+=== Thumbnail Processors
+
+Starting with Infinite Scale 5.0, image generation can be configured by defining different processors. Following processors are available:
+
+* `resize`
+* `fit`
+* `fill`
+* `thumbnail`
+
+To apply one of those, a query parameter has to be added to the request, e.g. `?processor=fit`
+
 === Deleting Thumbnails
 
 As of now, there is no automated thumbnail deletion. This is especially true when a source file gets deleted or moved. This situation will be solved at a later stage. For the time being, if you run short on physical thumbnails space, you have to manually delete the thumbnail store to free space. Thumbnails will then be recreated on request.


### PR DESCRIPTION
Fixes: #629 (Update thumbnail service readme)

Adds thumbnail processors to the service description.

Setting to WIP as the referenced ocis PR is not merged yet.