### PR TITLE
Default language

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -101,6 +101,10 @@ include::partial$deployment/services/webui_language_code.adoc[]
 *   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
 which is the source of the texts provided by the code.
 
+== Default Language
+
+The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. See the xref:{s-path}/settings.adoc#default-language[settings] service for a detailed description.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -63,7 +63,7 @@ The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` ser
 ** If a user sets another language in the WebUI in menu:Account[Language], then the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to English.
 
 * If  `OCIS_DEFAULT_LANGUAGE` **is set**, the expected behavior is:
-** The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE`  by default, until a user sets another language in the WebUI via menu:Account[Language].
+** The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE` by default, until a user sets another language in the WebUI via menu:Account[Language].
 ** If a user sets another language in the WebUI in menu:Account[Language], the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
 
 == Configuration

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -50,7 +50,7 @@ Services can set or query Infinite Scale *setting values* of a user from setting
 
 == Service Accounts
 
-The settings service needs to know the ID's of service accounts but it doesn't need their secrets. Currently only one service account can be configured which has the admin role. This can be set with the `SETTINGS_SERVICE_ACCOUNT_ID_ADMIN` envvar, but it will also pick up the global `OCIS_SERVICE_ACCOUNT_ID` envvar. Also see the xref:{s-path}/auth-service.adoc[auth-service] service description for additional details.
+The settings service needs to know the IDs of service accounts but it doesn't need their secrets. Currently only one service account can be configured which has the admin role. This can be set with the `SETTINGS_SERVICE_ACCOUNT_ID_ADMIN` envvar, but it will also pick up the global `OCIS_SERVICE_ACCOUNT_ID` envvar. Also see the xref:{s-path}/auth-service.adoc[auth-service] service description for additional details.
 
 == Default Language
 
@@ -59,12 +59,12 @@ Starting with Infinite Scale 5.0, the default language can be defined via the `O
 The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` services and the WebUI. Note that translations must exist for all named components to be presented correctly.
 
 * If  `OCIS_DEFAULT_LANGUAGE` **is not set**, the expected behavior is:
-** The `notification` and `userlog` services and the WebUI use English by default, until a user sets another language in the WebUI via menu:Account[Language].
-** If a user sets another language in the WebUI in menu:Account[Language], then the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to English.
+** The `notification` and `userlog` services and the Web UI use English by default, until a user sets another language in the Web UI via menu:Account[Language].
+** If a user sets another language in the Web UI in menu:Account[Language], then the `notification` and `userlog` services and Web UI use the language defined by the user. If no translation is found, it falls back to English.
 
 * If  `OCIS_DEFAULT_LANGUAGE` **is set**, the expected behavior is:
-** The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE` by default, until a user sets another language in the WebUI via menu:Account[Language].
-** If a user sets another language in the WebUI in menu:Account[Language], the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
+** The `notification` and `userlog` services and the Web UI use `OCIS_DEFAULT_LANGUAGE` by default, until a user sets another language in the Web UI via menu:Account[Language].
+** If a user sets another language in the Web UI in menu:Account[Language], the `notification` and `userlog` services and Web UI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -40,6 +40,22 @@ include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!
 . When using `redis-sentinel`, the Redis master to use is configured via `SETTINGS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
+== Settings Management
+
+Infinite Scale services can register *settings bundles* with the settings service.
+
+== Settings Usage
+
+Services can set or query Infinite Scale *setting values* of a user from settings bundles.
+
+== Service Accounts
+
+The settings service needs to know the ID's of service accounts but it doesn't need their secrets. Currently only one service account can be configured which has the admin role. This can be set with the `SETTINGS_SERVICE_ACCOUNT_ID_ADMIN` envvar, but it will also pick up the global `OCIS_SERVICE_ACCOUNT_ID` envvar. Also see the xref:{s-path}/auth-service.adoc[auth-service] service description for additional details.
+
+== Default Language
+
+The default language can be defined via `SETTINGS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for invitation emails.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -54,7 +54,17 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 == Default Language
 
-The default language can be defined via `SETTINGS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for invitation emails.
+Starting with Infinite Scale 5.0, the default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for notification and invitation emails.
+
+The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` services and the WebUI. Note that translations must exist for all named components to be presented correctly.
+
+* If  `OCIS_DEFAULT_LANGUAGE` **is not set**, the expected behavior is:
+** The `notification` and `userlog` services and the WebUI use English by default, until a user sets another language in the WebUI via menu:Account[Language].
+** If a user sets another language in the WebUI in menu:Account[Language], then the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to English.
+
+* If  `OCIS_DEFAULT_LANGUAGE` **is set**, the expected behavior is:
+** The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE`  by default until, a user sets another language in the WebUI via menu:Account[Language].
+** If a user sets another language in the WebUI in menu:Account[Language], the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -54,7 +54,7 @@ The settings service needs to know the ID's of service accounts but it doesn't n
 
 == Default Language
 
-Starting with Infinite Scale 5.0, the default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited by the list supported languages. This setting can be used to set the default language for notification and invitation emails.
+Starting with Infinite Scale 5.0, the default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited to the list of supported languages. This setting can be used to set the default language for notification and invitation emails.
 
 The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` services and the WebUI. Note that translations must exist for all named components to be presented correctly.
 
@@ -63,7 +63,7 @@ The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` ser
 ** If a user sets another language in the WebUI in menu:Account[Language], then the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to English.
 
 * If  `OCIS_DEFAULT_LANGUAGE` **is set**, the expected behavior is:
-** The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE`  by default until, a user sets another language in the WebUI via menu:Account[Language].
+** The `notification` and `userlog` services and the WebUI use `OCIS_DEFAULT_LANGUAGE`  by default, until a user sets another language in the WebUI via menu:Account[Language].
 ** If a user sets another language in the WebUI in menu:Account[Language], the `notification` and `userlog` services and WebUI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
 
 == Configuration

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -107,6 +107,10 @@ include::partial$deployment/services/webui_language_code.adoc[]
 *   If the base language `de` is also not available, the service falls back to the system's default English (`en`),
 which is the source of the texts provided by the code.
 
+== Default Language
+
+The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. See the xref:{s-path}/settings.adoc#default-language[settings] service for a detailed description.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]


### PR DESCRIPTION
Fixes: #630 (Update settings service description)

Adds the default language description in the settings service (+ userlog and notifications)

Set to Draft as the referenced ocis PR is not yes merged. 