### PR TITLE
Add envvar type description

### DIFF
--- a/modules/ROOT/pages/deployment/services/_special-envvar.adoc
+++ b/modules/ROOT/pages/deployment/services/_special-envvar.adoc
@@ -6,7 +6,7 @@ when a content is created, we can fix this here and in env-vars-special-scope.ad
 ////
 
 tag::service_tab_1[]
-[width="100%",cols="30%,70%",options="header",]
+[width="100%",cols="30%,70%",options="header"]
 |===
 | Name
 | Description
@@ -25,7 +25,7 @@ Note to get the current list of services started by default, you need to run `oc
 end::service_tab_1[]
 
 tag::service_tab_2[]
-[width="100%",cols="30%,70%",options="header",]
+[width="100%",cols="30%,70%",options="header"]
 |===
 | Name
 | Description
@@ -44,7 +44,7 @@ Note to get the current list of services started by default, you need to run `oc
 end::service_tab_2[]
 
 tag::service_tab_3[]
-[width="100%",cols="30%,70%",options="header",]
+[width="100%",cols="30%,70%",options="header"]
 |===
 | Name
 | Description

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -21,7 +21,7 @@ Examples:
 // their source is in: https://github.com/owncloud/ocis/blob/master/ocis-pkg/config/config.go
 // at 'type Runtime struct'
 
-The following environment variables are only available with the xref:deployment/binary/binary-setup.adoc[Binary Setup]:
+The following environment variables are only available with the xref:deployment/binary/binary-setup.adoc[Binary Setup]. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 
 [tabs]
 ====

--- a/modules/ROOT/pages/deployment/services/envvar-types-description.adoc
+++ b/modules/ROOT/pages/deployment/services/envvar-types-description.adoc
@@ -3,7 +3,7 @@
 ////
 The envvar type description document is referenced via `env-and-yaml.adoc`and `env-vars-special-scope.adoc`.
 It contains a general description how envvar types influence the values an envvar can take.
-This brings clearance and reducues possible errors and repeated explanation.
+This brings clarity and reduces possible errors and repeated explanation.
 If a new envvar type gets added, the description needs to be updated.
 Note, do not add this file to the navigation.
 ////
@@ -38,7 +38,7 @@ Note, do not add this file to the navigation.
 NOTE: If a string contains commas, it is still treated as a single string and not as an array containing multiple strings like: +
 `OCIS_LDAP_GROUP_BASE_DN=ou=groups,o=libregraph-idm`
 
-NOTE: Some values defined as string are _not_ defined as `int` by purpose to distinguish between `0` (zero) and `''`(empty). For an example see `GRAPH_SPACES_DEFAULT_QUOTA`.
+NOTE: Some values defined as string are _not_ defined as `int` on purpose to distinguish between `0` (zero) and `''`(empty). For an example see `GRAPH_SPACES_DEFAULT_QUOTA`.
 --
 
 | []string

--- a/modules/ROOT/pages/deployment/services/envvar-types-description.adoc
+++ b/modules/ROOT/pages/deployment/services/envvar-types-description.adoc
@@ -1,0 +1,74 @@
+= Environment Variable Types
+
+////
+The envvar type description document is referenced via `env-and-yaml.adoc`and `env-vars-special-scope.adoc`.
+It contains a general description how envvar types influence the values an envvar can take.
+This brings clearance and reducues possible errors and repeated explanation.
+If a new envvar type gets added, the description needs to be updated.
+Note, do not add this file to the navigation.
+////
+
+:description: The following table describes the allowed values for an environment variable based on it's type. If not stated otherwise, no quotes around values are needed.
+
+{description}
+
+{empty} +
+
+[width="100%",cols="10%,90%a",options="header"]
+|===
+| Type
+| Description & Examples
+
+| bool
+| A boolean value defined either by `true` or `false`. +
+`OCIS_LOG_PRETTY=false`
+
+| string
+| In general, only one allowed value.
+--
+* Any allowed string like a path or name: +
+`OCIS_REVA_GATEWAY=com.owncloud.api.gateway`
+* If predefined by a list of possible values - even from external sources, the exact value like: +
+`OCIS_LOG_LEVEL=error`
+* If a value might contain blanks or special characters like with templates, embed the value in quotes: +
+`FRONTEND_OCS_ADDITIONAL_INFO_ATTRIBUTE='{{.Mail}}'` +
+`STORAGE_USERS_OCIS_GENERAL_SPACE_ALIAS_TEMPLATE=` +
+{nbsp}{nbsp}{nbsp}{nbsp}{nbsp} `'{{.SpaceType}}/{{.SpaceName \| replace " " "-" \| lower}}'`
+
+NOTE: If a string contains commas, it is still treated as single string and not as array containing multiple strings like: +
+`OCIS_LDAP_GROUP_BASE_DN=ou=groups,o=libregraph-idm`
+
+NOTE: Some values defined as string are _not_ defined as `int` by purpose to distinguish between `0` (zero) and `''`(empty). For an example see `GRAPH_SPACES_DEFAULT_QUOTA`.
+--
+
+| []string
+| An array with multiple values allowed. The list is comma separated ONLY, no blanks or brackets of any kind:
+--
+* `FRONTEND_CHECKSUMS_SUPPORTED_TYPES=sha1,md5,adler32`
+* The complete array can be put into quotes like: +
+`THUMBNAILS_RESOLUTIONS='16x16,32x32,64x64,128x128'`
+* Though possible, _avoid_ putting values in quotes as this can easily cause escaping issues: +
+`OCIS_CORS_ALLOW_HEADERS="\'Authorization\',\'Origin\',\'Content-Type\'"`
+--
+
+| int
+| An integer value with no other characters than numbers. +
+See https://pkg.go.dev/builtin#int[int,window=_blank] for the value range. Empty values default to `0` (zero): +
+`WEB_CACHE_TTL=604800`
+
+| uint
+| An unsigned integer value with no other characters than numbers. +
+See https://pkg.go.dev/builtin#uint[uint,window=_blank] for the value range. Empty values default to `0` (zero): +
+`SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT=20971520`
+
+| int64
+| A 64bit integer value with no other characters than numbers. +
+See https://pkg.go.dev/builtin#int64[int64,window=_blank] for the value range. Empty values default to `0` (zero): +
+`USERS_OWNCLOUDSQL_NOBODY=90`
+
+| Duration
+| The duration can be set as number followed by a unit identifier like s, m or h. +
+Empty values default to `0` (zero): +
+`OCIS_PERSISTENT_STORE_TTL=0s` +
+`OCIS_CACHE_TTL=336h0m0s`
+|===

--- a/modules/ROOT/pages/deployment/services/envvar-types-description.adoc
+++ b/modules/ROOT/pages/deployment/services/envvar-types-description.adoc
@@ -35,7 +35,7 @@ Note, do not add this file to the navigation.
 `STORAGE_USERS_OCIS_GENERAL_SPACE_ALIAS_TEMPLATE=` +
 {nbsp}{nbsp}{nbsp}{nbsp}{nbsp} `'{{.SpaceType}}/{{.SpaceName \| replace " " "-" \| lower}}'`
 
-NOTE: If a string contains commas, it is still treated as single string and not as array containing multiple strings like: +
+NOTE: If a string contains commas, it is still treated as a single string and not as an array containing multiple strings like: +
 `OCIS_LDAP_GROUP_BASE_DN=ou=groups,o=libregraph-idm`
 
 NOTE: Some values defined as string are _not_ defined as `int` by purpose to distinguish between `0` (zero) and `''`(empty). For an example see `GRAPH_SPACES_DEFAULT_QUOTA`.
@@ -62,12 +62,12 @@ See https://pkg.go.dev/builtin#uint[uint,window=_blank] for the value range. Emp
 `SEARCH_CONTENT_EXTRACTION_SIZE_LIMIT=20971520`
 
 | int64
-| A 64bit integer value with no other characters than numbers. +
+| A 64-bit integer value with no other characters than numbers. +
 See https://pkg.go.dev/builtin#int64[int64,window=_blank] for the value range. Empty values default to `0` (zero): +
 `USERS_OWNCLOUDSQL_NOBODY=90`
 
 | Duration
-| The duration can be set as number followed by a unit identifier like s, m or h. +
+| The duration can be set as a number followed by a unit identifier like s, m or h. +
 Empty values default to `0` (zero): +
 `OCIS_PERSISTENT_STORE_TTL=0s` +
 `OCIS_CACHE_TTL=336h0m0s`

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -8,7 +8,7 @@
 
 {description} 
 
-== Configuration
+== Antivirus Configuration
 
 === Antivirus Scanner Type
 

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -71,11 +71,11 @@ ifndef::no_yaml[]
 
 === Environment Variables
 
-The `{service_name}` service is configured via the following environment variables:
+The `{service_name}` service is configured via the following environment variables. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 endif::no_yaml[]
 
 ifdef::no_yaml[]
-The `{service_name}` variables are defined in the following way:
+The `{service_name}` variables are defined in the following way. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 endif::no_yaml[]
 
 // create the tabs. note that if no_second_tab is set, the third tab is also not shown


### PR DESCRIPTION
Fixes: #648 (Add to each service a description how values of envvars are notated/treated)

This is the first step in fixing the issue that we have no documentation for how envvar types are treated and which values are allowed in which format.

The document is referenced on each service envvar description automatically on top of the table.

As next step, we need to fix _all_ the texts and defaults for envvars with arrays as the examples are written with blank instead of comma.

The current built can bee seen on [staging](https://doc.staging.owncloud.com/ocis/next/deployment/services/s-list/antivirus.html#configuration).

Note when merged, we can reference the document in the dev docs as that is quite complicated to rebuild in markdown and doubles work for maintenance.

Note that the docuement is not in the navigation by purpose.

@dragonchaser fyi