### PR TITLE
Use global variables for password policy in the frontend service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -56,21 +56,21 @@ With the password policy, mandatory criteria for the password can be defined via
 
 Generally, a password can contain any UTF-8 characters, however some characters are regarded as special since they are not used in ordinary texts. Which characters should be treated as special is defined by "The OWASP® Foundation" https://owasp.org/www-community/password-special-characters[password-special-characters] (between double quotes): " !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~"
 
-The validation against the banned passwords list can be configured via a text file with words separated by new lines. If a user tries to set a password listed in the banned passwords list, the password can not be used (is invalid) even if the other mandatory criteria are passed. The admin can define the path of the banned passwords list file. If the file doesn't exist in a location, Infinite Scale tries to load a file from the `OCIS_CONFIG_DIR/FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`. An option will be enabled when the file has been loaded successfully.
+The validation against the banned passwords list can be configured via a text file with words separated by new lines. If a user tries to set a password listed in the banned passwords list, the password can not be used (is invalid) even if the other mandatory criteria are passed. The admin can define the path of the banned passwords list file. If the file doesn't exist in a location, Infinite Scale tries to load a file from the `OCIS_CONFIG_DIR/OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST`. An option will be enabled when the file has been loaded successfully.
 
 The following environment variables can be set to define the password policy behavior:
 
-* `FRONTEND_PASSWORD_POLICY_MIN_CHARACTERS` +
+* `OCIS_PASSWORD_POLICY_MIN_CHARACTERS` +
 Define the minimum password length.
-* `FRONTEND_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS` +
+* `OCIS_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS` +
 Define the minimum number of uppercase letters.
-* `FRONTEND_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS` +
+* `OCIS_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS` +
 Define the minimum number of lowercase letters.
-* `FRONTEND_PASSWORD_POLICY_MIN_DIGITS` +
+* `OCIS_PASSWORD_POLICY_MIN_DIGITS` +
 Define the minimum number of digits.
-* `FRONTEND_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS` +
+* `OCIS_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS` +
 Define the minimum number of special characters.
-* `FRONTEND_PASSWORD_POLICY_BANNED_PASSWORDS_LIST` +
+* `OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST` +
 Path to the 'banned passwords list' file.
 
 NOTE: A password can have a *maximum length* of **72 bytes**. Depending on the alphabet used, a character is encoded by 1 to 4 bytes, defining the maximum length of a password indirectly. While US-ASCII will only need one byte, Latin alphabets and also Greek or Cyrillic ones need two bytes. Three bytes are needed for characters in Chinese, Japanese and Korean etc.


### PR DESCRIPTION
Fixes: #676 Use global variables for password policy in the frontend service

Change some envvars from local to global to be inline with ocis dev docs, see referenced issue.