### PR TITLE
Update site.yml and antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,7 +22,7 @@ asciidoc:
     # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1_tab_text: 'latest'
-    service_tab_2_tab_text: '4.0.2' # latest stable
+    service_tab_2_tab_text: '4.0.4' # latest stable including patch releases
     service_tab_3_tab_text: '3.0.0' # former stable
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
@@ -34,7 +34,7 @@ asciidoc:
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
     # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1_tab_text: 'latest'
-    compose_tab_2_tab_text: '4.0.2' # latest stable
+    compose_tab_2_tab_text: '4.0.4' # latest stable including patch releases
     compose_tab_3_tab_text: '3.0.0' # former stable
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)

--- a/site.yml
+++ b/site.yml
@@ -58,7 +58,7 @@ asciidoc:
     latest-server-download-version: 'next'
     current-server-version: 'next'
     oc-changelog-url: 'https://owncloud.com/changelog/server/'
-    oc-install-package-url: 'https://software.opensuse.org//download.html?project=isv%3AownCloud%3Aserver%3A10&package=owncloud-complete-files'
+    oc-install-package-url: 'https://download.owncloud.com/server/stable/?sort=time&order=asc'
     oc-examples-server-url: 'https://owncloud.install.com/owncloud'
     oc-examples-server-ip: '127.0.0.1'
     oc-examples-username: 'username'
@@ -79,8 +79,8 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next'
     previous-ocis-version: 'next'
-    ocis-actual-version: '4.0.2'
-    ocis-former-version: '4.0.1'
+    ocis-actual-version: '4.0.4'
+    ocis-former-version: '4.0.3'
     ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
 #   desktop


### PR DESCRIPTION
Small updates to `site.yml` (for local build only) and `antora.yml`.

Note that the vesion changes may be updated soon again.
Note that the link change in site.yml is only for completeness