### PR TITLE
docs: fix the ocis init config path in the docs

### DIFF
--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -232,7 +232,7 @@ docker run --rm -it \
 
 On success, you will see a message like:
 
-:init_path: /etc/ocis/ocis-config/ocis.yaml
+:init_path: /etc/ocis/ocis.yaml
 
 include::partial$deployment/ocis_init.adoc[]
 
@@ -242,7 +242,7 @@ If you get an error message like the following:
 
 [source,plaintext]
 ----
-Could not create config: config in /etc/ocis/ocis-config/ocis.yaml already exists
+Could not create config: config in /etc/ocis/ocis.yaml already exists
 ----
 
 you already have created a configuration once. As you cannot overwrite the existing configuration, you must delete the old configuration first to proceed. For more details, see: xref:deployment/general/general-info.adoc#initialize-infinite-scale[Initialize Infinite Scale].


### PR DESCRIPTION
Part of: https://github.com/owncloud/ocis/issues/7940

While testing the docs for the docker container following command responds
```console
docker run --rm -it \
    --mount type=bind,source=$PWD/ocis/ocis-config,target=/etc/ocis \
    owncloud/ocis init
```
```console
Do you want to configure Infinite Scale with certificate checking disabled?
 This is not recommended for public instances! [yes | no = default] 

=========================================
 generated OCIS Config
=========================================
 configpath : /etc/ocis/ocis.yaml
 user       : admin
 password   : <some-value>
```

The config path is ` /etc/ocis/ocis.yaml` and not `/etc/ocis/ocis-config/ocis.yaml` . I don't know if this is an expected path or not but the command responds as such and the setup also works. 

This PR fixes the `configpath`