### PR TITLE
Fix faulty xrefs found during the antora upgrade

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -146,7 +146,7 @@ As soon as that query is configured, the postprocessing service must be informed
 POSTPROCESSING_STEPS=policies
 ----
 
-Note that additional steps can be configured and their position in the list defines the order of processing. For details see the xref:{s-path}.adoc[postprocessing service] documentation.
+Note that additional steps can be configured and their position in the list defines the order of processing. For details see the xref:{s-path}/postprocessing.adoc[postprocessing service] documentation.
 
 == Example Policies
 

--- a/modules/ROOT/pages/deployment/services/s-list/search.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/search.adoc
@@ -55,7 +55,7 @@ This extractor is the most simple one and just uses the resource information pro
 === Tika Extractor
 
 This extractor is more advanced compared to the xref:basic-extractor[Basic extractor]. The main difference is that this extractor is able to provide file contents for the index.
-Though you can compile Tika manually on your system by following the https://tika.apache.org/{tika-version}/gettingstarted.html[Getting Started with Apache Tika] guide (newer Tika versions may be available) or download a precompiled xref:https://tika.apache.org/download.html[Tika server], you can also run Tika using a https://hub.docker.com/r/apache/tika[Tika container]. See the https://github.com/apache/tika-docker#usage[Tika container usage document] for a quickstart. Note that at the time of writing, containers are only available for the `amd64` platform.
+Though you can compile Tika manually on your system by following the https://tika.apache.org/{tika-version}/gettingstarted.html[Getting Started with Apache Tika] guide (newer Tika versions may be available) or download a precompiled https://tika.apache.org/download.html[Tika server], you can also run Tika using a https://hub.docker.com/r/apache/tika[Tika container]. See the https://github.com/apache/tika-docker#usage[Tika container usage document] for a quickstart. Note that at the time of writing, containers are only available for the `amd64` platform.
 
 As soon as Tika is installed and accessible, the search service must be configured for the use with Tika. The following settings must be set:
 

--- a/modules/ROOT/pages/deployment/services/services.adoc
+++ b/modules/ROOT/pages/deployment/services/services.adoc
@@ -34,7 +34,7 @@ The following services have been introduced with the releases listed:
 | xref:{s-path}/invitations.adoc[Invitations]
 | The Invitations service provides an invitation manager that can be used to invite external users, aka guests, to an organization.
 
-| xref:{s-path}/notification.adoc[Notification]
+| xref:{s-path}/notifications.adoc[Notification]
 | The Notification service is responsible for sending emails to users informing them about events that happened.
 
 | xref:{s-path}/policies.adoc[Policies]


### PR DESCRIPTION
These xrefs have been identified to cause errors and needed a fix.