### PR TITLE
Make the ocis content versioned

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -16,29 +16,24 @@ asciidoc:
     s-path: 'deployment/services/s-list'
 
     # service_tab_x will be used to assemble the url accessing the link for the services
-    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1: 'docs' # do not change, the docs branch contains changes of master
-    service_tab_2: 'docs-stable-4.0' # latest stable
-    service_tab_3: 'docs-stable-3.0' # former stable
+#    service_tab_2: 'docs-stable-4.0' # latest stable
+#    service_tab_3: 'docs-stable-3.0' # former stable
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
-    # note that we are refering via the 'service_tab_x' branch to the ocis repo, not the master branch!
-    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     service_tab_1_tab_text: 'latest'
-    service_tab_2_tab_text: '4.0.4' # latest stable including patch releases
-    service_tab_3_tab_text: '3.0.0' # former stable
+#    service_tab_2_tab_text: '4.0.4' # latest stable including patch releases
+#    service_tab_3_tab_text: '3.0.0' # former stable
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1: 'master'
-    compose_tab_2: 'v4.0.0' # latest stable
-    compose_tab_3: 'v3.0.0' # former stable
+#    compose_tab_2: 'v4.0.0' # latest stable
+#    compose_tab_3: 'v3.0.0' # former stable
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    # note that tab 2 should always contain the actual release and tab 3 the former, if use_service_tab_3 is enabled
     compose_tab_1_tab_text: 'latest'
-    compose_tab_2_tab_text: '4.0.4' # latest stable including patch releases
-    compose_tab_3_tab_text: '3.0.0' # former stable
+#    compose_tab_2_tab_text: '4.0.4' # latest stable including patch releases
+#    compose_tab_3_tab_text: '3.0.0' # former stable
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
     # note that tab 2 always contains the actual release and tab 3 the former

--- a/modules/ROOT/pages/conf-examples/office/ext-files/app-registry.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/app-registry.adoc
@@ -3,17 +3,17 @@ Note that this page is created because when the contents of the included yaml is
 
 The source content comes from github.
 
-Note that you cant create a attribute on the fly and handover to the include macro
+Note that you cant create a attribute on the fly and handover to the include macro.
 
-We need to allow substitution of attributes first, then macros
+We need to allow substitution of attributes first, then macros.
 ////
 
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/config/ocis/app-registry.yaml[]
+.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/ocis/app-registry.yaml[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/config/ocis/app-registry.yaml[]
+include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/ocis/app-registry.yaml[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/ext-files/docker-compose.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/docker-compose.adoc
@@ -3,17 +3,17 @@ Note that this page is created because when the contents of the included yaml is
 
 The source content comes from github.
 
-Note that you cant create a attribute on the fly and handover to the include macro
+Note that you cant create a attribute on the fly and handover to the include macro.
 
-We need to allow substitution of attributes first, then macros
+We need to allow substitution of attributes first, then macros.
 ////
 
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/docker-compose.yml[]
+.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/docker-compose.yml[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/docker-compose.yml[]
+include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/docker-compose.yml[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/ext-files/env.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/env.adoc
@@ -3,7 +3,7 @@ Note that this page is created because when the contents of the included yaml is
 
 The source content comes from github.
 
-Note that you cant create a attribute on the fly and handover to the include macro
+Note that you cant create an attribute on the fly and handover to the include macro.
 
 We need to allow substitution of attributes first, then macros
 ////
@@ -11,9 +11,9 @@ We need to allow substitution of attributes first, then macros
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/.env[]
+.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/.env[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/.env[]
+include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/.env[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/ext-files/wopiserver.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/wopiserver.adoc
@@ -3,17 +3,17 @@ Note that this page is created because when the contents of the included yaml is
 
 The source content comes from github.
 
-Note that you cant create a attribute on the fly and handover to the include macro
+Note that you cant create a attribute on the fly and handover to the include macro.
 
-We need to allow substitution of attributes first, then macros
+We need to allow substitution of attributes first, then macros.
 ////
 
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
+.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_2}{composer-final-path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
+include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/office-integration.adoc
+++ b/modules/ROOT/pages/conf-examples/office/office-integration.adoc
@@ -56,7 +56,7 @@ For the clients, make sure that the addresses can be resolved to the server(s) r
 
 == Installation
 
-Installing the Docker stacks only requires a few steps. Take care to use the relevant version. Select a base folder of choice for the target location. Note that the examples use the latest stable version: {compose_tab_2}.
+Installing the Docker stacks only requires a few steps. Take care to use the relevant version. Select a base folder of choice for the target location. Note that the examples use the version corresponding to this release.
 
 . Get the deployment example:
 +

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -106,30 +106,16 @@ When done, create a project directory like `ocis-compose` in your home directory
 
 Using git version name: `{compose_tab_1}`
 --
-{compose_tab_2_tab_text}::
-+
---
-{composer-url}{compose_tab_2}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
-
-Using git version name: `{compose_tab_2}`
---
-{compose_tab_3_tab_text}::
-+
---
-{composer-url}{compose_tab_3}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
-
-Using git version name: `{compose_tab_3}`
---
 ====
 +
 --
-Note that github will not let you download a single directory easily. You can get the examples using the following methods requiring minimum space, replace the version accordingly:
+Note that github will not let you download a single directory easily. You can get the examples using the following methods requiring minimum space. For stable releases, update the version accordingly like when there is a new patch release available:
 
 * Using a shallow git clone which minimizes the required clone space like:
 +
 [source,bash,subs="attributes+"]
 ----
-git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_2}
+git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_1}
 ----
 
 // https://stackoverflow.com/questions/7106012/download-a-single-folder-or-directory-from-a-github-repo
@@ -138,7 +124,7 @@ git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_2}
 +
 [source,plaintext,subs="attributes+"]
 ----
-{download-gh-directory-url}?url={composer-url}{compose_tab_2}{composer-final-path}
+{download-gh-directory-url}?url={composer-url}{compose_tab_1}{composer-final-path}
 ----
 --
 

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -35,10 +35,10 @@ include::./_special-envvar.adoc[tag=service_tab_1]
 == Extended Environment Variables
 
 ////
-note that if a description of an extended envvar is missing, you need to fix this in:
+Note that if a description of an extended envvar is missing, you need to fix this in:
 https://github.com/owncloud/ocis/blob/master/docs/helpers/extended_vars.yaml
 see the readme.md file in that folder.
-IMPORTANT, extended envvars do not have a extended_deprecation.adoc file. we therefore must set the attribute to true.
+IMPORTANT: Extended envvars do not have an extended_deprecation.adoc file. We therefore must set the attribute to true.
 ////
  
 :service_name: extended
@@ -46,7 +46,7 @@ IMPORTANT, extended envvars do not have a extended_deprecation.adoc file. we the
 
 include::partial$deployment/services/env-and-yaml.adoc[]
 
-// IMPORTANT, global envvars currently do not have a global_deprecation.adoc file. we therefore must set the attribute to true.
+// IMPORTANT: Global envvars currently do not have a global_deprecation.adoc file. We therefore must set the attribute to true.
 
 == Global Environment Variables
 

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -30,28 +30,23 @@ The following environment variables are only available with the xref:deployment/
 --
 include::./_special-envvar.adoc[tag=service_tab_1]
 --
-{service_tab_2_tab_text}::
-+
---
-include::./_special-envvar.adoc[tag=service_tab_2]
---
-{service_tab_3_tab_text}::
-+
---
-include::./_special-envvar.adoc[tag=service_tab_3]
---
 ====
 
 == Extended Environment Variables
 
-// note that if a description of an extended envvar is missing, you need to fix this in:
-// https://github.com/owncloud/ocis/blob/master/docs/helpers/extended_vars.yaml
-// see the readme.md file in that folder
+////
+note that if a description of an extended envvar is missing, you need to fix this in:
+https://github.com/owncloud/ocis/blob/master/docs/helpers/extended_vars.yaml
+see the readme.md file in that folder.
+IMPORTANT, extended envvars do not have a extended_deprecation.adoc file. we therefore must set the attribute to true.
+////
  
 :service_name: extended
 :no_deprecation: true
 
 include::partial$deployment/services/env-and-yaml.adoc[]
+
+// IMPORTANT, global envvars currently do not have a global_deprecation.adoc file. we therefore must set the attribute to true.
 
 == Global Environment Variables
 

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -161,20 +161,6 @@ The policies service contains a set of preconfigured example policies. See the d
 
 Using git version name: `{compose_tab_1}`
 --
-{compose_tab_2_tab_text}::
-+
---
-{composer-url}{compose_tab_2}{composer-final-path}[Rego policies deployment examples directory,window=_blank]
-
-Using git version name: `{compose_tab_2}`
---
-{compose_tab_3_tab_text}::
-+
---
-{composer-url}{compose_tab_3}{composer-final-path}[Rego policies deployment examples directory,window=_blank]
-
-Using git version name: `{compose_tab_3}`
---
 ====
 
 == Extend Mime Type File Extension Mapping

--- a/modules/ROOT/pages/deployment/wopi/wopi.adoc
+++ b/modules/ROOT/pages/deployment/wopi/wopi.adoc
@@ -75,30 +75,16 @@ image::deployment/wopi/wopi-overview.svg[WOPI Overview Diagram,width=500]
 
 Using git version name: `{compose_tab_1}`
 --
-{compose_tab_2_tab_text}::
-+
---
-{composer-url}{compose_tab_2}{composer-final-path}{wopi_subdir}[Docker Compose WOPI deployment examples directory,window=_blank]
-
-Using git version name: `{compose_tab_2}`
---
-{compose_tab_3_tab_text}::
-+
---
-{composer-url}{compose_tab_3}{composer-final-path}{wopi_subdir}[Docker Compose WOPI deployment examples directory,window=_blank]
-
-Using git version name: `{compose_tab_3}`
---
 ====
 +
 --
-Note that github will not let you download a single directory easily. You can get the examples using the following methods requiring minimum space. Replace the version accordingly:
+Note that github will not let you download a single directory easily. You can get the examples using the following methods requiring minimum space. For stable releases, update the version accordingly like when there is a new patch release available:
 
 * Using a shallow git clone which minimizes the required clone space like:
 +
 [source,bash,subs="attributes+"]
 ----
-git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_2}
+git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_1}
 ----
 
 // https://stackoverflow.com/questions/7106012/download-a-single-folder-or-directory-from-a-github-repo
@@ -107,6 +93,6 @@ git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_2}
 +
 [source,plaintext,subs="attributes+"]
 ----
-{download-gh-directory-url}?url={composer-url}{compose_tab_2}{composer-final-path}{wopi_subdir}
+{download-gh-directory-url}?url={composer-url}{compose_tab_1}{composer-final-path}{wopi_subdir}
 ----
 --

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -5,14 +5,14 @@ If no_yaml is set, it will exclude rendering yaml files because it does not exis
 Print a dependent explanation line:
 
 * no_yaml is not set = standard service
-* no_yaml is set = special scope envvars
+* no_yaml is set     = special scope envvars
 
 Conditional tab printing, example:
 
 * no_second_tab = based on first appearance of the service (defined in a service),
   must overrule service tab. If there is no second, there is also no third.
 
-*   Note to make a tab hidden by no_xxx_tab showing up again, just comment it.
+* Note to make a tab hidden by no_xxx_tab showing up again, just comment it.
 
 The included deprecation file just has an attribute necessary for rendering deprecations.
 This is necessary as attributes that are defined INSIDE a tabset will not get recognized, attributes need to be defined OUTSIDE the tabset definition. example content:
@@ -27,58 +27,33 @@ To exclude a deprecation file if not wanted - like when the file will just not e
 
 ////
 
-// read the xxx_deprecation.adoc file from ocis to evaluate deprecations but only if 'no_deprecation' is not set
-// see the deprecation evaluation in the next block how it gets handled 
+////
+important: the xxx_deprecation.adoc does not extist for extended or global envvars. it may change for global envvars! therefore we need to query 'no_deprecation' to skip importing - or if we exclicitely dont want to show deprecated content.
+when rendering an included content in a table, any attribute set in the included file is dropped and cant be queried. therefore we read upfront xxx_deprecation.adoc where only the deprecation state is set. having this we extra set 'show-deprecation' outside the tab but with the same value which is taken for building.
+////
+
+:show-deprecation: false
 
 ifndef::no_deprecation[]
 // deprecation test tab 1, uncomment for testing
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
-ifeval::["{show-deprecation}" == "true"]
-:has_deprecation_tab_1: true
-endif::[]
-
-ifndef::no_second_tab[]
-// deprecation test tab 2, uncomment for testing
-include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
-ifeval::["{show-deprecation}" == "true"]
-:has_deprecation_tab_2: true
-endif::[]
-
-ifndef::no_third_tab[]
-// deprecation test tab 3, uncomment for testing
-include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
-ifeval::["{show-deprecation}" == "true"]
-:has_deprecation_tab_3: true
-endif::[]
-endif::no_third_tab[]
-endif::no_second_tab[]
-
-////
-if one tab deprecation is set to true, set it generally. ifdef with comma uses or (with + uses and).
-this will show the deprecation table in *all* tabs if one is true, independent if that tab has one or not.
-this is because attributes are only evaluated OUTSIDE a tab definition.
-////
-
-ifdef::has_deprecation_tab_1,has_deprecation_tab_2,has_deprecation_tab_3[]
-:show-deprecation: true
-endif::[]
-
 endif::no_deprecation[]
 
-// conditionally render the variable entry text, either with or without section header
+// conditionally render the envvar entry text, either with or without section header
 
+// text version 1
 ifndef::no_yaml[]
-
 === Environment Variables
 
 The `{service_name}` service is configured via the following environment variables. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 endif::no_yaml[]
 
+// text version 2
 ifdef::no_yaml[]
 The `{service_name}` variables are defined in the following way. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 endif::no_yaml[]
 
-// create the tabs. note that if no_second_tab is set, the third tab is also not shown
+// create the tabs in any case
 
 [tabs]
 ====
@@ -87,24 +62,9 @@ endif::no_yaml[]
 --
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
 --
-ifndef::no_second_tab[]
-{service_tab_2_tab_text}::
-+
---
-include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
---
-ifndef::no_third_tab[]
-{service_tab_3_tab_text}::
-+
---
-include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
---
-endif::no_third_tab[]
-endif::no_second_tab[]
 ====
 
 ifndef::no_yaml[]
-
 === YAML Example
 
 Note that the filename shown below has been chosen on purpose. +
@@ -120,26 +80,5 @@ See the xref:deployment/general/general-info.adoc#configuration-file-naming[Conf
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}{service_name}-config-example.yaml[]
 ----
 --
-ifndef::no_second_tab[]
-{service_tab_2_tab_text}::
-+
---
-[source,yaml]
-----
-include::{ocis-services-raw-url}{service_tab_2}{ocis-services-final-path}{service_name}-config-example.yaml[]
-----
---
-ifndef::no_third_tab[]
-{service_tab_3_tab_text}::
-+
---
-[source,yaml]
-----
-include::{ocis-services-raw-url}{service_tab_3}{ocis-services-final-path}{service_name}-config-example.yaml[]
-----
---
-endif::no_third_tab[]
-endif::no_second_tab[]
 ====
-
 endif::no_yaml[]

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -28,8 +28,8 @@ To exclude a deprecation file if not wanted - like when the file will just not e
 ////
 
 ////
-important: the xxx_deprecation.adoc does not extist for extended or global envvars. it may change for global envvars! therefore we need to query 'no_deprecation' to skip importing - or if we exclicitely dont want to show deprecated content.
-when rendering an included content in a table, any attribute set in the included file is dropped and cant be queried. therefore we read upfront xxx_deprecation.adoc where only the deprecation state is set. having this we extra set 'show-deprecation' outside the tab but with the same value which is taken for building.
+Important: The xxx_deprecation.adoc does not exist for extended or global envvars. It may change for global envvars! Therefore we need to query 'no_deprecation' to skip importing - or if we explicitly don't want to show deprecated content.
+When rendering an included content in a table, any attribute set in the included file is dropped and can't be queried. Therefore we read upfront xxx_deprecation.adoc where only the deprecation state is set. Having this extra, we set 'show-deprecation' outside the tab but with the same value which is taken for building.
 ////
 
 :show-deprecation: false


### PR DESCRIPTION
Fixes: #675 ([5.0] Versionize the ocis admin docs)

This PR:

* Removes ALL versioned stuff from the master branch shown as `next` in the URL.
* In existing tabs, keeps only one tab with a heading to show where we are where applicapable.
* Only uses the necessary data for the tab heading and it's content sourced from `antora.yml`.
* Prepares to branch off a version where the tab related stuff needs some changes in the upcoming release branch
* When branching has finished, we need to do a small cleanup task to remove all commented out attributes not longer necessary. Currently we keep them to make preperation easier.

**NOTE:** Versioning ocis has finished when the branches needed are created, which are 4.0 and 5.0 !!

**NOTE:** For the upcoming branching tasks, the branches will get the version and its data from `antora.yml` correctly.

**NOTE:** To make any branch beside master available in the documentation, we need to add these branches to the content catalog in the `docs` repo (as usual).