### PR TITLE
Correct the version in .drone.star in 4.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "master"
+    latest_version = "4.0"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)


### PR DESCRIPTION
This PR corrects the `latest_version` in `.drone.star` for the 4.0 branch.

Missed when creating the 4.0 branch.