### PR TITLE
Make the 5.0 release point to the correct ocis branches.

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -16,20 +16,16 @@ asciidoc:
     s-path: 'deployment/services/s-list'
 
     # service_tab_x will be used to assemble the url accessing the link for the services
-    service_tab_1: 'docs' # do not change, the docs branch contains changes of master
-#    service_tab_1: 'docs-stable-5.0' # latest stable
+    service_tab_1: 'docs-stable-5.0' # latest stable
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
-    service_tab_1_tab_text: 'latest'
-#    service_tab_2_tab_text: '5.0.0' # latest stable including patch releases
+    service_tab_1_tab_text: '5.0.0' # latest stable including patch releases
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_tab_1: 'master'
-#    compose_tab_1: 'v5.0.0' # latest stable
+    compose_tab_1: 'v5.0.0' # latest stable
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    compose_tab_1_tab_text: 'latest'
-#    compose_tab_1_tab_text: '5.0.0' # latest stable including patch releases
+    compose_tab_1_tab_text: '5.0.0' # latest stable including patch releases
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
     # note that tab 2 always contains the actual release and tab 3 the former

--- a/site.yml
+++ b/site.yml
@@ -46,9 +46,9 @@ asciidoc:
     # needs to be changed here and mandatory in the docs repo to be properly shown on the web
     # the following versions get printed on <all> build versions where applicable
     # for branch only dependent version content, change the values in antora.yml at compose_tab_1_tab_text
-    ocis-actual-version: '4.0.5'
-    ocis-former-version: '4.0.4'
-    ocis-compiled: '2023-10-06 00:00:00 +0000 UTC'
+    ocis-actual-version: '5.0.0'
+    ocis-former-version: '4.0.5'
+    ocis-compiled: '2024-02-15 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
   extensions:
     - ./ext-asciidoc/tabs.js


### PR DESCRIPTION
The sources referenced were still on 4.0.
Now they are on 5.0