### PR TITLE
Add envvars to yaml config

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-var-note.adoc
+++ b/modules/ROOT/pages/deployment/services/env-var-note.adoc
@@ -51,3 +51,18 @@ If a service offers path customization like the `IDM_LDAPS_CERT` (see the xref:{
 If you're using a container and want or need to keep all data persistent, you need to provide host filesystem access to the container, which you can do with mounts or volumes.
 ====
 --
+
+== Using Environment Variables in YAML
+
+Environment variables can be used in yaml config files. This allows them to be used in config files for Infinite Scale services, which will then be replaced by the actual value of the environment variable at runtime.
+
+Example:
+
+[source,yaml]
+----
+web:
+  http:
+    addr: ${SOME_HTTP_ADDR}
+----
+
+This makes it possible to use the same config file for different environments, without the need to change the config file itself. Such a setting is especially useful when using docker compose to run Infinite Scale services. It is a common pattern to create an `.env` file which contains the environment variables to be used with docker compose. Now you can use the same `.env` file to configure the Infinite Scale services via yaml.

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -67,8 +67,9 @@ include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{s
 ifndef::no_yaml[]
 === YAML Example
 
-Note that the filename shown below has been chosen on purpose. +
-See the xref:deployment/general/general-info.adoc#configuration-file-naming[Configuration File Naming] for details when setting up your own configuration.
+* Note that the filename shown below has been chosen on purpose.
+* See the xref:deployment/general/general-info.adoc#configuration-file-naming[Configuration File Naming] for details when setting up your own configuration.
+* See the xref:deployment/services/env-var-note.adoc[Notes for Environment Variables] if you want to use environment variables in the yaml file.
 
 [tabs]
 ====


### PR DESCRIPTION
Fixes: #708 ([5.0] Use env variable in yaml config files)

Adding envvars to yaml configs:
* Creating a general description text.
* Adding a note in the partial that will then show up automatically in any service where defined.

Language review welcomed

Backport to 5.0