### PR TITLE
Make local/global envvars in caching more clear

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -22,7 +22,7 @@ The `eventhistory` services consumes all events from the configured event system
 
 == Storing
 
-The `eventhistory` service stores each consumed event via the configured store in `EVENTHISTORY_STORE`. Possible stores are:
+The `eventhistory` service stores each consumed event via the configured store in `EVENTHISTORY_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -93,7 +93,7 @@ A lot of user management is done via the standardized LibreGraph API. Depending 
 
 == Caching
 
-The `frontend` service can use a configured store via `FRONTEND_OCS_STAT_CACHE_STORE`. Possible stores are:
+The `frontend` service can use a configured store via `FRONTEND_OCS_STAT_CACHE_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -16,7 +16,7 @@
 
 == Caching
 
-The `gateway` service can use a configured store via `GATEWAY_STAT_CACHE_STORE`. Possible stores are:
+The `gateway` service can use a configured store via `GATEWAY_STAT_CACHE_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -44,7 +44,7 @@ image::deployment/services/graph/mermaid-graph.svg[width=600]
 
 == Caching
 
-The `graph` service can use a configured store via `GRAPH_CACHE_STORE`. Possible stores are:
+The `graph` service can use a configured store via `GRAPH_CACHE_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -83,7 +83,7 @@ ocis postprocessing restart -u <uploadID>
 
 The `postprocessing` service needs to store some metadata about uploads to be able to orchestrate post-processing. When running in single binary mode, the default in-memory implementation will be just fine. In distributed deployments it is recommended to use a persistent store, see below for more details.
 
-The `postprocessing` service stores each consumed event via the configured store in `POSTPROCESSING_STORE`. Possible stores are:
+The `postprocessing` service stores each consumed event via the configured store in `POSTPROCESSING_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -103,7 +103,7 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
 
 == Caching
 
-The `proxy` service can use a configured store via `PROXY_OIDC_USERINFO_CACHE_STORE`. Possible stores are:
+The `proxy` service can use a configured store via `PROXY_OIDC_USERINFO_CACHE_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -34,7 +34,7 @@ The settings service supports two different backends for persisting the data. Th
 
 When using `SETTINGS_STORE_TYPE=metadata`, the `settings` service caches the results of queries against the storage backend to provide faster responses. The content of this cache is independent of the cache used in the `storage-system` service as it caches directory listing and settings content stored in files.
 
-The store used for the cache can be configured using the `SETTINGS_CACHE_STORE` environment variable. Possible stores are:
+The store used for the cache can be configured using the `SETTINGS_CACHE_STORE` environment variable.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -16,7 +16,7 @@
 
 == Caching
 
-The `frontend` service can use a configured store via `STORAGE_SYSTEM_CACHE_STORE`. Possible stores are:
+The `frontend` service can use a configured store via `STORAGE_SYSTEM_CACHE_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -123,7 +123,7 @@ The configuration for the `purge-expired` command is done by using the following
 
 == Caching
 
-The `storage-users` service caches stat, metadata and uuids of files and folders via the configured store in `STORAGE_USERS_STAT_CACHE_STORE`, `STORAGE_USERS_FILEMETADATA_CACHE_STORE` and `STORAGE_USERS_ID_CACHE_STORE`. Possible stores are:
+The `storage-users` service caches stat, metadata and uuids of files and folders via the configured store in `STORAGE_USERS_STAT_CACHE_STORE`, `STORAGE_USERS_FILEMETADATA_CACHE_STORE` and `STORAGE_USERS_ID_CACHE_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -22,7 +22,7 @@ Running the `userlog` service without running the xref:{s-path}/eventhistory.ado
 
 == Storing
 
-The `userlog` service persists information via the configured store in `USERLOG_STORE`. Possible stores are:
+The `userlog` service persists information via the configured store in `USERLOG_STORE`.
 
 include::partial$multi-location/caching-list.adoc[]
 // you must not have one or more blank lines here as it breaks continuous numbering!

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -5,7 +5,11 @@ When including, there must be at the top and the bottom a line manually added de
 ////
 
 // to be added manually like:
-// The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`. Possible stores are:
+// The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`.
+
+Note that for each service based environment variable, a global one might be available additionally. Check the configuration section below. Possible stores are:
+{empty} +
+{empty} +
 
 [width=100%,cols="25%,85%",options=header]
 |===

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -7,7 +7,7 @@ When including, there must be at the top and the bottom a line manually added de
 // to be added manually like:
 // The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`.
 
-Note that for each service based environment variable, a global one might be available additionally. Check the configuration section below. Possible stores are:
+Note that for each service-based environment variable, a global one might be available additionally. Check the configuration section below. Possible stores are:
 {empty} +
 {empty} +
 


### PR DESCRIPTION
Fixes: #721 ([5.0] Use global envvar for cache or store description)

This PR makes the use of local and global envvars in caching more clear.

Backport to 5.0  