### PR TITLE
Update the General Info page with $HOME and ~ for config and data dir

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -96,7 +96,7 @@ Refer to the xref:deployment/general/general-info.adoc#default-users-and-groups[
 
 ==== First Time Start
 
-Infinite Scale needs a xref:deployment/general/general-info.adoc#initialize-infinite-scale[first time initialization] to set up the environment. You will need to answer questions as the basis for generating a default `ocis.yaml` file. You can edit this file later. The default location for config files is, if not otherwise defined, `$HOME/.ocis/config/`. For details see: xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules]. Type the following command to initialize Infinite Scale.
+Infinite Scale needs a xref:deployment/general/general-info.adoc#initialize-infinite-scale[first time initialization] to set up the environment. You will need to answer questions as the basis for generating a default `ocis.yaml` file. You can edit this file later. The default location for config files is, if not otherwise defined, `~/.ocis/config/`. For details see: xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules]. Type the following command to initialize Infinite Scale.
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -145,7 +145,7 @@ The default locations (no need to set them explicitly) for _config_ files, which
 `/etc/ocis/`
 +
 * For binary releases +
-`$HOME/.ocis/config/`
+`$HOME/.ocis/config/` or `~/.ocis/config/` (preferred)
 +
 NOTE: You can deviate from the default location and define a custom configuration file location on startup using the environment variable `OCIS_CONFIG_DIR`.
 +
@@ -186,7 +186,7 @@ The environment variable `OCIS_BASE_DATA_PATH`, if manually defined, sets the ba
 `/var/lib/ocis`
 +
 * For binary releases +
-`$HOME/.ocis/`
+`$HOME/.ocis/` or `~/.ocis/config/` (preferred)
 +
 NOTE: You can deviate from the default location and define a custom configuration file location on startup using 
 the environment variable `OCIS_BASE_DATA_PATH`. When setting the base directory manually, it will be used automatically for the services described above - if they are not otherwise manually defined. 


### PR DESCRIPTION
Fixes: 714 ([5.0] change ocis basepath from home to /etc)

Add an info to use `$HOME` and `~` for config and data dir.

Backport to 5.0