### PR TITLE
Update caching and persistence

### DIFF
--- a/modules/ROOT/pages/deployment/services/caching.adoc
+++ b/modules/ROOT/pages/deployment/services/caching.adoc
@@ -25,7 +25,7 @@
 ** persistence is not a requirement (issue: restart/reboot) and
 ** scaling of services is not required (issue: instantiation).
 
-* *External products* like `redis`, `redis-sentinel`, `etcd`, `nats-js` which are independent services not related to Infinite Scale. They are usually installed on separate hardware requiring their own performance, availability and scalability measures. These products are connected via a fast network. Infinite Scale connects to these store types and uses their services like a black box.
+* *External products* like `nats-js-kv` or `redis-sentinel` are independent services not related to Infinite Scale. They are usually installed on separate hardware requiring their own performance, availability and scalability measures. These products are connected via a fast network. Infinite Scale connects to these store types and uses their services like a black box.
 
 === Local vs Global Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -45,6 +45,10 @@ The antivirus service can scan files during `post-processing`. `on demand` scann
 
 The antivirus service will scan files during post-processing. It listens for a post-processing step called `virusscan`. This step can be added in the environment variable `POSTPROCESSING_STEPS`. Read the documentation of the xref:{s-path}/postprocessing.adoc[postprocessing service] for more details.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/audit.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/audit.adoc
@@ -39,6 +39,10 @@ The audit service logs:
 - Sharing operations +
 (user/group sharing, sharing via link, changing permissions, calls to sharing API from clients)
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/clientlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/clientlog.adoc
@@ -18,6 +18,10 @@ include::partial$deployment/services/log-service-ecosystem.adoc[]
 
 The messages the `clientlog` service sends are intended for use by clients, _not by users_. The client might for example be informed that a file has finished post-processing. With that, the client can make the file available to the user without additional server queries.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -22,11 +22,9 @@ The `eventhistory` services consumes all events from the configured event system
 
 == Storing
 
-The `eventhistory` service stores each consumed event via the configured store in `EVENTHISTORY_STORE`.
+:is_stat: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `EVENTHISTORY_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -16,19 +16,23 @@
 
 Running the `eventhistory` service without an event system like NATS is not possible.
 
-== Consuming
+=== Consuming
 
 The `eventhistory` services consumes all events from the configured event system.
 
-== Storing
+=== Storing
 
 :is_stat: true
 
 include::partial$multi-location/caching-list.adoc[]
 
-== Retrieving
+=== Retrieving
 
 Other services can call the `eventhistory` service via a gRPC call to retrieve events. The request must contain the event ID that should be retrieved.
+
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -62,14 +62,19 @@ The following environment variables can be set to define the password policy beh
 
 * `OCIS_PASSWORD_POLICY_MIN_CHARACTERS` +
 Define the minimum password length.
+
 * `OCIS_PASSWORD_POLICY_MIN_LOWERCASE_CHARACTERS` +
 Define the minimum number of uppercase letters.
+
 * `OCIS_PASSWORD_POLICY_MIN_UPPERCASE_CHARACTERS` +
 Define the minimum number of lowercase letters.
+
 * `OCIS_PASSWORD_POLICY_MIN_DIGITS` +
 Define the minimum number of digits.
+
 * `OCIS_PASSWORD_POLICY_MIN_SPECIAL_CHARACTERS` +
 Define the minimum number of special characters.
+
 * `OCIS_PASSWORD_POLICY_BANNED_PASSWORDS_LIST` +
 Path to the 'banned passwords list' file.
 
@@ -93,11 +98,9 @@ A lot of user management is done via the standardized LibreGraph API. Depending 
 
 == Caching
 
-The `frontend` service can use a configured store via `FRONTEND_OCS_STAT_CACHE_STORE`.
+:is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_STAT_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -96,6 +96,10 @@ While the frontend service does not persist any data, it does cache information 
 
 A lot of user management is done via the standardized LibreGraph API. Depending on how the system is configured, there might be some user attributes that an Infinite Scale instance admin can't change because of properties coming from an external LDAP server, or similar. This can be the case when the Infinite Scale admin is not the LDAP admin. To make life easier for admins, read-only attributes can be displayed differently, e.g. grayed out. To configure these hints for the frontend, use the environment variable `FRONTEND_READONLY_USER_ATTRIBUTES`, which takes a comma separated list of attributes. See the environment variable for supported values.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Caching
 
 :is_cache: true

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -16,11 +16,9 @@
 
 == Caching
 
-The `gateway` service can use a configured store via `GATEWAY_STAT_CACHE_STORE`.
+:is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `GATEWAY_STAT_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -89,6 +89,10 @@ The client that is used to authenticate with Keycloak has to be able to list use
 
 Note that these roles are only available to assign if the client is in the `master` realm.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -44,11 +44,9 @@ image::deployment/services/graph/mermaid-graph.svg[width=600]
 
 == Caching
 
-The `graph` service can use a configured store via `GRAPH_CACHE_STORE`.
+:is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `GRAPH_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Keycloak Configuration for the Personal Data Export
 

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -105,6 +105,10 @@ which is the source of the texts provided by the code.
 
 The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. See the xref:{s-path}/settings.adoc#default-language[settings] service for a detailed description.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -187,6 +187,10 @@ policies:
 
 A good example of how such a file should be formatted can be found in the https://svn.apache.org/repos/asf/httpd/httpd/trunk/docs/conf/mime.types[Apache svn repository].
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -79,6 +79,10 @@ ocis storage-users uploads list
 ocis postprocessing restart -u <uploadID>
 ----
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Storing
 
 :is_stat: true

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -81,13 +81,11 @@ ocis postprocessing restart -u <uploadID>
 
 == Storing
 
+:is_stat: true
+
 The `postprocessing` service needs to store some metadata about uploads to be able to orchestrate post-processing. When running in single binary mode, the default in-memory implementation will be just fine. In distributed deployments it is recommended to use a persistent store, see below for more details.
 
-The `postprocessing` service stores each consumed event via the configured store in `POSTPROCESSING_STORE`.
-
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `POSTPROCESSING_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -103,11 +103,9 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
 
 == Caching
 
-The `proxy` service can use a configured store via `PROXY_OIDC_USERINFO_CACHE_STORE`.
+:is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `PROXY_OIDC_USERINFO_CACHE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Special Settings
 

--- a/modules/ROOT/pages/deployment/services/s-list/search.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/search.adoc
@@ -153,6 +153,10 @@ In the following example, let's assume a file tree `foo/bar/baz` exists.
 If the folder `bar` gets renamed to `new-bar`, the path to `baz` is no longer `foo/bar/baz` but `foo/new-bar/baz`.  
 The search service checks the change and either just updates the path in the index or creates a new index for all items affected if none was present.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -32,13 +32,11 @@ The settings service supports two different backends for persisting the data. Th
 
 == Caching
 
+:is_cache: true
+
 When using `SETTINGS_STORE_TYPE=metadata`, the `settings` service caches the results of queries against the storage backend to provide faster responses. The content of this cache is independent of the cache used in the `storage-system` service as it caches directory listing and settings content stored in files.
 
-The store used for the cache can be configured using the `SETTINGS_CACHE_STORE` environment variable.
-
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `SETTINGS_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Settings Management
 

--- a/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
@@ -14,6 +14,10 @@
 
 * Sharing listens on port 9150 by default.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/sse.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/sse.adoc
@@ -18,6 +18,10 @@ include::partial$deployment/services/log-service-ecosystem.adoc[]
 
 Clients can subscribe to the `/sse` endpoint to be informed by the server when an event happens. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that sse has a limitation of six open connections per browser which can be reached if one has opened various tabs of the Web UI pointing to the same Infinite Scale instance.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -16,11 +16,9 @@
 
 == Caching
 
-The `frontend` service can use a configured store via `STORAGE_SYSTEM_CACHE_STORE`.
+:is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_SYSTEM_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Deprecated Metadata Backend
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -121,6 +121,10 @@ The configuration for the `purge-expired` command is done by using the following
 
 * `STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE` has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `project space` trash-bin files.
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Caching
 
 :is_cache: true

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -123,11 +123,11 @@ The configuration for the `purge-expired` command is done by using the following
 
 == Caching
 
-The `storage-users` service caches stat, metadata and uuids of files and folders via the configured store in `STORAGE_USERS_STAT_CACHE_STORE`, `STORAGE_USERS_FILEMETADATA_CACHE_STORE` and `STORAGE_USERS_ID_CACHE_STORE`.
+:is_cache: true
+
+The `storage-users` service caches stat, metadata and uuids of files and folders via the configured stores.
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-. When using `redis-sentinel`, the Redis master to use is configured via `STORAGE_USERS_STAT_CACHE_STORE_NODES`, `STORAGE_USERS_FILEMETADATA_CACHE_STORE_NODES` and `STORAGE_USERS_ID_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -26,6 +26,10 @@ Running the `userlog` service without running the xref:{s-path}/eventhistory.ado
 
 include::partial$multi-location/caching-list.adoc[]
 
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
 == Configuring Events
 
 Currently, the configuration which user-related events are of interest is hard-coded and cannot be changed.

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -22,11 +22,9 @@ Running the `userlog` service without running the xref:{s-path}/eventhistory.ado
 
 == Storing
 
-The `userlog` service persists information via the configured store in `USERLOG_STORE`.
+:is_stat: true
 
 include::partial$multi-location/caching-list.adoc[]
-// you must not have one or more blank lines here as it breaks continuous numbering!
-.  When using `redis-sentinel`, the Redis master to use is configured via `USERLOG_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
 
 == Configuring Events
 

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -54,7 +54,7 @@ Other store types may work but are currently not supported.
 
 NOTE: The {service_name} service can only be scaled if not using the `memory` store and the stores are configured identically over all instances!
 
-NOTE: If you have used one of the deprecated stores of a former version, you should reconfigure to one of the supported ones as the deprecated stores will be removed in a later version.
+NOTE: If you have used one of the deprecated stores of a former version, you should reconfigure to use one of the supported ones as the deprecated stores will be removed in a later version.
 
 Store specific notes::
 +

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -1,7 +1,6 @@
 ////
 This partial contains the commonly used list of cache stores plus notes.
 It is used as partial so when there is a change, we only need to do it in one place
-When including, there must be at the top and the bottom a line manually added describing service dependent stuff, see below.
 ////
 
 ifdef::is_cache[]

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -4,10 +4,19 @@ It is used as partial so when there is a change, we only need to do it in one pl
 When including, there must be at the top and the bottom a line manually added describing service dependent stuff, see below.
 ////
 
-// to be added manually like:
-// The `frontend` service can use a configured store via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE`.
+ifdef::is_cache[]
+:env_store: OCIS_CACHE_STORE
+:env_nodes: OCIS_CACHE_STORE_NODES
+endif::is_cache[]
 
-Note that for each service-based environment variable, a global one might be available additionally. Check the configuration section below. Possible stores are:
+ifdef::is_stat[]
+:env_store: OCIS_PERSISTENT_STORE
+:env_nodes: OCIS_PERSISTENT_STORE_NODES
+endif::is_stat[]
+
+The {service_name} service can use a configured store via the global {env_store} environment variable.
+
+Note that for each global environment variable, a service-based one might be available additionally. For precedences see xref:deployment/services/env-var-note.adoc[Environment Variable Notes]. Check the configuration section below. Supported stores are:
 {empty} +
 {empty} +
 
@@ -19,28 +28,42 @@ Note that for each service-based environment variable, a global one might be ava
 | `memory`
 | Basic in-memory store and the default.
 
-| `ocmem`
-| Advanced in-memory store allowing max size.
-
-| `redis`
-| Stores data in a configured Redis cluster.
-
 | `redis-sentinel`
 | Stores data in a configured Redis Sentinel cluster.
 
-| `etcd`
-| Stores data in a configured etcd cluster.
-
-| `nats-js`
-| Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
+| `nats-js-kv`
+| Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]
 
 | `noop`
 | Stores nothing. Useful for testing. Not recommended in production environments.
+
+| `ocmem`
+| *(deprecated)* Advanced in-memory store allowing max size.
+
+| `redis`
+| *(deprecated)* Stores data in a configured Redis cluster.
+
+| `etcd`
+| *(deprecated)* Stores data in a configured etcd cluster.
+
+| `nats-js`
+| *(deprecated)* Stores data using the key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
 |===
 
-. Note that in-memory stores are by nature not reboot-persistent.
-. Though usually not necessary, a database name and a database table can be configured for event stores if the event store supports this. Generally not applicable for stores of type `in-memory`. These settings are blank by default which means that the standard settings of the configured store apply.
-. The {service_name} service can be scaled if not using `in-memory` stores and the stores are configured identically over all instances.
-// no blank lines here, this will break continuous numbering!!
-// to be added manually like:
-// . When using `redis-sentinel`, the Redis master to use is configured via `FRONTEND_OCS_RESOURCE_INFO_CACHE_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+Other store types may work but are currently not supported.
+
+NOTE: The {service_name} service can only be scaled if not using the `memory` store and the stores are configured identically over all instances!
+
+NOTE: If you have used one of the deprecated stores of a former version, you should reconfigure to one of the supported ones as the deprecated stores will be removed in a later version.
+
+Store specific notes::
++
+--
+* When using `redis-sentinel`: +
+The Redis master to use is configured via e.g. `{env_nodes}` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
+* When using `nats-js-kv`: +
+** It is recommended to set `{env_nodes}` to the same value as `OCIS_EVENTS_ENDPOINT`. That way the cache uses the same nats instance as the event bus.
+** Authentication can be added, if configured, via `OCIS_CACHE_AUTH_USERNAME` and `OCIS_CACHE_AUTH_PASSWORD`.
+** It is possible to set `OCIS_CACHE_DISABLE_PERSISTENCE` to instruct nats to not persist cache data on disc.
+--

--- a/modules/ROOT/partials/multi-location/event-bus.adoc
+++ b/modules/ROOT/partials/multi-location/event-bus.adoc
@@ -10,7 +10,7 @@ The Infinite Scale event bus can be configured by a set of environment variables
 ====
 * If you are using a binary installation as described in xref:deployment/binary/binary-setup.adoc[Binary Setup] or xref:depl-examples/bare-metal.adoc[Bare Metal with systemd], the address of the event bus `OCIS_EVENTS_ENDPOINT` is predefined as localhost address without the need for further configuration, but changable on demand.
 
-* In case of an orchestrated installation like with Docker or Kubernetes, the event bus must be an external service for scalability like a `Redis Sentinel cluster` or a key-value-store https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]. Both named stores are supperted as also used in xref:deployment/services/caching.adoc[Caching and Persistence]. The store used is not part of the Infinite Scale installation and must be seperately provided and configured.
+* In case of an orchestrated installation like with Docker or Kubernetes, the event bus must be an external service for scalability like a `Redis Sentinel cluster` or a key-value-store https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]. Both named stores are supported and also used in xref:deployment/services/caching.adoc[Caching and Persistence]. The store used is not part of the Infinite Scale installation and must be separately provided and configured.
 
 * Note that from a configuration point of view, caching respectively persistance is independent from the event bus configuration.
 ====

--- a/modules/ROOT/partials/multi-location/event-bus.adoc
+++ b/modules/ROOT/partials/multi-location/event-bus.adoc
@@ -12,7 +12,7 @@ The Infinite Scale event bus can be configured by a set of environment variables
 
 * In case of an orchestrated installation like with Docker or Kubernetes, the event bus must be an external service for scalability like a `Redis Sentinel cluster` or a key-value-store https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]. Both named stores are supported and also used in xref:deployment/services/caching.adoc[Caching and Persistence]. The store used is not part of the Infinite Scale installation and must be separately provided and configured.
 
-* Note that from a configuration point of view, caching respectively persistance is independent from the event bus configuration.
+* Note that from a configuration point of view, caching and persistence are independent of the event bus configuration.
 ====
 
 Note that for each global environment variable, a service-based one might be available additionally. For precedences see xref:deployment/services/env-var-note.adoc[Environment Variable Notes]. Check the configuration section below. 

--- a/modules/ROOT/partials/multi-location/event-bus.adoc
+++ b/modules/ROOT/partials/multi-location/event-bus.adoc
@@ -1,0 +1,47 @@
+////
+This partial contains the commonly used description for the event bus settings.
+It is used as partial so when there is a change, we only need to do it in one place
+////
+
+
+The Infinite Scale event bus can be configured by a set of environment variables.
+
+[NOTE]
+====
+* If you are using a binary installation as described in xref:deployment/binary/binary-setup.adoc[Binary Setup] or xref:depl-examples/bare-metal.adoc[Bare Metal with systemd], the address of the event bus `OCIS_EVENTS_ENDPOINT` is predefined as localhost address without the need for further configuration, but changable on demand.
+
+* In case of an orchestrated installation like with Docker or Kubernetes, the event bus must be an external service for scalability like a `Redis Sentinel cluster` or a key-value-store https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]. Both named stores are supperted as also used in xref:deployment/services/caching.adoc[Caching and Persistence]. The store used is not part of the Infinite Scale installation and must be seperately provided and configured.
+
+* Note that from a configuration point of view, caching respectively persistance is independent from the event bus configuration.
+====
+
+Note that for each global environment variable, a service-based one might be available additionally. For precedences see xref:deployment/services/env-var-note.adoc[Environment Variable Notes]. Check the configuration section below. 
+
+Without the aim of completeness, see the list of environment variables to configure the event bus:
+{empty} +
+{empty} +
+
+[width=100%,cols="35%,75%",options=header]
+|===
+| Envvar
+| Description
+
+| `OCIS_EVENTS_ENDPOINT`
+| The address of the event system.
+
+| `OCIS_EVENTS_CLUSTER`
+| The clusterID of the event system. Mandatory when using NATS as event system.
+
+| `OCIS_EVENTS_ENABLE_TLS`
+| Enable TLS for the connection to the events broker.
+
+| `OCIS_INSECURE`
+| Whether to verify the server TLS certificates.
+
+| `OCIS_EVENTS_AUTH_USERNAME`
+| The username to authenticate with the events broker. 
+
+| `OCIS_EVENTS_AUTH_PASSWORD`
+| The password to authenticate with the events broker.
+|===
+


### PR DESCRIPTION
Fixes: #684 ([5.0] Cache Store changes in several services)

First commit fixing classical caches and persistances.
I need fo make another commit adding changes for the event bus, occurences in the ocis repo/services see below:

`find . -path '**/pkg/config' -exec grep -rn OCIS_EVENTS_AUTH_USERNAME {} \; | sort`
```
./antivirus/pkg/config/config.go:57:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;ANTIVIRUS_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./audit/pkg/config/config.go:32:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;AUDIT_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./clientlog/pkg/config/config.go:38:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;CLIENTLOG_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./eventhistory/pkg/config/config.go:57:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;EVENTHISTORY_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./frontend/pkg/config/config.go:175:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;FRONTEND_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./graph/pkg/config/config.go:124:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;GRAPH_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./notifications/pkg/config/config.go:59:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;NOTIFICATIONS_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./policies/pkg/config/config.go:57:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;POLICIES_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./postprocessing/pkg/config/config.go:44:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;POSTPROCESSING_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./search/pkg/config/search.go:14:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;SEARCH_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./sharing/pkg/config/config.go:156:	AuthUsername      string `yaml:"auth_username" env:"OCIS_EVENTS_AUTH_USERNAME;SHARING_EVENTS_AUTH_USERNAME" desc:"Username for the events broker."`
./sse/pkg/config/config.go:54:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;SSE_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./storage-users/pkg/config/config.go:180:	AuthUsername      string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;STORAGE_USERS_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
./userlog/pkg/config/config.go:59:	AuthUsername         string `yaml:"username" env:"OCIS_EVENTS_AUTH_USERNAME;USERLOG_EVENTS_AUTH_USERNAME" desc:"The username to authenticate with the events broker. The events broker is the ocis service which receives and delivers events between the services."`
```

Backport to 5.0