### PR TITLE
Make store service configurable

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocs.adoc
@@ -18,6 +18,40 @@
 
 The `ocs` service provides an endpoint `/cloud/user/signing-key` which is accessed from the web frontend via GET to request a signing key used for uploads.
 
+== Signing-Keys Store
+
+To authenticate presigned URLs, the xref:deployment/services/s-list/proxy.adoc[proxy] service needs to read the signing keys from a store that is populated by the `ocs` service.
+
+The following stores can be configured via the `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE` environment variable:
+
+* `nats-js-kv` +
+Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[nats jetstream].
+
+* `redis-sentinel` +
+Stores data in a configured Redis Sentinel cluster.
+
+* `ocisstoreservice` +
+Stores data in the _deprecated_ Infinite Scale xref:deployment/services/s-list/store.adoc[store] service. +
+Requires setting `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` to `com.owncloud.api.store`.
+
+[NOTE]
+====
+* The `memory` or `ocmem` stores cannot be used as they do not share the memory from the ocs service signing key memory store, even in a single process.
+
+* Make sure to configure the same store in the proxy service.
+====
+
+Store specific notes:
+
+* When using `redis-sentinel` +
+The Redis master to use is configured via e.g. `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
+* When using `nats-js-kv` +
+It is recommended to set `PROXY_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` to the same value as `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES`. That way the xref:deployment/services/s-list/proxy.adoc[proxy] service uses the same nats instance as the ocs service.
+
+* When using `ocisstoreservice` +
+The `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` must be set to the service name `com.owncloud.api.store`. It does not support TTL and stores the presigning keys indefinitely. Also, the xref:deployment/services/s-list/store.adoc[store]  service needs to be started.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -103,9 +103,47 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
 
 == Caching
 
+Important, also see section xref:presigned-urls[Presigned Urls] below.
+
 :is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]
+
+== Presigned Urls
+
+Important, also see section xref:caching[caching] above.
+
+To authenticate presigned URLs, the `proxy` service needs to read the signing keys from a store that is populated by the xref:deployment/services/s-list/ocs.adoc[ocs] service.
+
+The following stores can be configured via the `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE` environment variable:
+
+* `nats-js-kv` +
+Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[nats jetstream].
+
+* `redis-sentinel` +
+Stores data in a configured Redis Sentinel cluster.
+
+* `ocisstoreservice` +
+Stores data in the _deprecated_ Infinite Scale xref:deployment/services/s-list/store.adoc[store] service. +
+Requires setting `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` to `com.owncloud.api.store`.
+
+[NOTE]
+====
+* The `memory` or `ocmem` stores cannot be used as they do not share the memory from the ocs service signing key memory store, even in a single process.
+
+* Make sure to configure the same store in the proxy service.
+====
+
+Store specific notes:
+
+* When using `redis-sentinel` +
+The Redis master to use is configured via e.g. `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` in the form of `<sentinel-host>:<sentinel-port>/<redis-master>` like `10.10.0.200:26379/mymaster`.
+
+* When using `nats-js-kv` +
+It is recommended to set `PROXY_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` to the same value as `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES`. That way the `proxy` service uses the same nats instance as the xref:deployment/services/s-list/ocs.adoc[ocs] service.
+
+* When using `ocisstoreservice` +
+The `OCS_PRESIGNEDURL_SIGNING_KEYS_STORE_NODES` must be set to the service name `com.owncloud.api.store`. It does not support TTL and stores the presigning keys indefinitely. Also, the xref:deployment/services/s-list/store.adoc[store] service needs to be started.
 
 == Special Settings
 

--- a/modules/ROOT/pages/deployment/services/s-list/store.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/store.adoc
@@ -8,6 +8,9 @@
 
 {description}
 
+NOTE: The store service is marked for deprecation and will be removed in a later version. Its tasks will be taken over by other services.
+
+
 // fixme: source description is still missing, and a better description is needed
 
 == Default Values


### PR DESCRIPTION
Fixes: #720 ([5.0] Make store service configurable)

* Adding description text to the proxy and ocs service
* Add a deprecation note to the store service

NOTE: the new envvars need to be added in the ocis repo in to the 4-5-added file immediately.
Done with: https://github.com/owncloud/ocis/pull/8556

Backport to 5.0
 