### PR TITLE
Updating the storage-users service description

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -75,7 +75,7 @@ COMMANDS:
 
 === Manage Trash-Bin Items
 
-This command set is about the trash-bin to get an overview of items, restore items and purging old items of `personal` spaces and `project` spaces (spaces that have been created manually). `trash-bin` commands require a `spaceID` as parameter. See the xref:maintenance/space-ids/space-ids.adoc[Listing Space IDs] for details how to get them.
+This command set provides commands to get an overview of trash-bin items, restore items and purge old items of `personal` spaces and `project` spaces (spaces that have been created manually). `trash-bin` commands require a `spaceID` as parameter. See xref:maintenance/space-ids/space-ids.adoc[Listing Space IDs] for details of how to get them.
 
 [source,bash]
 ----
@@ -106,14 +106,14 @@ The behaviour of the `purge-expired` command can be configured by using the foll
 Used to obtain space trash-bin information and takes the system admin user as the default which is the `OCIS_ADMIN_USER_ID` but can be set individually. It should be noted, that the `OCIS_ADMIN_USER_ID` is only assigned automatically when using the single binary deployment and must be manually assigned in all other deployments. The command only considers spaces to which the assigned user has access and delete permission.
 
 * `STORAGE_USERS_PURGE_TRASH_BIN_PERSONAL_DELETE_BEFORE` +
-Has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `personal space` trash-bin files.
+Has a default value of `720h` which equals `30 days`. This means, the command will delete all files older than `30 days`. The value is human-readable, for valid values see the duration type described in the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types]. A value of `0` is equivalent to disable and prevents the deletion of `personal space` trash-bin files.
 
 * `STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE` +
 Has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `project space` trash-bin files.
 
 ==== List and Restore Trash-Bins Items
 
-The variable `STORAGE_USERS_CLI_MAX_ATTEMPTS_RENAME_FILE` defines a maximum number of attempts to rename a file when the admin restores the file with the CLI option `--option keep-both` to existing destination with the same name.
+The variable `STORAGE_USERS_CLI_MAX_ATTEMPTS_RENAME_FILE` defines a maximum number of attempts to rename a file when the admin restores the file with the CLI option `--option keep-both` to an existing destination with the same name.
 
 {empty}
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -33,6 +33,15 @@ When hard-stopping Infinite Scale, for example with the `kill <pid>` command (SI
 
 == CLI Commands
 
+For any command listed, use `--help` to get more details and possible options and arguments.
+
+To authenticate CLI commands use:
+
+* `OCIS_SERVICE_ACCOUNT_SECRET=<acc-secret>` and
+* `OCIS_SERVICE_ACCOUNT_ID=<acc-id>`.
+
+The `storage-users` CLI tool uses the default address to establish the connection to the xref:{s-path}/gateway.adoc[gateway] service. If the connection fails, check your custom `gateway` service `GATEWAY_GRPC_ADDR` configuration and set the same address in `storage-users` `OCIS_GATEWAY_GRPC_ADDR` or `STORAGE_USERS_GATEWAY_GRPC_ADDR`.
+
 === Manage Unfinished Uploads
 
 When using Infinite Scale as user storage, a directory named `storage/users/uploads` can be found in the Infinite Scale data folder. This is an intermediate directory based on {tus-url}[TUS] which is an open protocol for resumable uploads. Each upload consists of a _blob_ and a _blob.info_ file. Note that the term _blob_ is just a placeholder.
@@ -60,47 +69,13 @@ ocis storage-users uploads <command>
 [source,plaintext]
 ----
 COMMANDS:
-   list     Print a list of all incomplete uploads
-   clean    Clean up leftovers from expired uploads
+   sessions  Print a list of upload sessions
+   clean     Clean up leftovers from expired uploads
 ----
 
-==== Command Examples
+=== Manage Trash-Bin Items
 
-Command to identify incomplete uploads::
-+
---
-[source,bash]
-----
-ocis storage-users uploads list
-----
-
-[source,plaintext]
-----
-Incomplete uploads:
- - 455bd640-cd08-46e8-a5a0-9304908bd40a (file_example_PPT_1MB.ppt, Size: 1028608, Expires: 2022-08-17T12:35:34+02:00)
-----
---
-
-{empty}
-
-Command to clear expired uploads::
-+
---
-[source,bash]
-----
-ocis storage-users uploads clean
-----
-
-[source,plaintext]
-----
-Cleaned uploads:
-- 455bd640-cd08-46e8-a5a0-9304908bd40a (Filename: file_example_PPT_1MB.ppt, Size: 1028608, Expires: 2022-08-17T12:35:34+02:00)
-----
---
-
-=== Purge Expired Space Trash-Bin Items
-
-This command is about purging old trash-bin items of `project` spaces (spaces that have been created manually) and `personal` spaces.
+This command set is about the trash-bin to get an overview of items, restore items and purging old items of `personal` spaces and `project` spaces (spaces that have been created manually). `trash-bin` commands require a `spaceID` as parameter. See the xref:maintenance/space-ids/space-ids.adoc[Listing Space IDs] for details how to get them.
 
 [source,bash]
 ----
@@ -110,16 +85,64 @@ ocis storage-users trash-bin <command>
 [source,plaintext]
 ----
 COMMANDS:
-   purge-expired     Purge all expired items from the trashbin
+   purge-expired  Purge expired trash-bin items
+   list           Print a list of all trash-bin items of a space.
+   restore-all    Restore all trash-bin items for a space.
+   restore        Restore a trash-bin item by ID.
 ----
 
-The configuration for the `purge-expired` command is done by using the following environment variables.
+==== Purge Expired
 
-* `STORAGE_USERS_PURGE_TRASH_BIN_USER_ID` is used to obtain space trash-bin information and takes the system admin user as the default which is the `OCIS_ADMIN_USER_ID` but can be set individually. It should be noted, that the `OCIS_ADMIN_USER_ID` is only assigned automatically when using the single binary deployment and must be manually assigned in all other deployments. The command only considers spaces to which the assigned user has access and delete permission.
+Purge all expired items from the trash-bin.
 
-* `STORAGE_USERS_PURGE_TRASH_BIN_PERSONAL_DELETE_BEFORE` has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `personal space` trash-bin files.
+[source,plaintext]
+----
+ocis storage-users trash-bin purge-expired
+----
 
-* `STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE` has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `project space` trash-bin files.
+The behaviour of the `purge-expired` command can be configured by using the following environment variables.
+
+* `STORAGE_USERS_PURGE_TRASH_BIN_USER_ID` +
+Used to obtain space trash-bin information and takes the system admin user as the default which is the `OCIS_ADMIN_USER_ID` but can be set individually. It should be noted, that the `OCIS_ADMIN_USER_ID` is only assigned automatically when using the single binary deployment and must be manually assigned in all other deployments. The command only considers spaces to which the assigned user has access and delete permission.
+
+* `STORAGE_USERS_PURGE_TRASH_BIN_PERSONAL_DELETE_BEFORE` +
+Has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `personal space` trash-bin files.
+
+* `STORAGE_USERS_PURGE_TRASH_BIN_PROJECT_DELETE_BEFORE` +
+Has a default value of `30 days`, which means the command will delete all files older than `30 days`. The value is human-readable, valid values are `24h`, `60m`, `60s` etc. `0` is equivalent to disable and prevents the deletion of `project space` trash-bin files.
+
+==== List and Restore Trash-Bins Items
+
+The variable `STORAGE_USERS_CLI_MAX_ATTEMPTS_RENAME_FILE` defines a maximum number of attempts to rename a file when the admin restores the file with the CLI option `--option keep-both` to existing destination with the same name.
+
+{empty}
+
+Print a list of all trash-bin items of a space::
++
+--
+[source,bash]
+----
+ocis storage-users trash-bin list
+----
+--
+
+Restore all trash-bin items for a space::
++
+--
+[source,bash]
+----
+ocis storage-users trash-bin restore-all
+----
+--
+
+Restore a trash-bin item by ID::
++
+--
+[source,bash]
+----
+ocis storage-users trash-bin restore
+----
+--
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/maintenance/space-ids/space-ids.adoc
+++ b/modules/ROOT/pages/maintenance/space-ids/space-ids.adoc
@@ -4,24 +4,24 @@
 
 == Introduction
 
-{description} As example for a use case, see the xref:deployment/services/s-list/storage-users.adoc#manage-trash-bin-items[Manage Trash-Bin Items] command set.
+{description} As an example of a use case, see the xref:deployment/services/s-list/storage-users.adoc#manage-trash-bin-items[Manage Trash-Bin Items] command set.
 
 Space IDs can currently not be listed by the administrator via the WebUI. They can only be listed via the shell using an authenticated curl GET command accessing the Infinite Scale https://owncloud.dev/apis/[API].
 
 The following prerequisites apply:
 
-* The administrator must have shell access where Infinite Scale runs on.
-* The administrator needs to use his active bearer token in the request described below.
+* The administrator must have shell access where Infinite Scale runs.
+* The administrator needs to use their active bearer token in the request described below.
 * For ease of reading the result, the https://jqlang.github.io/jq/[jq] library should be installed on the OS where the shell command is executed. It is used in the examples.
 
-To be said, the life span of the bearer token is short, in  particular less than a minute. If the token expires, the curl command will fail with an unauthorized message. Preparing is therefore key.
+Note that the life span of the bearer token is short, in  particular less than a minute. If the token expires, the curl command will fail with an unauthorized message. So it is important to be prepared.
 
 == Preparation
 
 * Open a terminal window for shell access
 ** The generated curl command described will be executed here.
 * Prepare an editor
-** Open an editor of choice where you can easily copy and paste to and add the following on top. The example lists `personal` users space ID's. Replace it with `project` for listing manually created spaces. Replace `<your host:9200>` with the URL:port you are accessing the Infinite Scale instance. Note to add a trailing blank line in the example as content is copied afterwards.
+** Open an editor of choice where you can easily copy and paste to and add the following on top. The example lists `personal` users space ID's. Replace it with `project` for listing manually created spaces. Replace `<your host:9200>` with the URL:port of the Infinite Scale instance. Note to add a trailing blank line in the example as content is copied afterwards.
 +
 --
 [source,bash]
@@ -34,7 +34,7 @@ curl -XGET -vk 'https://<your host:9200>/graph/v1.0/drives?$filter=driveType+eq+
 --
 
 * Open a browser
-** Login as administrator at `\https://<your host:9200>`, replace `<your host:9200>` with the URL:port you are accessing the Infinite Scale instance.
+** Login as administrator at `\https://<your host:9200>`, replace `<your host:9200>` with the URL:port of the Infinite Scale instance.
 ** Open the browsers menu:Developer Console[].
 ** Open the menu:Network[] tab.
 ** Select btn:[XHR], browser dependent, it is maybe called `Fetch XHR`.
@@ -131,7 +131,7 @@ Project Space::
 
 == Output Interpretation and Usage
 
-Depending if you are looking for a personal or project space, find the name of the space in the `name` respectively the `driveAlias` field. The ID identifying the space is under `driveType` named `id` like:
+Depending on if you are looking for a personal or project space, find the name of the space in the `name` or the `driveAlias` field. The ID identifying the space is under `driveType` named `id` like:
 
 [source,json]
 ----

--- a/modules/ROOT/pages/maintenance/space-ids/space-ids.adoc
+++ b/modules/ROOT/pages/maintenance/space-ids/space-ids.adoc
@@ -1,0 +1,147 @@
+= Listing Space IDs
+:toc: right
+:description: There are rare situations like when using shell commands that require the ID of a space as parameter. This page shows how to get it.
+
+== Introduction
+
+{description} As example for a use case, see the xref:deployment/services/s-list/storage-users.adoc#manage-trash-bin-items[Manage Trash-Bin Items] command set.
+
+Space IDs can currently not be listed by the administrator via the WebUI. They can only be listed via the shell using an authenticated curl GET command accessing the Infinite Scale https://owncloud.dev/apis/[API].
+
+The following prerequisites apply:
+
+* The administrator must have shell access where Infinite Scale runs on.
+* The administrator needs to use his active bearer token in the request described below.
+* For ease of reading the result, the https://jqlang.github.io/jq/[jq] library should be installed on the OS where the shell command is executed. It is used in the examples.
+
+To be said, the life span of the bearer token is short, in  particular less than a minute. If the token expires, the curl command will fail with an unauthorized message. Preparing is therefore key.
+
+== Preparation
+
+* Open a terminal window for shell access
+** The generated curl command described will be executed here.
+* Prepare an editor
+** Open an editor of choice where you can easily copy and paste to and add the following on top. The example lists `personal` users space ID's. Replace it with `project` for listing manually created spaces. Replace `<your host:9200>` with the URL:port you are accessing the Infinite Scale instance. Note to add a trailing blank line in the example as content is copied afterwards.
++
+--
+[source,bash]
+----
+curl -XGET -vk 'https://<your host:9200>/graph/v1.0/drives?$filter=driveType+eq+personal' \
+  -H 'Authorization: Bearer ...
+| jq '.'
+
+----
+--
+
+* Open a browser
+** Login as administrator at `\https://<your host:9200>`, replace `<your host:9200>` with the URL:port you are accessing the Infinite Scale instance.
+** Open the browsers menu:Developer Console[].
+** Open the menu:Network[] tab.
+** Select btn:[XHR], browser dependent, it is maybe called `Fetch XHR`.
+** Reload the page to get updated content for XHR
+** In the column where you see `Name Status Type ...` check that `Method` is present. +
+If not, right click on one column item and select menu:Method[].
+** Click on btn:[Method] to sort, a `PROPFIND` line should be the first entry.
+
+== Get Space IDs
+
+=== Command Preparation
+
+* Reload the screen in the browser to get an updated bearer token.
+* Right click on the line containing `PROPFIND` and select menu:Copy[Copy as cURL (bash)].
+* Paste the copied result into the editor under the blank line, this may now look like this, the bearer is shortened in the example for ease of readbility:
++
+--
+[source,bash]
+----
+curl -XGET -vk 'https://<your host:9200>/graph/v1.0/drives?$filter=driveType+eq+personal' \
+  -H 'Authorization: Bearer ...
+| jq '.'
+
+curl 'https://<your host:9200>/remote.php/dav/spaces/59ee3b90-3231-4621-81aa-4531d33e7671%24fb9e2625-cdb0-4f21-8a34-db775a976707' \
+  -X 'PROPFIND' \
+  -H 'Accept: */*' \
+  -H 'Accept-Language: en' \
+  -H 'Authorization: Bearer eyJhb ... C1wUs' \
+  -H 'Connection: keep-alive' \
+  ...
+----
+--
+* After `++  -H 'Accept-Language: en' \++`: +
+Copy the complete line `++  -H 'Authorization: Bearer eyJhb ... C1wUs' \++`
+* Replace the `Authorisation` line on top containing the prepared command with the copied content. +
+You now have a full curl command including an active bearer token for authentication that can be used in the next step.
+
+=== Command Execution
+
+* Copy the full curl command from the top and paste it into the prepared shell. +
+You should get prettyfied json strings printed.
+
+=== Output
+
+Personal Space::
++
+--
+[source,json]
+----
+{
+  "value": [
+    {
+      "driveAlias": "personal/admin",
+      "driveType": "personal",
+      "id": "59ee3b90-3231-4621-81aa-4531d33e7671$fb9e2625-cdb0-4f21-8a34-db775a976707",
+      "lastModifiedDateTime": "2024-03-14T12:55:21.538631978+01:00",
+      "name": "Admin",
+      "owner": {
+        "user": {
+          "displayName": "",
+          "id": "fb9e2625-cdb0-4f21-8a34-db775a976707"
+        }
+      },
+  ...
+}
+----
+--
+
+{empty} +
+
+Project Space::
++
+--
+[source,json]
+----
+{
+  "value": [
+    {
+      "driveAlias": "project/my-project-space",
+      "driveType": "project",
+      "id": "59ee3b90-3231-4621-81aa-4531d33e7671$ee008d1d-b17d-4c61-a7f5-4e5435d2b4e8",
+      "lastModifiedDateTime": "2024-03-14T15:55:41.418616154+01:00",
+      "name": "My Project Space",
+      "owner": {
+        "user": {
+          "displayName": "",
+          "id": "ee008d1d-b17d-4c61-a7f5-4e5435d2b4e8"
+        }
+      },
+ ...
+}
+----
+--
+
+== Output Interpretation and Usage
+
+Depending if you are looking for a personal or project space, find the name of the space in the `name` respectively the `driveAlias` field. The ID identifying the space is under `driveType` named `id` like:
+
+[source,json]
+----
+"id": "59ee3b90-3231-4621-81aa-4531d33e7671$ee008d1d-b17d-4c61-a7f5-4e5435d2b4e8",
+----
+
+Copy the ID _excluding_ the surrounding double quotes and _embed_ it in single quotes for any tasks that require a space ID as parameter. Example:
+
+`"59ee3b90-3231-4621-81aa-4531d33e7671$ee008d1d-b17d-4c61-a7f5-4e5435d2b4e8"` -> +
+`'59ee3b90-3231-4621-81aa-4531d33e7671$ee008d1d-b17d-4c61-a7f5-4e5435d2b4e8'`
+
+The single quotes are necessary as the ID contains a `$` sign and `$` is a special shell character.
+

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -31,7 +31,7 @@ Note that for each global environment variable, a service-based one might be ava
 | Stores data in a configured Redis Sentinel cluster.
 
 | `nats-js-kv`
-| Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]
+| Stores data using key-value-store feature of https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream].
 
 | `noop`
 | Stores nothing. Useful for testing. Not recommended in production environments.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -75,6 +75,7 @@
 *** xref:maintenance/b-r/backup.adoc[Backup]
 *** xref:maintenance/b-r/restore.adoc[Restore]
 ** xref:maintenance/commands/commands.adoc[Maintenance Commands]
+** xref:maintenance/space-ids/space-ids.adoc[Listing Space IDs]
 * Migration and Upgrades
 ** xref:migration/upgrading-ocis.adoc[Upgrading Infinite Scale]
 * Configuration Examples


### PR DESCRIPTION
Fixes: #679 ([5.0] AND [4.0] New / deprecated ocis cli commands)

This PR:

* adds new commands as listed in #679 
* adds a page describing how to get a spaceID that is a required parameter in `trash-bin` commands

Language review welcomed.

Currently visible on [staging](https://doc.staging.owncloud.com).

Backport to 5.0, partially to 4.0

Important: the content that is in the storage-users readme in the ocis repo needs a rewrite according the changes made in the service description here.

@2403905 many thanks for your support and clarifications!