### PR TITLE
Update upgrading_4.0.0_5.0.0.adoc

### DIFF
--- a/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
@@ -8,7 +8,7 @@
 
 IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#introduction[Upgrading Infinite Scale] documentation before you start.
 
-IMPORTANT: Check if you are affected and follow every step mentioned for a smooth upgrade.
+IMPORTANT: Check below, if you are affected by breaking changes and prepare all steps mentioned before you start the upgrade.
 
 == Upgrade Steps
 


### PR DESCRIPTION
"check if you are affected" was ambiguous. In my understanding, I am of course affected, as I run ocis 4 and want ocis 5. "the upgrade affects me". But this is not the point. 

The important warning we have to have in the introduction, is that one should read about all the possibly breaking changes before starting with step 1. 

I am reprhasing the wording, in the assumption that the latter is meant.

Backport to 5.0