### PR TITLE
Update of the restart postprocessing process

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -63,16 +63,23 @@ The backoff behavior as mentioned in the `retry` outcome can be configured using
 
 === Resume Post-Processing
 
-If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. A system administrator can instead run a CLI command to retry the failed upload which is a two step process:
+If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. A system administrator can instead run CLI commands to retry the failed upload which is a two step process. For details on the `storage-users` command see the xref:{s-path}/storage-users.adoc#manage-unfinished-uploads[Manage Unfinished Uploads] documentation.
 
-* First, find the upload ID of the failed upload.
+* First list ongoing upload sessions:
 +
 [source,bash]
 ----
-ocis storage-users uploads list
+ocis storage-users uploads sessions
 ----
 
-* Then use the restart command to resume post-processing of the ID selected.
+* If you want to restart *all* uploads, just rerun the command with the `--restart` flag:
++
+[source,bash]
+----
+ocis storage-users uploads sessions --restart
+----
+
+* If you want to restart *only one* upload, use the postprocessing restart command with the ID selected:
 +
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -86,6 +86,17 @@ ocis storage-users uploads sessions --restart
 ocis postprocessing restart -u <uploadID>
 ----
 
+Alternatively, instead of starting one specific upload, a system admin can also restart all uploads that are currently in a specific step.
+
+Examples:
+
+[source,bash]
+----
+ocis postprocessing restart                # Restarts all uploads where postprocessing is finished, but upload is not finished.
+ocis postprocessing restart -s "finished"  # Equivalent to the above.
+ocis postprocessing restart -s "virusscan" # Restart all uploads currently in virusscan step.
+----
+
 == Event Bus Configuration
 
 include::partial$multi-location/event-bus.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -58,7 +58,8 @@ When using Infinite Scale as user storage, a directory named `storage/users/uplo
 
 Example cases for expired uploads::
 * When a user uploads a big file but the file exceeds the user-quota, the upload can't be moved to the target after it has finished. The file stays at the upload location until it is manually cleared.
-* If the bandwith is limited and the file to transfer can't be transferred completely before the upload expiration time is reached, the file expires and can't be processed. 
+* If the bandwith is limited and the file to transfer can't be transferred completely before the upload expiration time is reached, the file expires and can't be processed.
+* If the upload was technically successful, but the postprocessing step failed due to an internal error, it will not get further processed. See the procedure in the xref:{s-path}/postprocessing.adoc#resume-post-processing[Resume Post-Processing] documentation for details how to solve this.
 
 There are two commands available to manage unfinished uploads::
 [source,bash]


### PR DESCRIPTION
Fixes: #771 (The storage-users uploads sessions command was updated)

* Adding cross references for the issue between postprocessing and storage-users.
* Updating the command according the referenced issue. 

Backport to 5.0 (part of the 5.0.1 release)

Some changes need transfer back into the ocis service readme. 