### PR TITLE
Fixing comments in antora.yml

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,10 +22,10 @@ asciidoc:
     service_tab_1_tab_text: 'master' # latest stable including patch releases like 5.0.0
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_tab_1: 'master' # latest stable like v5.0.0
+    compose_tab_1: 'master' # latest stable including patch releases like v5.0.0 (note the v !)
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    compose_tab_1_tab_text: 'master' # latest stable including patch releases like 5.0.0
+    compose_tab_1_tab_text: 'master' # latest stable including patch releases like 5.0.0 (must be without v !)
 
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc


### PR DESCRIPTION
Make some comments in `antora.yml` more precise.

No backport, already added in 5.0 branch via #781