### PR TITLE
Fix for docker pull in upgrade to print the correct version

### DIFF
--- a/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
@@ -12,15 +12,25 @@ IMPORTANT: Check below, if you are affected by breaking changes and prepare all 
 
 == Upgrade Steps
 
+////
+'compose_tab_1_tab_text' from the version (branch) can be 'master'. in this case we must use the site.yml's 'ocis-actual-version' to point to a number and not master. this is necessary to dynamically have a version number used and never master as this does not work with docker! we also cant use 'latest' as we have to stick to the referenced stable version.
+////
+
+:compose_version: {compose_tab_1_tab_text}
+
+ifeval::["{compose_tab_1_tab_text}" == "master"]
+:compose_version: {ocis-actual-version}
+endif::[]
+
 . Shut down the Infinite Scale instance.
 . Update Infinite Scale via:
 +
 --
 * Docker
 +
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-docker pull owncloud/ocis:5.0.0
+docker pull owncloud/ocis:{compose_version}
 ----
 
 * or get the binary from {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank].

--- a/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
@@ -17,7 +17,6 @@ IMPORTANT: Check below, if you are affected by breaking changes and prepare all 
 ////
 
 :compose_version: {compose_tab_1_tab_text}
-
 ifeval::["{compose_tab_1_tab_text}" == "master"]
 :compose_version: {ocis-actual-version}
 endif::[]

--- a/site.yml
+++ b/site.yml
@@ -42,12 +42,11 @@ asciidoc:
 #   ocis
     latest-ocis-version: 'next@'   # do not change, soft set, correctly defined via antora.yml
     previous-ocis-version: 'next@' # do not change, soft set, correctly defined via antora.yml
-    # these versions are just for printing like in releases but not used for referencing
-    # needs to be changed here and mandatory in the docs repo to be properly shown on the web
-    # the following versions get printed on <all> build versions where applicable
-    # for branch only dependent version content, change the values in antora.yml at compose_tab_1_tab_text
-    ocis-actual-version: '5.0.0'
-    ocis-former-version: '4.0.5'
+    # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
+    # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
+    # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
+    ocis-actual-version: '5.0.1'
+    ocis-former-version: '4.0.7'
     ocis-compiled: '2024-02-15 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
   extensions:


### PR DESCRIPTION
This PR creates a fix to always print in the upgrade guide a numbered version for docker pull and never master. It also takes care that we reference the target version we upgrade to and nothing else.

This avoids printing master for next. It is also future proof when we have a new version and copy and adapt the content, as we use attributes for the version.

The changes in site.yml are only relevant for local building and consistency.

Backport to 5.0 