### PR TITLE
Fix S3 and Storage

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -1,7 +1,6 @@
 = General Information
 :toc: right
 :description: This document covers general aspects of Infinite Scale like start modes, services, important minimum configuration etc. for a common understanding.
-:aws-bucket-policy-url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html
 
 == Introduction
 
@@ -180,7 +179,8 @@ See xref:using-s3-for-blobs[Using S3 for Blobs] for the S3 configuration.
 +
 [NOTE]
 ====
-* Do not replace `$HOME` with `~` (tilde). The code does not resolve `~` to the users home directory.
+* Do not replace `$HOME` with `~` (tilde).
+** The code does not resolve `~` to the users home directory.
 * Check that `$HOME` resolves to a valid directory.
 ** When using a system user for the runtime, which has no login and therefore no home directory, like in the scenario xref:deployment/binary/binary-setup.adoc#setting-up-systemd-for-infinite-scale[Setting up systemd for Infinite Scale], you *must* specify a configuration file location.
 ====
@@ -192,13 +192,12 @@ See xref:using-s3-for-blobs[Using S3 for Blobs] for the S3 configuration.
 Because Infinite Scale does not use a database for storing information like users, groups, spaces, internal data, etc., it saves all this data to a permanent file location. Depending on the system setup, the base directory contains not only the metadata but also blobs. See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Filesystems and Shared Storage] for more details.
 
 * When only using a supported POSIX filesystem, blobs and metadata are stored on POSIX.  
-* When using S3 and POSIX, blobs are stored on S3, while metadata is stored on POSIX. Also see xref:using-s3-for-blobs[Using S3 for Blobs].
+* When using S3 and POSIX, blobs are stored on S3, while metadata is stored on POSIX. See the xref:deployment/storage/s3.adoc[S3] documentation for more details.
 
 {empty}
 
 Path for System Data::
-The environment variable `OCIS_BASE_DATA_PATH` sets the base path in a generic way. It has a xref:default-location[default location] but can also be manually defined. It is the root for many services which automatically add a subdirectory to that root for storing their data. Some services can manually define that path if necessary. Defining them independently can be required like when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup or recommended for using the xref:{s-path}/search.adoc[search service].
-
+The environment variable `OCIS_BASE_DATA_PATH` sets the base path in a generic way. It has a xref:default-location[default location] but can also be manually defined. It is the root for many services which automatically add a subdirectory to that root for storing their data. Some services can manually define that path if necessary. Defining them independently can be required like when using a xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] setup or recommended for using the xref:{s-path}/search.adoc[search service] or xref:{s-path}/thumbnails.adoc[thumbnails service].
 
 // ocis/services$ grep -r 'OCIS_BASE_DATA_PATH' --include=*.go **/pkg/config
 // https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/
@@ -246,7 +245,7 @@ The following environment variables can overwrite the base data path if required
 
 ==== Default Location
 
-* The base path has a default location for metadata and service dependent data (xref:#services_using_base_path[see above]) which *must be* on a POSIX storage. If not otherwise defined via xref:using-s3-for-blobs[Using S3 for Blobs], it is also used to store blobs using that path:
+* The base path has a default location for metadata and service dependent data (xref:#services_using_base_path[see above]) which *must be* on a POSIX storage. If not otherwise defined when using xref:deployment/storage/s3.adoc[S3], it is also used to store blobs using that path:
 
 ** For container images (inside the container) +
 `/var/lib/ocis`
@@ -256,7 +255,9 @@ The following environment variables can overwrite the base data path if required
 +
 [NOTE]
 ====
-* Do not replace `$HOME` with `~` (tilde). The code does not resolve `~` to the users home directory.
+* Do not replace `$HOME` with `~` (tilde).
+** The code does not resolve `~` to the users home directory.
+
 * Check that `$HOME` resolves to a valid directory.
 ** When using a system user for the runtime, which has no login and therefore no home directory, like in the generic binary setup scenario xref:deployment/binary/binary-setup.adoc#setting-up-systemd-for-infinite-scale[Setting up systemd for Infinite Scale] or in the deployment example xref:depl-examples/small-scale.adoc[Small-Scale with systemd], you *must* specify a base directory location because a system user has no logon and therefore no home directory!
 ====
@@ -265,46 +266,17 @@ The following environment variables can overwrite the base data path if required
 
 * More Important Notes
 +
-NOTE: When setting the base directory manually, it will be used automatically for the xref:#services_using_base_path[services described above] - if they are not otherwise manually defined. 
-+
-WARNING: The location must be used by Infinite Scale exclusively. Writing into this location not using Infinite Scale is discouraged to avoid any unexpected behavior. 
-+
-[IMPORTANT]
-====
-Consider using a separate partition or an external filesystem like NFS for the data path. If you only have one partition for your OS, Infinite Scale and your data, *filling up the filesystem with user data can make your system unresponsive*. This can easily happen under the following conditions: 
+--
+IMPORTANT: When setting the base directory manually, it will be used automatically for the xref:#services_using_base_path[services described above] - if they are not otherwise manually defined. 
 
-* The total storage space consumed by all spaces, even if there are individual quotas set for spaces, exceeds the available disk space.
-* When multiple users have concurrent uploads of big files, those big files - partly uploaded - will not count against the target space quota. These files are temporarily located in the upload folder located in the data path and moved when finished to the target space if the target space quota is not exceeded.
-* Expired uploads that have not been cleaned up (see xref:manage-unfinished-uploads[Manage Unfinished Uploads]) can demand storage unnecessarily and can be a hidden cause of exceeding the available storage space.
-* The index data stored for the xref:{s-path}/search.adoc[search service] is located on the same root path and filled up the filesystem. 
-====
+WARNING: The location must be used by Infinite Scale exclusively. Writing into this location not using Infinite Scale is discouraged to avoid any unexpected behavior. 
+--
 
 === Using S3 for Blobs
 
-When using S3 for storing user data (blobs), metadata must reside on POSIX using the base directory `OCIS_BASE_DATA_PATH` as path. For more details see the section xref:base-data-directory[Base Data Directory] above.
+When using S3 for storing user data (blobs), metadata must reside on POSIX. The environment variable responsible for storaing metadata in S3 is `STORAGE_USERS_S3NG_ROOT` and derives, if not otherwise defined, from the base directory `OCIS_BASE_DATA_PATH`. For more details see the section xref:base-data-directory[Base Data Directory] above.
 
-Configuring the xref:{s-path}/storage-users.adoc[Storage-Users] service is necessary to define the usage of POSIX and S3 storage for Infinite Scale.
-
-The following environment variables are need to be configured for the use with S3 (see the Storage-Users service for details):
-
-[source, yaml]
-----
-# activate s3ng storage driver
-STORAGE_USERS_DRIVER: s3ng
-# Path to metadata stored on POSIX
-STORAGE_USERS_S3NG_ROOT:
-# keep system data on ocis storage
-STORAGE_SYSTEM_DRIVER: ocis
-
-# s3ng specific settings
-STORAGE_USERS_S3NG_ENDPOINT:
-STORAGE_USERS_S3NG_REGION:
-STORAGE_USERS_S3NG_ACCESS_KEY:
-STORAGE_USERS_S3NG_SECRET_KEY:
-STORAGE_USERS_S3NG_BUCKET:
-----
-
-Also see the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples] for more details.
+Read the xref:deployment/storage/s3.adoc[S3] documentation for more details on how to configure Infinite Scale for the use with S3.
 
 == Initialize Infinite Scale
 
@@ -607,31 +579,3 @@ include::partial$multi-location/idm-https-reverse-proxy.adoc[]
 == Maintenance Commands
 
 There are multiple commands available to maintain the Infinite Scale instance. See the xref:maintenance/commands/commands.adoc[Maintenance Commands] document for more details.
-
-== S3 Bucket Policy
-
-With S3 bucket policies, you can configure and secure access to objects in your buckets, see
-{aws-bucket-policy-url}[Using bucket policies]. The following S3 bucket policies are a requirement when connecting to an S3 bucket, replace the bucket name accordingly. When using an S3 bucket you have to set the storage driver to `s3ng`. Also see the xref:deployment/container/orchestration/orchestration.adoc#deploy-the-chart[Deploy the Chart] section in the `Container Orchestration` documentation and the xref:{s-path}/storage-users.adoc[STORAGE_USERS_DRIVER] configuration value.
-
-{empty}
-[source,yaml]
-----
-# The S3NG driver needs an existing S3 bucket with following permissions:
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "ListObjectsInBucket",
-            "Effect": "Allow",
-            "Action": ["s3:ListBucket"],
-            "Resource": ["arn:aws:s3:::bucket-name"]
-        },
-        {
-            "Sid": "AllObjectActions",
-            "Effect": "Allow",
-            "Action": "s3:*Object",
-            "Resource": ["arn:aws:s3:::bucket-name/*"]
-        }
-    ]
-}
-----

--- a/modules/ROOT/pages/deployment/storage/general-considerations.adoc
+++ b/modules/ROOT/pages/deployment/storage/general-considerations.adoc
@@ -9,7 +9,7 @@
 
 Note that depending on the storage used, special settings can be defined to optimize resources for memory and performance.
 
-For a quick and rough overview, the following storages are mapped against an expected sizing. Note that the way that Infinite Scale is setup like xref:depl-examples/bare-metal.adoc[binary] or xref:deployment/container/orchestration/orchestration.adoc[orchestration] with its variants usually comes along with the expected sizing:
+For a quick and rough overview, the following storages are mapped against an expected sizing. Note the way how Infinite Scale is setup like xref:depl-examples/bare-metal.adoc[binary] or xref:deployment/container/orchestration/orchestration.adoc[orchestration] with its variants usually comes along with the expected sizing:
 
 {empty} +
 
@@ -43,19 +43,35 @@ NFS for metadata and other data
 
 Independent of the storage used and how many instances of the xref:{s-path}/storage-users.adoc[storage-users] service are running, Infinite Scale has mechanisms implemented to guarantee consistent writing to the backend for distributed setups. In any case, a file ID based on UUIDv4 is created to guarantee the uniqueness of file names. Proper file locking is implemented for writing metadata.
 
+== Important Data Distribution Notes
+
+Read the following note carefully, especially if all your data is stored on POSIX only:
+
+[IMPORTANT]
+====
+Consider using a separate partition or an external filesystem like NFS for the base data path. If you only have one partition for your OS, Infinite Scale and your data, *filling up the filesystem with user data can make your system unresponsive*. This can easily happen under the following conditions: 
+
+* The total storage space consumed by all spaces, even if there are individual quotas set for spaces, exceeds the available disk space.
+* When multiple users have concurrent uploads of big files, those big files - partly uploaded - will not count against the target space quota. These files are temporarily located in the upload folder located in the base data path and moved when finished to the target space if the target space quota is not exceeded.
+* Expired uploads that have not been cleaned up (see xref:manage-unfinished-uploads[Manage Unfinished Uploads]) can demand storage unnecessarily and can be a hidden cause of exceeding the available storage space.
+* Index and thumbnail data stored for the xref:{s-path}/search.adoc[search service] and the xref:{s-path}/thumbnails.adoc[thumbnails service] is located on the same base data path and filled up the filesystem. 
+====
+
+We highly recommend the follwing topics for production instances. For details and which environment variables are necessary for the changes see the xref:deployment/general/general-info.adoc#default-paths[Default Paths] documentation:
+
+* To avoid filling up the filesystem the OS is running on making the system unresponsive, separate the OS from where Infinite Scale data will be stored by:
+** Use independent partitions for data and the OS.
+** Use NFS for the data.
+** Use S3 for blobs.
+
+* If you expect a data volume that can lead to a high demand for *search* and/or *thumbnail* space - which would be stored by default in a subfolder using the `OCIS_BASE_DATA_PATH` as base path:
+** The data path for services mentioned in xref:deployment/general/general-info.adoc#base-data-directory[Services That Can Deviate from the Base Data Path] can be individually configured. Using additional partitions/mount points are a possible way to achieve this.
+
 == Local Storage
 
-Using local storage is a good choice if you want to test or plan to have a small productive instance. Drawbacks are less scalability and failover, because of one monolithic block of storage. Note that at any time you can switch selected mount points to NFS which is described in the next section.
+Using local storage is a good choice if you want to test or plan to have a small productive instance. Drawbacks are less scalability and failover, because of one monolithic block. Note that at any time you can switch selected mount points to NFS which is described in the next section.
 
 To decide which filesystems can be used for local storage, see xref:prerequisites/prerequisites.adoc#supported-posix-compliant-filesystems[Supported POSIX-compliant Filesystems].
-
-We highly recommend, if the instance is planned to be used in production, to consider the follwing topics. For details and which environment variables are necessary for the changes see the xref:deployment/general/general-info.adoc#default-paths[Default Paths] documentation:
-
-* To avoid filling up the filesystem and making the system unresponsive:
-** Use partitions to separate the OS from where Infinite Scale metadata and blobs will be stored.
-
-* If you expect a data volume that can lead to a high demand for *search* and/or *thumbnail* space - which would be stored by default in a subfolder using the `OCIS_BASE_DATA_PATH` as base path.
-** The data path for services mentioned in xref:deployment/general/general-info.adoc#base-data-directory[Services That Can Deviate from the Base Data Path] can be individually configured. Using an additional partition/mount point is a possible way to achieve this.
 
 The following table describes where data should be stored when using Infinite Scale in production:
 
@@ -78,7 +94,7 @@ The following table describes where data should be stored when using Infinite Sc
 
 == NFS
 
-Using NFS is beneficial because the instance components are separated from the storage and can scale independently. Such a setup is used when you plan a production environment with many users. The same rules apply as described in the xref:local-storage[Local Storage] section, but instead of using partitions you use NFS mount points. In addition, the Infinite Scale config is also stored on NFS using the xref:deployment/general/general-info.adoc#default-paths[OCIS_CONFIG_DIR] environment variable as this is a requirement for xref:deployment/container/orchestration/orchestration.adoc[orchestrated environments]. For details on NFS see the xref:deployment/storage/nfs.adoc[Network File System] documentation.
+Using NFS is beneficial because the instance components are separated from the storage and can scale independently. Such a setup is used when you plan a production environment with many users. In addition, the Infinite Scale config is also stored on NFS using the xref:deployment/general/general-info.adoc#default-paths[OCIS_CONFIG_DIR] environment variable as this is a requirement for xref:deployment/container/orchestration/orchestration.adoc[orchestrated environments]. For details on NFS see the xref:deployment/storage/nfs.adoc[Network File System] documentation.
 
 {empty} +
 
@@ -103,7 +119,7 @@ Using NFS is beneficial because the instance components are separated from the s
 
 == S3
 
-S3 to store blobs is typically used by large enterprises and hosters, though it can fit for medium enterprises too. Data distribution and separation is a bit different compared to a pure POSIX backend. For details on S3 see the xref:deployment/storage/s3.adoc[S3] documentation. Also see the xref:deployment/general/general-info.adoc#using-s3-for-blobs[Using S3 for Blobs] description:
+S3 to store blobs is typically used by large enterprises and hosters, though it can fit for medium enterprises too. Data distribution and separation is a bit different compared to a pure POSIX backend. For details on S3 including configuration notes see the xref:deployment/storage/s3.adoc[S3] documentation:
 
 * POSIX storage, usually NFS.
 ** Metadata
@@ -145,7 +161,7 @@ Alternatively NFS_4
 | High
 |===
 
-== Resource Optimisation
+== Server Resource Optimisation
 
 Depending on the storage connected and the servers capabilities, Infinite Scale can be optimized using the servers resources. The relevant environment variable to configure this is:
 

--- a/modules/ROOT/pages/deployment/storage/s3.adoc
+++ b/modules/ROOT/pages/deployment/storage/s3.adoc
@@ -3,6 +3,8 @@
 :toclevels: 2
 :description: Infinite Scale can store blobs on S3 storage. This document gives some general information and considerations for the use of S3.
 
+:aws-bucket-policy-url: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-policies.html
+
 == Introduction
 
 {description} See the xref:deployment/storage/general-considerations.adoc#s3[General Storage Considerations] in the S3 section for which data is stored where.
@@ -41,11 +43,73 @@ There is no way to guarantee consistency correctness because object operations a
 Writes or any mutations to a file do not appear in the namespace until it is committed. Concurrent access across shared buckets will not see any modifications. Shared access is therefore not the focus of S3.
 
 * *Access Control:* +
-The way S3 APIs handle identity and access management policies is incompatible with POSIX.
+The way S3 APIs handle identity and access management (IAM) policies is incompatible with POSIX.
 
 == Configuration
 
-To configure Infinite Scale for use with S3, read the
+Basically, two configurations need to be made.
 
-* xref:deployment/general/general-info.adoc#using-s3-for-blobs[Using S3 for Blobs] documenation and the
-* xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples] in particular `ocis_s3`.
+* The xref:{s-path}/storage-users.adoc[Storage-Users] service needs to be configured for the use of POSIX and S3 storage for Infinite Scale. This includes the following environment variables:
++
+[source, yaml]
+----
+# activate s3ng storage driver
+STORAGE_USERS_DRIVER: s3ng
+# Path to metadata stored on POSIX
+STORAGE_USERS_S3NG_ROOT:
+# keep system data on ocis storage
+STORAGE_SYSTEM_DRIVER: ocis
+
+# s3ng specific settings
+STORAGE_USERS_S3NG_ENDPOINT:
+STORAGE_USERS_S3NG_REGION:
+STORAGE_USERS_S3NG_ACCESS_KEY:
+STORAGE_USERS_S3NG_SECRET_KEY:
+STORAGE_USERS_S3NG_BUCKET:
+----
+
+* A xref:s3-bucket-policy[S3 Bucket Policy] needs to be created.
+
+Also see the xref:deployment/container/orchestration/orchestration.adoc#docker-compose-examples[Docker Compose Examples]  in particular `ocis_s3` and the xref:deployment/container/orchestration/orchestration.adoc#deploy-the-chart[Deploy the Chart] section in the `Container Orchestration` documentation.
+
+=== S3 Bucket Policy
+
+Bucket policies are an Identity and Access Management (IAM) mechanism for controlling access to resources. They are a critical element in securing your S3 buckets against unauthorized access and attacks.
+
+Bucket policies, which are a collection of statements *defined on S3*, are evaluated one after another in order of appearance, that describe what a requester is allowed to do on a bucket and with each object contained in that bucket. It applies to a requester who has been authenticated to access the bucket in question. For more details see {aws-bucket-policy-url}[AWS: Using bucket policies, window=_blank]. 
+
+The following S3 bucket policies are a *requirement* for Infinite Scale when connecting to an S3 bucket. Replace the bucket name according your environment.
+
+{empty}
+
+[source,yaml]
+----
+# The S3NG driver needs an existing S3 bucket with following permissions:
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ListBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::bucket-name"
+            ]
+        },
+        {
+            "Sid": "ActionsInBucketContext",
+            "Effect": "Allow",
+            "Action": [
+                "s3:*Object",
+                "s3:*MultipartUpload",
+                "s3:ListMultipartUploadParts"
+            ],
+            "Resource": [
+                "arn:aws:s3:::bucket-name/*"
+            ]
+        }
+    ]
+}
+----


### PR DESCRIPTION
Fixes: #674 ([5.0] Update s3 bucket permissions for oCIS 5)

* Fix the S3 Bucket Policy changes
* Storage related stuff including S3 was formerly scattered too much
  * Bringing the S3 stuff into one place
  * Make the storage text more streamlined

Currently visible on [staging](https://doc.staging.owncloud.com/ocis/next/deployment/storage/s3.html).

Backport to 5.0