### PR TITLE
Describe allow disabling the password policy

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -60,6 +60,9 @@ The validation against the banned passwords list can be configured via a text fi
 
 The following environment variables can be set to define the password policy behavior:
 
+* `OCIS_PASSWORD_POLICY_DISABLED` +
+Disable the password policy.
+
 * `OCIS_PASSWORD_POLICY_MIN_CHARACTERS` +
 Define the minimum password length.
 


### PR DESCRIPTION
Fixes: #685 ([5.0] New envvar to disable password policy)

Add list item in the frontend service documentation to allow disabling the passsord policy.

Backport to 5.0