### PR TITLE
Fix: paths for default deployments, Update general-info.adoc 

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -171,10 +171,10 @@ See xref:using-s3-for-blobs[Using S3 for Blobs] for the S3 configuration.
 
 * The configuration directory has a default location for _config_ files, which *must be* on a POSIX storage:
 
-** For container images (inside the container) +
+** For container images (inside the container) and xref:depl-examples/bare-metal.html#used-settings[systemd Deployments] +
 `/etc/ocis/`
 +
-** For binary releases +
+** For a simple binary setup +
 `$HOME/.ocis/config/`
 +
 [NOTE]


### PR DESCRIPTION
/etc/ocis is used much more frequently. 
It is confusing to see that we describe systemd setups in detail with the setting that seems to be for docker containers only. 

I suggest to update this here, and make a distinction between quick simple test usage of the all in one binary, and "everything else"


Note1:
 we describe have two systemd setups in
* https://doc.owncloud.com/ocis/5.0/deployment/binary/binary-setup.html#setting-up-systemd-for-infinite-scale
* https://doc.owncloud.com/ocis/5.0/depl-examples/bare-metal.html#used-settings

They are confusingly similar, but not exactly the same.

Note2:
When discussing $HOME and ~, we mention that the code does not resolve ~. Does that imply, the code resolves $HOME? I'd expect neither, as both are features of the shell.
