### PR TITLE
Fix: Remove mDNS from binary-setup.adoc ?

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -34,7 +34,7 @@ IMPORTANT: ownCloud highly recommends reading the xref:deployment/general/genera
 
 == Prerequisite
 
-NOTE: Infinite Scale by default relies on Multicast DNS (mDNS), usually via `avahi-daemon`. If your system has a firewall, make sure mDNS is allowed in your active zone and http and https ports are open.
+See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[ocis prerequisites,window=_blank].
 
 == Installation
 


### PR DESCRIPTION
Not 100% sure. please double check.
I believe mDNS is not a prerequisite. I non't have it in any of my test sysstems, and I see no mentioning elsewhere in the docs.

Backport to 5.0