### PR TITLE
Fix ps command in binary description

### DIFF
--- a/modules/ROOT/pages/deployment/binary/binary-setup.adoc
+++ b/modules/ROOT/pages/deployment/binary/binary-setup.adoc
@@ -196,8 +196,11 @@ Depending on the user you started `ocis` with and which user you are currently l
 + 
 [source,bash]
 ----
-ps ax | grep "ocis server" | grep -v grep | \
-   awk '{ print $1 }' | xargs kill -15
+ps -ax | \
+   grep "ocis server" | \
+   grep -v grep | \
+   awk '{ print $1 }' | \
+   xargs kill -15
 ----
 
 Stopping a particular ocis PID::


### PR DESCRIPTION
The ps command was missing a minus symbol, correct is `-ax`.
Additionally, I made all components multilined.

Backport to 5.0 necessary.