### PR TITLE
Add the collaboration service

### DIFF
--- a/modules/ROOT/pages/deployment/services/ports-used.adoc
+++ b/modules/ROOT/pages/deployment/services/ports-used.adoc
@@ -59,5 +59,6 @@ The following port ranges are used by services:
 | 9260-9264  | xref:{s-path}/clientlog.adoc[clientlog]
 | 9270-9274  | xref:{s-path}/eventhistory.adoc[eventhistory]
 | 9280-9284  | xref:{s-path}/ocm.adoc[ocm]
+| 9300-9304  | xref:{s-path}/collaboration.adoc[collaboration]
 | 9460-9464  | xref:{s-path}/store.adoc[store]
 |===

--- a/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
@@ -8,7 +8,7 @@
 
 {description}
 
-IMPORTANT: Since this service requires an external document server, it won't start by default when using `ocis server` (xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[supervised mode]). You must start it therefore manually with the `ocis collaboration server` command.
+IMPORTANT: Since this service requires an external document server, it won't start by default when using `ocis server` (xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[supervised mode]). You must start it manually with the `ocis collaboration server` command.
 
 == Default Values
 
@@ -16,13 +16,13 @@ IMPORTANT: Since this service requires an external document server, it won't sta
 
 == Requirements
 
-The collaboration service requires the target document server (ONLYOFFICE, Collabora, etc.) to be up and running. Additionally, some Infinite Scale services are also required to be running in order to register the GRPC service for the `open in app` action in the webUI. The following internal end external services need to be available:
+The collaboration service requires the target document server (ONLYOFFICE, Collabora, etc.) to be up and running. Additionally, some Infinite Scale services are also required to be running in order to register the GRPC service for the `open in app` action in the webUI. The following internal and external services need to be available:
 
 * External document server
 * xref:{s-path}/gateway.adoc[gateway] service.
 * xref:{s-path}/app-provider.adoc[app provider] service.
 
-If any of the named services above have not been started or are not reachable, the collaboration service won't start. For the binary or the docker release of Infinite Scale, check with the xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[List running services] command if they have been started. If not, you must start them manually upfront starting the collaboration service.
+If any of the named services above have not been started or are not reachable, the collaboration service won't start. For the binary or the docker release of Infinite Scale, check with the xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[List running services] command if they have been started. If not, you must start them manually upfront before starting the collaboration service.
 
 == WOPI Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
@@ -1,0 +1,46 @@
+= Collaboration
+:toc: right
+:description: The collaboration service connects Infinite Scale with document servers such as Collabora and ONLYOFFICE using the WOPI protocol.
+
+:service_name: collaboration
+
+== Introduction
+
+{description}
+
+IMPORTANT: Since this service requires an external document server, it won't start by default when using `ocis server` (xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[supervised mode]). You must start it therefore manually with the `ocis collaboration server` command.
+
+== Default Values
+
+* The collaboration service listens on port 9300 by default.
+
+== Requirements
+
+The collaboration service requires the target document server (ONLYOFFICE, Collabora, etc.) to be up and running. Additionally, some Infinite Scale services are also required to be running in order to register the GRPC service for the `open in app` action in the webUI. The following internal end external services need to be available:
+
+* External document server
+* xref:{s-path}/gateway.adoc[gateway] service.
+* xref:{s-path}/app-provider.adoc[app provider] service.
+
+If any of the named services above have not been started or are not reachable, the collaboration service won't start. For the binary or the docker release of Infinite Scale, check with the xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[List running services] command if they have been started. If not, you must start them manually upfront starting the collaboration service.
+
+== WOPI Configuration
+
+There are a few variables that you need to set:
+
+* `COLLABORATION_WOPIAPP_ADDR`: +
+The URL of the WOPI app (onlyoffice, collabora, etc). +
+For example: `\https://office.example.com`.
+
+* `COLLABORATION_HTTP_ADDR`: +
+The external address of the collaboration service. The target app (onlyoffice, collabora, etc) will use this address to read and write files from Infinite Scale. +
+For example: `\https://wopiserver.example.com`.
+
+* `COLLABORATION_HTTP_SCHEME`: +
+The scheme to be used when accessing the collaboration service. Either `http` or `https`. This will be used to finally build the URL that the WOPI app needs in order to contact the collaboration service.
+
+The rest of the configuration options available can be left with the default values.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -39,6 +39,7 @@
 **** xref:deployment/services/s-list/auth-machine.adoc[Auth Machine]
 **** xref:deployment/services/s-list/auth-service.adoc[Auth Service]
 **** xref:deployment/services/s-list/clientlog.adoc[Clientlog]
+**** xref:deployment/services/s-list/collaboration.adoc[Collaboration]
 **** xref:deployment/services/s-list/eventhistory.adoc[Eventhistory]
 **** xref:deployment/services/s-list/frontend.adoc[Frontend]
 **** xref:deployment/services/s-list/gateway.adoc[Gateway]


### PR DESCRIPTION
Referencing: https://github.com/owncloud/ocis/pull/8374 (feat: add new collaboration service (WOPI))

Adds the new collaboration service to the documentation.
This PR also removes the build errors because of missing references to the collaboration service.

Note, some text changes need to be transported to the ocis repo.

Language review welcomed.

NO backport!