### PR TITLE
Fix the Bare Metal deployments

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -22,7 +22,7 @@
 
 {description}
 
-This deployment example addresses a small productive environment. For a minimal test and development environment, see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. The main differences between the setup described in this document and a minimal test environment is, the use of systemd, letsencrypt and a reverse proxy.
+This deployment example addresses a small production environment. For a minimal test and development environment, see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. The main differences between the setup described in this document and a minimal test environment is, the use of systemd, letsencrypt and a reverse proxy.
 
 Note that this guide expects that prerequisite of a computer with an installed Linux distribution of choice is met and required software other than Infinite Scale is installed and preconfigured. There is no detailed explanation but, where possible, links for more information are provided.
 

--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -22,6 +22,8 @@
 
 {description}
 
+This deployment example addresses a small productive environment. For a minimal test and development environment, see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. The main differences between the setup described in this document and a minimal test environment is, the use of systemd, letsencrypt and a reverse proxy.
+
 Note that this guide expects that prerequisite of a computer with an installed Linux distribution of choice is met and required software other than Infinite Scale is installed and preconfigured. There is no detailed explanation but, where possible, links for more information are provided.
 
 This guide was tested on a Debian 11 (bullseye) host but should work on any other modern Linux system with systemd.
@@ -57,8 +59,8 @@ There are a few steps that are recommended but not covered in this guide:
 The following settings were used in this guide. You can change this according your needs:
 
 * The Infinite Scale binary location: `{ocis_bin}` (OS default)
-* The Infinite Scale configuration directory: `{ocis_env}`
-* The Infinite Scale data directory: `{ocis_data}`
+* The Infinite Scale xref:deployment/general/general-info.adoc#configuration-directory[configuration directory]: `{ocis_env}`
+* The Infinite Scale xref:deployment/general/general-info.adoc#base-data-directory[base data directory]: `{ocis_data}`
 * The URL accessing Infinite Scale: `{ocis_url}` +
 Note that this URL must resolve to the server running this installation.
 * The internal port accessing Infinite Scale: {ocis_port} (default)

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -23,11 +23,11 @@ For a small production environment, see the xref:depl-examples/bare-metal.adoc[B
 
 [IMPORTANT]
 ====
-This binary setup description makes the following assumptions:
+This minimal bare metal deployment makes the following assumptions:
 
-* Server Access:
-** If you only want to acccess the server running Infinite Scale from the server itself, you can use <localhost> as URL and no further configuration is neccesary.
-** If you want to access the server from remote clients, you must configure and access Infinite Scale using the servers hostname. See the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd] example when using a dedicated domain name.
+* Acccessing Infinite Scale only from the server. + 
+Use <localhost> as URL and no further configuration is neccesary. +
+To access Infinite Scale via hostname or IP, see xref:accessing-infinite-scale-other-than-localhost[Accessing Infinite Scale Other Than Localhost].
 
 * You are fine in the first step using Infinite Scales internal unsigned certificates. +
 Trusted certificates can be installed later on, see xref:deployment/general/general-info.adoc#handling-certificates[Handling Certificates] for more information. 
@@ -115,11 +115,11 @@ Infinite Scale is started in two steps:
 * A first time start to initialize the system and
 * a recurring start after initialization.
 
-Refer to the xref:deployment/general/general-info.adoc#default-users-and-groups[Default Users and Groups] section if you want to have demo users created when initializing the system.
+Refer to the xref:deployment/general/general-info.adoc#default-users-and-groups[Default Users and Groups] section if you want to have demo users created when initializing the system. This step can only be done during initialisation.
 
 ==== First Time Initializing Infinite Scale
 
-Infinite Scale needs a xref:deployment/general/general-info.adoc#initialize-infinite-scale[first time initialization] to set up the environment. You will need to answer questions as the basis for generating a default `ocis.yaml` file. You can edit this file later. The default location for config files is, if not otherwise defined, `$HOME/.ocis/config/`. For details see the xref:deployment/general/general-info.adoc#configuration-directory[Configuration Directory] documentation. Type the following command to initialize Infinite Scale.
+Infinite Scale needs a xref:deployment/general/general-info.adoc#initialize-infinite-scale[first time initialization] to set up the environment. You will need to answer questions as the basis for generating a default `ocis.yaml` file. You can edit this file later. The default location for config files is, if not otherwise defined, `{ocis_env}`. For details see the xref:deployment/general/general-info.adoc#configuration-directory[Configuration Directory] documentation. Type the following command to initialize Infinite Scale.
 
 [source,bash]
 ----
@@ -146,13 +146,16 @@ you already have created a configuration once. As you cannot overwrite the exist
 
 ==== Recurring Start of Infinite Scale
 
-After initializing Infinite Scale for the first time, you can start the Infinite Scale runtime which includes embedded services. See the sections xref:deployment/general/general-info.adoc#starting-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables] and xref:deployment/general/general-info.adoc#configurations-to-access-the-web-ui[Configurations to Access the Web UI] or xref:deployment/general/general-info.adoc#base-data-directory[Base Data Directory] for basic environment variables.
+After initializing Infinite Scale for the first time, you can start the Infinite Scale runtime which includes embedded services. See the following sections for more information and details:
+
+* xref:deployment/general/general-info.adoc#starting-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables]
+* xref:deployment/general/general-info.adoc#configurations-to-access-the-web-ui[Configurations to Access the Web UI]
 
 NOTE: You cannot instantiate runtime services though you can define which services should start or be excluded from starting. See xref:deployment/general/general-info.adoc#managing-services[Managing Services] for more details.
 
 ==== Accessing the Infinite Scale Runtime
 
-When you have configured and started the Infinite Scale runtime as described in the example command below, you can access it via a browser using `\https://localhost:{ocis_port}`.
+When you have configured and started the Infinite Scale runtime as described in the example command above, you can access it via a browser using `\https://localhost:{ocis_port}`.
 
 Starting Infinite Scale::
 The example commands shown below have no environment variables or command line options for ease of reading, add them according to your requirements.
@@ -174,13 +177,15 @@ ocis server & disown -h
 ----
 
 .ZSH
-[source,bash]
+[source,zsh]
 ----
 ocis server & disown %%
 ----
 
 See the respective shell documentation for how to manage processes respectively detach and re-attach sessions.
 --
+
+=== Accessing Infinite Scale Other Than Localhost
 
 include::partial$multi-location/idm-https-reverse-proxy.adoc[]
 

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -27,7 +27,7 @@ This binary setup description makes the following assumptions:
 
 * Server Access:
 ** If you only want to acccess the server running Infinite Scale from the server itself, you can use <localhost> as URL and no further configuration is neccesary.
-** If you want to access the server from remote clients, you must configure and access Infinite Scale using the servers hostname. See the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd] when using a dedicated domain name.
+** If you want to access the server from remote clients, you must configure and access Infinite Scale using the servers hostname. See the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd] example when using a dedicated domain name.
 
 * You are fine in the first step using Infinite Scales internal unsigned certificates. +
 Trusted certificates can be installed later on, see xref:deployment/general/general-info.adoc#handling-certificates[Handling Certificates] for more information. 
@@ -41,13 +41,13 @@ See the xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Pre
 
 == Used Settings
 
-The following settings were used in this guide. You can change this according your needs:
+The following settings were used in this guide. You can change this according to your needs:
 
 * The Infinite Scale binary location: `{ocis_bin}` (OS default)
 * The Infinite Scale xref:deployment/general/general-info.adoc#configuration-directory[configuration directory]: `{ocis_env}`
 * The Infinite Scale xref:deployment/general/general-info.adoc#base-data-directory[base data directory]: `{ocis_data}`
-* The URL accessing Infinite Scale: `{ocis_url}`
-* The internal port accessing Infinite Scale: {ocis_port} (default)
+* The URL for accessing Infinite Scale: `{ocis_url}`
+* The port for accessing Infinite Scale: {ocis_port} (default)
 
 == Installation
 

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -15,7 +15,7 @@
 
 == Introduction
 
-This description gives a brief overview and can be used as basic template running the ocis binary. It does not cover extended deployment tasks or how to manage trusted certificates.
+This description gives a brief overview and can be used as basic template for running the ocis binary. It does not cover extended deployment tasks or how to manage trusted certificates.
 
 {description} 
 

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -1,22 +1,25 @@
-= Binary Setup
+= Minimal Bare Metal Deployment
 :toc: right
 :toclevels: 3
-:description: Installing the Infinite Scale binary manually works well if you want to quickly test Infinite Scale without performing additional tasks
+:page-aliases: deployment/binary/binary-setup.adoc
+:description: Installing the Infinite Scale binary manually works well if you want to quickly test Infinite Scale without performing additional tasks.
 
 :systemd-url: https://systemd.io/
 :traefik-url: https://doc.traefik.io/traefik/getting-started/install-traefik/
 
 :ocis_bin: /usr/local/bin
-:ocis_env: /etc/ocis
+:ocis_env: $HOME/.ocis/config/
 :ocis_data: /var/lib/ocis
-:ocis_url: ocis.example.com
+:ocis_url: localhost or IP
 :ocis_port: 9200
 
 == Introduction
 
-This description gives a brief overview and can be used as basic template running the ocis binary, including an example of how to configure systemd. It does not cover extended deployment tasks or how to manage trusted certificates.
+This description gives a brief overview and can be used as basic template running the ocis binary. It does not cover extended deployment tasks or how to manage trusted certificates.
 
-{description} like a xref:deployment/container/orchestration/orchestration.adoc[container orchestration] or using a xref:depl-examples/bare-metal.adoc[reverse proxy]. Of course you can use it for production in your environment, too. See the xref:availability_scaling/availability_scaling.adoc[Availability and Scalability] documentation for impacts. 
+{description} 
+
+For a small production environment, see the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd]. The main differences between the setup described in this document and the small production environment is the use of systemd, letsencrypt and a reverse proxy.
 
 [IMPORTANT]
 ====
@@ -24,7 +27,7 @@ This binary setup description makes the following assumptions:
 
 * Server Access:
 ** If you only want to acccess the server running Infinite Scale from the server itself, you can use <localhost> as URL and no further configuration is neccesary.
-** If you want to acccess the server running Infinite Scale from clients, you must configure and access Infinite Scale using the servers hostname or IP. <localhost> is not possible. See the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd] when using a dedicated domain name.
+** If you want to access the server from remote clients, you must configure and access Infinite Scale using the servers hostname. See the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd] when using a dedicated domain name.
 
 * You are fine in the first step using Infinite Scales internal unsigned certificates. +
 Trusted certificates can be installed later on, see xref:deployment/general/general-info.adoc#handling-certificates[Handling Certificates] for more information. 
@@ -34,7 +37,17 @@ IMPORTANT: ownCloud highly recommends reading the xref:deployment/general/genera
 
 == Prerequisite
 
-See xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[ocis prerequisites,window=_blank].
+See the xref:prerequisites/prerequisites.adoc#filesystems-and-shared-storage[Prerequisites,window=_blank] section for more details.
+
+== Used Settings
+
+The following settings were used in this guide. You can change this according your needs:
+
+* The Infinite Scale binary location: `{ocis_bin}` (OS default)
+* The Infinite Scale xref:deployment/general/general-info.adoc#configuration-directory[configuration directory]: `{ocis_env}`
+* The Infinite Scale xref:deployment/general/general-info.adoc#base-data-directory[base data directory]: `{ocis_data}`
+* The URL accessing Infinite Scale: `{ocis_url}`
+* The internal port accessing Infinite Scale: {ocis_port} (default)
 
 == Installation
 
@@ -139,11 +152,10 @@ NOTE: You cannot instantiate runtime services though you can define which servic
 
 ==== Accessing the Infinite Scale Runtime
 
-When you have configured and started the Infinite Scale _runtime_ either xref:starting-infinite-scale[manually] or via xref:setting-up-systemd-for-infinite-scale[systemd] as described below, you can access it via a browser using `\https://localhost:{ocis_port}`.
+When you have configured and started the Infinite Scale runtime as described in the example command below, you can access it via a browser using `\https://localhost:{ocis_port}`.
 
-include::partial$multi-location/idm-https-reverse-proxy.adoc[]
-
-The example commands shown below have no environment variables or command line options for ease of reading, add them according to your requirements::
+Starting Infinite Scale::
+The example commands shown below have no environment variables or command line options for ease of reading, add them according to your requirements.
 +
 --
 To start the Infinite Scale runtime type:
@@ -170,6 +182,8 @@ ocis server & disown %%
 See the respective shell documentation for how to manage processes respectively detach and re-attach sessions.
 --
 
+include::partial$multi-location/idm-https-reverse-proxy.adoc[]
+
 === List Running Infinite Scale Processes
 
 To list all running ocis processes type:
@@ -189,10 +203,10 @@ ps ax | grep ocis | grep -v grep
 
 Depending on what you want to stop, different commands need to be applied.
 
-If a service is being terminated with its PID, the signal `SIGTERM` (-15) is used. Note that SIGTERM politely asks a process to terminate. It will terminate gracefully, cleaning up all resources (files, sockets, child processes, etc.), deleting temporary files and so on.
+If a service is being terminated with its PID, the signal `SIGTERM` (-15) is used. Note that SIGTERM politely asks a process to terminate. It will terminate gracefully, cleaning up all resources (files, sockets, child processes, etc.), deleting temporary files and so on. Do not use `SIGKILL` (-9) as this will initiate a dirty shutdown.
 
 Stopping the complete runtime with all its running services::
-Depending on the user you started `ocis` with and which user you are currently logged in as, you may need to use `sudo` for proper permissions.
+Depending on the user you started `ocis` with and which user you are currently logged in as, you may need to use `sudo` for the kill command for proper permissions.
 + 
 [source,bash]
 ----
@@ -200,7 +214,7 @@ ps -ax | \
    grep "ocis server" | \
    grep -v grep | \
    awk '{ print $1 }' | \
-   xargs kill -15
+   xargs sudo kill -15
 ----
 
 Stopping a particular ocis PID::
@@ -225,61 +239,3 @@ To terminate the `ocis proxy` service type the following command, where `sudo` m
 ----
 sudo kill -15 221706
 ----
-
-== Setting up systemd for Infinite Scale
-
-Note that the procedure assumes that a fresh setup from scratch is made. If not, you must relocate and adapt an existing config file.  
-
-=== Create a Service User
-
-In your operating system, create a user and group who will run the ocis service and own all the files of the Infinite Scale service but is not allowed to log in, has no shell and no home directory.
-
-[source,bash]
-----
-sudo useradd --system --no-create-home --shell=/sbin/nologin ocis
-----
-
-* We strongly advise *against* using the user `root` for this purpose.
-* Since the `ocis` user doesn't have a home directory, the directories `{ocis_env}` and `{ocis_data}` must exist and the user `ocis` must be able to read it.
-+
---
-[source,bash,subs="attributes+"]
-----
-sudo mkdir -p {ocis_env} {ocis_data}
-----
-
-[source,bash,subs="attributes+"]
-----
-sudo chown -R ocis:ocis {ocis_env} {ocis_data}
-----
---
-* Placing the environment file in `{ocis_env}` is only a suggestion, but a good one.
-** Create the file `{ocis_env}/ocis.env` with the definitions of environment variables. See the following sections for information on additional environment variables: xref:deployment/general/general-info.adoc#configurations-to-access-the-webui[Configurations to Access the Web UI] and xref:deployment/general/general-info.adoc#base-data-directory[Base Data Directory].
-+
---
-NOTE: This is just an example with a minimal set of environment variables used.
-
-[source,plaintext,subs="attributes+"]
-----
-OCIS_INSECURE=true
-OCIS_URL=https://<hostname or IP>:{ocis_port}
-PROXY_HTTP_ADDR=0.0.0.0:{ocis_port}
-OCIS_CONFIG_DIR={ocis_env}
-OCIS_BASE_DATA_PATH={ocis_data}
-OCIS_LOG_LEVEL=error
-----
---
-
-Use the following command to initialize the Infinite Scale config:
-
-[source,bash,subs="attributes+"]
-----
-OCIS_CONFIG_DIR={ocis_env} \
-sudo -u ocis ocis init --insecure true
-----
-
-=== Setup systemd Service
-
-include::partial$deployment/systemd.adoc[]
-
-include::partial$deployment/dependent_startup.adoc[leveloffset=+2]

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -8,7 +8,7 @@
 
 IMPORTANT: We highly recommend reading this document first before you start setting up your system. Many obstacles can be avoided when knowing the basic concepts. Though it is tempting to just give things a try - which is totally ok, you will quickly realize that you may have to start again from scratch before the setup meets your requirements.
 
-The example commands shown need to be adjusted depending on whether you are using the xref:deployment/binary/binary-setup.adoc[Binary Setup] or a xref:deployment/container/container-setup.adoc[Container Setup].
+The example commands shown need to be adjusted depending on whether you are using the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] or a xref:deployment/container/container-setup.adoc[Container Setup].
 
 When using global options on startup, you can always use command line options or environment variables. Run `ocis help` and see xref:starting-infinite-scale-with-environment-variables[] for details.
 
@@ -24,7 +24,7 @@ Starting Infinite Scale using the embedded supervisor::
 This mode can be used when scaling is not the primary focus and can be the case if you have a:
 * testing and/or development environment, or
 * small production environment (xref:availability_scaling/availability_scaling.adoc#single-server-setup[Single Server Setup]).
-* See: xref:deployment/binary/binary-setup.adoc[Binary Setup] and xref:deployment/container/container-setup.adoc[Container Setup] for more details.
+* See: xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] and xref:deployment/container/container-setup.adoc[Container Setup] for more details.
 
 Starting Infinite Scale in unsupervised mode::
 This mode is used when _availability, scaling and the adjustment to dynamically changing requirements_ have a xref:availability_scaling/availability_scaling.adoc#deployment-evolution[high priority]. In this case, an external supervisor like Kubernetes is used to deploy and run Infinite Scale with its services.
@@ -61,7 +61,7 @@ ocis list
 ----
 
 Stopping the Infinite Scale Runtime::
-In supervised mode, you have to stop the `ocis server` which also stops all services. See xref:deployment/binary/binary-setup.adoc#stopping-infinite-scale[Stopping Infinite Scale] for more details.
+In supervised mode, you have to stop the `ocis server` which also stops all services. See xref:depl-examples/minimal-bare-metal.adoc#stopping-infinite-scale[Stopping Infinite Scale] for more details.
 
 ==== Unsupervised Services
 
@@ -188,7 +188,7 @@ See xref:using-s3-for-blobs[Using S3 for Blobs] for the S3 configuration.
 * Do not replace `$HOME` with `~` (tilde).
 ** The code does not resolve `~` to the users home directory.
 * Check that `$HOME` resolves to a valid directory.
-** When using a system user for the runtime, which has no login and therefore no home directory, like in the scenario xref:deployment/binary/binary-setup.adoc#setting-up-systemd-for-infinite-scale[Setting up systemd for Infinite Scale], you *must* specify a configuration file location.
+** When using a system user for the runtime, which has no login and therefore no home directory, like in the scenario xref:depl-examples/bare-metal.adoc#setup-the-systemd-service[Setup the systemd Service], you *must* specify a configuration file location.
 ====
 
 * You can deviate from the default location and define a custom configuration directory on startup using the environment variable `OCIS_CONFIG_DIR`.
@@ -265,7 +265,7 @@ The following environment variables can overwrite the base data path if required
 ** The code does not resolve `~` to the users home directory.
 
 * Check that `$HOME` resolves to a valid directory.
-** When using a system user for the runtime, which has no login and therefore no home directory, like in the generic binary setup scenario xref:deployment/binary/binary-setup.adoc#setting-up-systemd-for-infinite-scale[Setting up systemd for Infinite Scale] or in the deployment example xref:depl-examples/small-scale.adoc[Small-Scale with systemd], you *must* specify a base directory location because a system user has no logon and therefore no home directory!
+** When using a system user for the runtime, which has no login and therefore no home directory, like in the generic binary setup scenario xref:depl-examples/bare-metal.adoc#setup-the-systemd-service[Setup the systemd Service] or in the deployment example xref:depl-examples/small-scale.adoc[Small-Scale with systemd], you *must* specify a base directory location because a system user has no logon and therefore no home directory!
 ====
 
 * You can deviate from the default location and define a custom base directory on startup using the environment variable `OCIS_BASE_DATA_PATH`.
@@ -286,7 +286,7 @@ Read the xref:deployment/storage/s3.adoc[S3] documentation for more details on h
 
 == Initialize Infinite Scale
 
-Infinite Scale can be run by manually defining the environment like you do when using xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration]. When using the xref:deployment/binary/binary-setup.adoc[Binary Setup] or the xref:deployment/container/container-setup.adoc[Container Setup], you can prepare Infinite Scale for further configuration and recurring starts. After reading xref:deployment/general/ocis-init.adoc[The ocis init Command] for important details, start the initialisation. To do so, run:
+Infinite Scale can be run by manually defining the environment like you do when using xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration]. When using the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] or the xref:deployment/container/container-setup.adoc[Container Setup], you can prepare Infinite Scale for further configuration and recurring starts. After reading xref:deployment/general/ocis-init.adoc[The ocis init Command] for important details, start the initialisation. To do so, run:
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -399,13 +399,13 @@ NOTE: In case of a service overwriting its shared logging config received from t
 
 These are the necessary log keys and the available values:
 
-[source,plaintext]
+[source,yaml]
 ----
 log:
-  level: [ error | warning | info | debug ]
-  color: [ true | false ]
+  level:  [ error | warning | info | debug ]
+  color:  [ true | false ]
   pretty: [ true | false ]
-  file: [ path/to/log/file ] # MUST not be used with pretty = true
+  file:   [ path/to/log/file ] # MUST not be used with pretty = true
 ----
 
 == Configurations to Access the Web UI

--- a/modules/ROOT/pages/deployment/general/ocis-init.adoc
+++ b/modules/ROOT/pages/deployment/general/ocis-init.adoc
@@ -10,9 +10,9 @@
 
 In general, the xref:deployment/general/general-info.adoc#initialize-infinite-scale[ocis init] command initializes ocis _for the first run_ and creates an `ocis.yaml` configuration file. See xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules] for the file location. This command is helpful if you do not provide the necessary settings manually, but some rules apply.
 
-=== Binary Setup
+=== Minimal Bare Metal Deployment
 
-When using the xref:deployment/binary/binary-setup.adoc[Binary Setup], the command *is recommended* to be run manually once before first usage, though you can also fully configure the initial setup manually.
+When using the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment], the command *is recommended* to be run manually once before first usage, though you can also fully configure the initial setup manually.
 
 * The following command line parameters or their equivalent environment variables can be defined to configure the `ocis init` command. When using environment variables the following structure is used; multiple variables are allowed:
 +

--- a/modules/ROOT/pages/deployment/index.adoc
+++ b/modules/ROOT/pages/deployment/index.adoc
@@ -8,7 +8,7 @@
 
 * The xref:deployment/general/general-info.adoc[General Info] section summarizes general and important information which is not dependent on the way that you install Infinite Scale. Any setup refers to this general information as prerequisite knowledge.
 
-* If you only want to play around and see what Infinite Scale has to offer, we suggest the quick and easy xref:deployment/binary/binary-setup.adoc[Binary Setup] section.
+* If you only want to play around and see what Infinite Scale has to offer, we suggest the quick and easy xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] section.
 
 * If you have already decided on a container instance with one or more containers, checkout the xref:deployment/container/container-setup.adoc[Container Setup].
 

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -21,7 +21,7 @@ Examples:
 // their source is in: https://github.com/owncloud/ocis/blob/master/ocis-pkg/config/config.go
 // at 'type Runtime struct'
 
-The following environment variables are only available with the xref:deployment/binary/binary-setup.adoc[Binary Setup]. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
+The following environment variables are only available with the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 
 [tabs]
 ====

--- a/modules/ROOT/partials/multi-location/event-bus.adoc
+++ b/modules/ROOT/partials/multi-location/event-bus.adoc
@@ -8,7 +8,7 @@ The Infinite Scale event bus can be configured by a set of environment variables
 
 [NOTE]
 ====
-* If you are using a binary installation as described in xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] or xref:depl-examples/bare-metal.adoc[Bare Metal with systemd], the address of the event bus `OCIS_EVENTS_ENDPOINT` is predefined as localhost address without the need for further configuration, but changable on demand.
+* If you are using a binary installation as described in xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] or xref:depl-examples/bare-metal.adoc[Bare Metal with systemd], the address of the event bus `OCIS_EVENTS_ENDPOINT` is predefined as localhost address without the need for further configuration, but changeable on demand.
 
 * In case of an orchestrated installation like with Docker or Kubernetes, the event bus must be an external service for scalability like a `Redis Sentinel cluster` or a key-value-store https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]. Both named stores are supported and also used in xref:deployment/services/caching.adoc[Caching and Persistence]. The store used is not part of the Infinite Scale installation and must be separately provided and configured.
 

--- a/modules/ROOT/partials/multi-location/event-bus.adoc
+++ b/modules/ROOT/partials/multi-location/event-bus.adoc
@@ -8,7 +8,7 @@ The Infinite Scale event bus can be configured by a set of environment variables
 
 [NOTE]
 ====
-* If you are using a binary installation as described in xref:deployment/binary/binary-setup.adoc[Binary Setup] or xref:depl-examples/bare-metal.adoc[Bare Metal with systemd], the address of the event bus `OCIS_EVENTS_ENDPOINT` is predefined as localhost address without the need for further configuration, but changable on demand.
+* If you are using a binary installation as described in xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] or xref:depl-examples/bare-metal.adoc[Bare Metal with systemd], the address of the event bus `OCIS_EVENTS_ENDPOINT` is predefined as localhost address without the need for further configuration, but changable on demand.
 
 * In case of an orchestrated installation like with Docker or Kubernetes, the event bus must be an external service for scalability like a `Redis Sentinel cluster` or a key-value-store https://docs.nats.io/nats-concepts/jetstream/key-value-store[NATS JetStream]. Both named stores are supported and also used in xref:deployment/services/caching.adoc[Caching and Persistence]. The store used is not part of the Infinite Scale installation and must be separately provided and configured.
 

--- a/modules/ROOT/partials/multi-location/idm-https-reverse-proxy.adoc
+++ b/modules/ROOT/partials/multi-location/idm-https-reverse-proxy.adoc
@@ -3,7 +3,10 @@
 If you want to reuse an already configured _minimized_ setup for any other address than `\https://localhost` :
 
 * When accessing the server using the hostname or IP:
-** You *must* start Infinite Scale using the environment variable `OCIS_URL=<hostname or IP>`. See the sections xref:deployment/general/general-info.adoc#starting-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables] and xref:deployment/general/general-info.adoc#configurations-to-access-the-web-ui[Configurations to Access the Web UI].
+** You *must* start Infinite Scale using the environment variable `OCIS_URL=<hostname or IP>`. +
+See the following sections for more details and information:
+*** xref:deployment/general/general-info.adoc#starting-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables] and 
+*** xref:deployment/general/general-info.adoc#configurations-to-access-the-web-ui[Configurations to Access the Web UI].
 
 * When accessing the server using a dedicated domain name:
 ** You *must* use a reverse proxy. When Infinite Scale is accessed, it forwards requests to the embedded xref:{s-path}/idp.adoc[IDP service] which requires a secure connection and a domain name that matches the reverse proxy settings. See the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd] for more details on using a reverse proxy setup.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -12,7 +12,6 @@
 *** xref:deployment/storage/s3.adoc[S3]
 ** xref:deployment/general/general-info.adoc[General Information]
 ** xref:deployment/general/ocis-init.adoc[The ocis init Command]
-** xref:deployment/binary/binary-setup.adoc[Binary Setup]
 ** xref:deployment/container/container-setup.adoc[Container Setup]
 ** xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration]
 ** xref:deployment/wopi/wopi.adoc[Office Applications using WOPI]
@@ -88,6 +87,7 @@
 ** xref:conf-examples/office/office-integration.adoc[Office Integration]
 ** xref:conf-examples/search/configure-search.adoc[Search]
 * Deployment Examples
+** xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal]
 ** xref:depl-examples/bare-metal.adoc[Bare Metal with systemd]
 * Additional Information
 ** xref:additional-information/knowledge-base.adoc[Knowledge Base]


### PR DESCRIPTION
Supersedes: #804 (Fix: paths for default deployments, Update general-info.adoc)

The bare metal deployments got revised and restructured.

Language review welcomed.

Currently visible on [staging](https://doc.staging.owncloud.com/ocis/next/)

Backport to 5.0