### PR TITLE
Reset password fix for docker compose

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -534,7 +534,7 @@ The admin password can be reset via command line if it has been forgotten and th
 
 After running the respective command and entering a new password, the admin can relogin using the new password.
 
-Note that when Infinite Scale gets initialized with xref:deployment/general/ocis-init.adoc[The ocis init Command], an admin password is created and stored in the `ocis.yaml` file. The lifespan of this admin password is up to the point when it either gets changed in the webUI or via the resetpassword command. Any admin password changes are NOT written back to the `ocis.yaml` file nor manual changes to the `admin_password` are considerd as a new password.
+Note that when Infinite Scale gets initialized with xref:deployment/general/ocis-init.adoc[The ocis init Command], an admin password is created and stored in the `ocis.yaml` file. The lifespan of this admin password is up to the point when it either gets changed in the webUI or via the resetpassword command. Any admin password changes are NOT written back to the `ocis.yaml` file nor manual changes to the `admin_password` are considered as a new password.
 
 [source,yaml]
 ----
@@ -551,6 +551,8 @@ To reset the admin password, you either must:
 
 * Shutdown Infinite scale if you are using the binary setup.
 * Stop the container if you are using a docker setup.
+* Stop the environment if you are using docker compose. +
+Note that the environemnt must be stopped and not paused.
 * Stop the xref:{s-path}/idm.adoc[IDM] service if you are using an orchestrated setup.
 
 This is because the IDM service needs exclusive access to particular backend information. If the IDM service is running, an error message will be logged and the admin password can't be changed.
@@ -572,10 +574,10 @@ The use of `sudo` depends on if docker has been setup rootless or not.
 Replace the following placeholders according your setup:
 
 * `<ocis-path>` +
-This is the local path the where Infinite Scale stores all data except the configuration.
+This is the local path the where Infinite Scale stores all data except the configuration. See the important information when using xref:docker-volumes[Docker Volumes].
 
 * `<ocis-config-path>` +
-This is the local path where the Infinite Scale configuration is stored. 
+This is the local path where the Infinite Scale configuration is stored. When listing the content, you must see the file `ocis.yaml`. See the important information when using xref:docker-volumes[Docker Volumes].
 
 * `<ocis-version>` +
 The Infinite Scale version used like `latest` or `{compose_version}` or ... .
@@ -584,11 +586,38 @@ The Infinite Scale version used like `latest` or `{compose_version}` or ... .
 ----
 sudo docker run -it \
   -v <ocis-path>:/var/lib/ocis \
-  -v <ocis-config-path>/config:/etc/ocis \
+  -v <ocis-config-path>:/etc/ocis \
   owncloud/ocis:<ocis-version> idm resetpassword
 ----
 
 Note that depending on your setup, you can add `--rm` to your `docker run` command which removes the container afterwards.
+
+[#docker-volumes]
+When you have defined docker volumes for storing data::
+Volume names can be used as paths, which is the case when using docker compose. Note that _full volume names_ need to be identified and used. You can identify them by issuing the following command:
+
+[source,bash]
+----
+sudo docker volume ls
+----
+
+This will give you the following example output like when using the `ocis_wopi` deployment example:
+
+[source]
+----
+DRIVER    VOLUME NAME
+local     ...
+local     ocis_wopi_certs
+local     ocis_wopi_companion-data
+local     ocis_wopi_ocis-config
+local     ocis_wopi_ocis-data
+local     ocis_wopi_wopi-recovery
+----
+
+The volume names needed to reset the password are:
+
+* `ocis_wopi_ocis-data` and
+* `ocis_wopi_ocis-config`.
 
 === Demo Users and Groups
 


### PR DESCRIPTION
The documentation for resetting the admin password needed a fix, because important information for compose environments were missing.

Backport to 5.0