### PR TITLE
Render fix in the general-info page

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -215,7 +215,7 @@ Services That Can Deviate from the Base Data Path::
 The following environment variables can overwrite the base data path if required:
 +
 --
-[source,subs="+callouts,macros,attributes+"]
+[,subs="+callouts,macros,attributes+"]
 ----
 • xref:{s-path}/auth-basic.adoc[OCIS_LDAP_CACERT;AUTH_BASIC_LDAP_CACERT, window=_blank]
 • xref:{s-path}/graph.adoc[OCIS_LDAP_CACERT;GRAPH_LDAP_CACERT, window=_blank]


### PR DESCRIPTION
This is just a small fix to render a block containing callouts correctly.

Before it was rendered as source block, now it is renderd as plain verbatim block. The differernce is, that when using source as parameter, highlight js gets triggered and with it its css rules making the background black as we have with command examples. As this is not a command example but a listing, this was looking bad.

The change is necessary because of the recent docs-ui change fixing hljs rendering.

Backport to 5.0