### PR TITLE
Make ocis 5.0.4 the actual version

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -19,13 +19,13 @@ asciidoc:
     service_tab_1: 'docs-stable-5.0' # latest stable
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
-    service_tab_1_tab_text: '5.0.3' # latest stable including patch releases
+    service_tab_1_tab_text: '5.0.4' # latest stable including patch releases
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_tab_1: 'v5.0.2' # latest stable including patch releases like v5.0.0 (note the v !)
+    compose_tab_1: 'v5.0.4' # latest stable including patch releases like v5.0.0 (note the v !)
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    compose_tab_1_tab_text: '5.0.3' # latest stable including patch releases like 5.0.0 (must be without v !)
+    compose_tab_1_tab_text: '5.0.4' # latest stable including patch releases like 5.0.0 (must be without v !)
 
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc

--- a/site.yml
+++ b/site.yml
@@ -45,9 +45,9 @@ asciidoc:
     # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
-    ocis-actual-version: '5.0.3'
+    ocis-actual-version: '5.0.4'
     ocis-former-version: '4.0.7'
-    ocis-compiled: '2024-05-02 00:00:00 +0000 UTC'
+    ocis-compiled: '2024-05-14 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
   extensions:
     - ./ext-asciidoc/tabs.js


### PR DESCRIPTION
References: https://github.com/owncloud/docs-main/pull/42 (Add release notes for ocis 5.0.4)

No backport, 5.0 only !