### PR TITLE
Add text how to manually define which services will be started

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -363,7 +363,11 @@ This will print an output like:
 +--------------------+
 ----
 
-=== Starting Infinite Scale With Environment Variables
+== Start Infinite Scale With Defined Services
+
+Infinite Scale can be started with a defined set of services which can deviate from the default list. To do so, environment variables can be set as described below. The environment variables relevant to define which services will be started are described in the xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[Special Environment Variables].
+
+== Starting Infinite Scale With Environment Variables
 
 You can use environment variables to define or overwrite config parameters which will be used when starting Infinite Scale like:
 

--- a/modules/ROOT/pages/monitoring/prometheus.adoc
+++ b/modules/ROOT/pages/monitoring/prometheus.adoc
@@ -54,7 +54,14 @@ Build version of the proxy.
 
 == Prometheus Configuration
 
-The following is an example prometheus configuration for the single process mode. It assumes that the proxy service is configured to bind on all interfaces `PROXY_HTTP_ADDR=0.0.0.0:9205` and that the proxy is available via the `ocis` service name (typically in docker-compose). The prometheus service detects the `/metrics` endpoint automatically and scrapes it every 15 seconds.
+The following is an example prometheus configuration for the single process mode. It assumes that:
+
+* the proxy service is configured to bind on all interfaces `PROXY_HTTP_ADDR=0.0.0.0:9205` and 
+* the proxy is available via the `ocis` service name (typically in docker-compose environments).
+
+The prometheus service detects the `/metrics` endpoint automatically and scrapes it every 15 seconds.
+
+IMPORTANT: Note that Metrics are on the debug port 9205 and not on port 9200 !
 
 [source,yaml]
 ----

--- a/modules/ROOT/pages/monitoring/prometheus.adoc
+++ b/modules/ROOT/pages/monitoring/prometheus.adoc
@@ -54,14 +54,7 @@ Build version of the proxy.
 
 == Prometheus Configuration
 
-The following is an example prometheus configuration for the single process mode. It assumes that:
-
-* the proxy service is configured to bind on all interfaces `PROXY_HTTP_ADDR=0.0.0.0:9205` and 
-* the proxy is available via the `ocis` service name (typically in docker-compose environments).
-
-The prometheus service detects the `/metrics` endpoint automatically and scrapes it every 15 seconds.
-
-IMPORTANT: Note that Metrics are on the debug port 9205 and not on port 9200 !
+The following is an example prometheus configuration for the single process mode. It assumes that the proxy service is configured to bind on all interfaces `PROXY_HTTP_ADDR=0.0.0.0:9205` and that the proxy is available via the `ocis` service name (typically in docker-compose). The prometheus service detects the `/metrics` endpoint automatically and scrapes it every 15 seconds.
 
 [source,yaml]
 ----


### PR DESCRIPTION
We missed a text to descibe that we can define which services get started by the supervisor. The envvars relevant for this were already present but you needed to find them.

Backport to 5.0