### PR TITLE
Update prometheus.adoc - correct wrong envvar used

### DIFF
--- a/modules/ROOT/pages/monitoring/prometheus.adoc
+++ b/modules/ROOT/pages/monitoring/prometheus.adoc
@@ -56,7 +56,7 @@ Build version of the proxy.
 
 The following is an example prometheus configuration for the single process mode. It assumes that:
 
-* the proxy service is configured to bind on all interfaces `PROXY_HTTP_ADDR=0.0.0.0:9205` and 
+* the proxy service is configured to bind on all interfaces `PROXY_DEBUG_ADDR=0.0.0.0:9205` and 
 * the proxy is available via the `ocis` service name (typically in docker-compose environments).
 
 The prometheus service detects the `/metrics` endpoint automatically and scrapes it every 15 seconds.


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/issues/9168 and #843

The envvar used was the wrong one, most likely a c/p error - fixed.
Note, dev docs are correct - checked.

Backport to 5.0

@rcrisanti fyi