### PR TITLE
Update Restore Trash-Bins Items in storage-users

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -233,7 +233,7 @@ Has a default value of `720h` which equals `30 days`. This means, the command wi
 Restoring is possible only to the original location. The personal or project `spaceID` is required for the items to be restored. To authenticate the CLI tool use:
 
 --
-`OCIS_SERVICE_ACCOUNT_SECRET=<acc-secret>` and +
+`OCIS_SERVICE_ACCOUNT_SECRET=<acc-secret>` +
 `OCIS_SERVICE_ACCOUNT_ID=<acc-id>`
 --
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -169,7 +169,6 @@ ocis storage-users uploads sessions --expired=false --processing=false
 |
 |===
 
-
 The sessions command can also clear and restart uploads. The output is the same as if run without the `--clean` or `--restart` flag. Note that it is recommended to run the command first without the `--clean` (`--processing`) flag to double check which uploads get cleaned (restarted).
 
 .Cleans all expired uploads regardless of processing and virus state.
@@ -209,12 +208,14 @@ COMMANDS:
 
 ==== Purge Expired
 
-Purge all expired items from the trash-bin.
-
+Purge all expired items from the trash-bin::
++
+--
 [source,bash]
 ----
 ocis storage-users trash-bin purge-expired
 ----
+--
 
 The behaviour of the `purge-expired` command can be configured by using the following environment variables.
 
@@ -229,25 +230,45 @@ Has a default value of `720h` which equals `30 days`. This means, the command wi
 
 ==== List and Restore Trash-Bins Items
 
-The variable `STORAGE_USERS_CLI_MAX_ATTEMPTS_RENAME_FILE` defines a maximum number of attempts to rename a file when the admin restores the file with the CLI option `--option keep-both` to an existing destination with the same name.
+Restoring is possible only to the original location. The personal or project `spaceID` is required for the items to be restored. To authenticate the CLI tool use:
+
+--
+`OCIS_SERVICE_ACCOUNT_SECRET=<acc-secret>` and +
+`OCIS_SERVICE_ACCOUNT_ID=<acc-id>`
+--
+
+The `storage-users` CLI tool uses the default address to establish the connection to the `gateway` service. If the connection fails, check the `GATEWAY_GRPC_ADDR` configuration from your `gateway` service and set the same address to the `storage-users` variable `STORAGE_USERS_GATEWAY_GRPC_ADDR` or globally with `OCIS_GATEWAY_GRPC_ADDR`.
 
 {empty}
+
+Export the gateway address if your configuration differs from the default::
++
+--
+[source,bash]
+----
+export STORAGE_USERS_GATEWAY_GRPC_ADDR=127.0.0.1:9142
+----
+--
 
 Print a list of all trash-bin items of a space::
 +
 --
 [source,bash]
 ----
-ocis storage-users trash-bin list
+ocis storage-users trash-bin list [command options] ['spaceID' required]
 ----
 --
+
+The restore option defines the behavior for an item to be restored, when the item name already exists in the target space. Supported options are: `skip`, `replace` and `keep-both`. The default value is `skip`.
+
+When the CLI tool restores the item with the `replace` option, the existing item will be moved to a trash-bin. When the cli tool restores the item with the `keep-both` option and the designated item already exists, the name of the restored item will be changed by adding a numeric suffix in parentheses. The variable `STORAGE_USERS_CLI_MAX_ATTEMPTS_RENAME_FILE` defines a maximum number of attempts to rename an item.
 
 Restore all trash-bin items for a space::
 +
 --
 [source,bash]
 ----
-ocis storage-users trash-bin restore-all
+ocis storage-users trash-bin restore-all [command options] ['spaceID' required]
 ----
 --
 
@@ -256,7 +277,7 @@ Restore a trash-bin item by ID::
 --
 [source,bash]
 ----
-ocis storage-users trash-bin restore
+ocis storage-users trash-bin restore [command options] ['spaceID' required] ['itemID' required]
 ----
 --
 


### PR DESCRIPTION
Fixes: #850 (Missing details in the 'Restore Trash-Bins Items' doc section in storage-users)
References: https://github.com/owncloud/ocis/pull/9298 ([docs-only] fix two service readme's)

Update the text with regards to Restore Trash-Bins Items.

NO backport.