### PR TITLE
Thumbnails and SecureView

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
@@ -103,6 +103,10 @@ Since source files need to be loaded into memory when generating thumbnails, lar
 
 To have more control over memory and CPU consumption, the maximum number of concurrent requests can be limited by setting the environment variable `THUMBNAILS_MAX_CONCURRENT_REQUESTS`. The default value is 0 which does not apply any restrictions to the number of concurrent requests. As soon as the number of concurrent requests is reached, any further request will be responded with `429/Too Many Requests` and a requesting client can retry at a later point in time.
 
+=== Thumbnails and SecureView
+
+If a resource is shared using SecureView, the share reciever will get a 403 (forbidden) response when requesting a thumbnail. The requesting client needs to decide what to show and usually a placeholder thumbnail is used.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[]


### PR DESCRIPTION
Referencing: https://github.com/owncloud/ocis/pull/9299 (Thumbnailer respect secure view)

Adding a short sentence about the thumbnail behavior when using SecureView.

No backport.