### PR TITLE
add activitylog service

### DIFF
--- a/modules/ROOT/pages/deployment/services/ports-used.adoc
+++ b/modules/ROOT/pages/deployment/services/ports-used.adoc
@@ -42,7 +42,7 @@ The following port ranges are used by services:
 | 9180-9184  | FREE
 | 9185-9189  | xref:{s-path}/thumbnails.adoc[thumbnails]
 | 9190-9194  | xref:{s-path}/settings.adoc[settings]
-| 9195-9197  | FREE
+| 9195-9197  | xref:{s-path}/activitylog.adoc[activitylog]
 | 9198-9199  | xref:{s-path}/auth-service.adoc[auth-service]
 | 9200-9204  | xref:{s-path}/proxy.adoc[proxy]
 | 9205-9209  | xref:{s-path}/proxy.adoc[proxy]

--- a/modules/ROOT/pages/deployment/services/s-list/activitylog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/activitylog.adoc
@@ -1,0 +1,30 @@
+= Activitylog
+:toc: right
+:description: The Infinite Scale activitylog service is responsible for storing events (activities) per resource.
+
+:service_name: activitylog
+
+== Introduction
+
+{description} Resources can be `Space Roots`, `Files` and `Folders`.
+
+== Default Values
+
+* Activitylog listens on port 9195 by default.
+
+include::partial$deployment/services/log-service-ecosystem.adoc[]
+
+== Storing
+
+// renders dependent on is_cache or is_stat
+:is_stat: true
+
+include::partial$multi-location/caching-list.adoc[]
+
+== Event Bus Configuration
+
+include::partial$multi-location/event-bus.adoc[]
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -22,6 +22,7 @@ The `eventhistory` services consumes all events from the configured event system
 
 === Storing
 
+// renders dependent on is_cache or is_stat
 :is_stat: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -119,6 +119,7 @@ include::partial$multi-location/event-bus.adoc[]
 
 == Caching
 
+// renders dependent on is_cache or is_stat
 :is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -16,6 +16,7 @@
 
 == Caching
 
+// renders dependent on is_cache or is_stat
 :is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -44,6 +44,7 @@ image::deployment/services/graph/mermaid-graph.svg[width=600]
 
 == Caching
 
+// renders dependent on is_cache or is_stat
 :is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -103,6 +103,7 @@ include::partial$multi-location/event-bus.adoc[]
 
 == Storing
 
+// renders dependent on is_cache or is_stat
 :is_stat: true
 
 The `postprocessing` service needs to store some metadata about uploads to be able to orchestrate post-processing. When running in single binary mode, the default in-memory implementation will be just fine. In distributed deployments it is recommended to use a persistent store, see below for more details.

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -107,6 +107,7 @@ The default `role_claim` (or `PROXY_ROLE_ASSIGNMENT_OIDC_CLAIM`) is `roles`. The
 
 Important, also see section xref:presigned-urls[Presigned Urls] below.
 
+// renders dependent on is_cache or is_stat
 :is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -32,6 +32,7 @@ The settings service supports two different backends for persisting the data. Th
 
 == Caching
 
+// renders dependent on is_cache or is_stat
 :is_cache: true
 
 When using `SETTINGS_STORE_TYPE=metadata`, the `settings` service caches the results of queries against the storage backend to provide faster responses. The content of this cache is independent of the cache used in the `storage-system` service as it caches directory listing and settings content stored in files.

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -16,6 +16,7 @@
 
 == Caching
 
+// renders dependent on is_cache or is_stat
 :is_cache: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -287,6 +287,7 @@ include::partial$multi-location/event-bus.adoc[]
 
 == Caching
 
+// renders dependen on is_cache or is_stat
 :is_cache: true
 
 The `storage-users` service caches stat, metadata and uuids of files and folders via the configured stores.

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -22,6 +22,7 @@ Running the `userlog` service without running the xref:{s-path}/eventhistory.ado
 
 == Storing
 
+// renders dependent on is_cache or is_stat
 :is_stat: true
 
 include::partial$multi-location/caching-list.adoc[]

--- a/modules/ROOT/partials/deployment/services/log-service-ecosystem.adoc
+++ b/modules/ROOT/partials/deployment/services/log-service-ecosystem.adoc
@@ -1,19 +1,30 @@
 == The Log Service Ecosystem
 
-Log services like the `userlog`, `clientlog` and `sse` are responsible for composing notifications for a certain audience.
+Log services like the `activitylog`, `clientlog`, `sse` and `userlog` are responsible for composing notifications for a certain audience.
 
 {empty} +
 
 [width=80%,cols="20%,80%",options="header"]
 |====
 2+^| Log services and their tasks
-| xref:{s-path}/userlog.adoc[userlog]
-| This service *translates and adjusts messages* to be human-readable.
+
+| xref:{s-path}/activitylog.adoc[activitylog] ^1^
+| This service *stores events per resource*. These can be retrieved to show item activities.
 
 | xref:{s-path}/clientlog.adoc[clientlog]
 | This service *composes machine-readable messages*, so clients can act without the need to query the server.
 
+| xref:{s-path}/eventhistory.adoc[eventhistory]
+| This service *stores events* and allows other services to retrieve them via an event ID.
+
 | xref:{s-path}/sse.adoc[sse]
 | This service is only responsible for *sending these messages*. It does not care about their form or language.
 
+| xref:{s-path}/userlog.adoc[userlog] ^2^
+| This service *translates and adjusts messages* to be human-readable.
 |====
+
+Services may depend on each other:
+
+1. The `activitylog` service mandatory requires the `eventhistory` service. +
+2. The `userlog` service is configured by default to use both the `eventhistory` and `sse` service. It can be configured to use both, the one, or the other. 

--- a/modules/ROOT/partials/multi-location/caching-list.adoc
+++ b/modules/ROOT/partials/multi-location/caching-list.adoc
@@ -13,9 +13,10 @@ ifdef::is_stat[]
 :env_nodes: OCIS_PERSISTENT_STORE_NODES
 endif::is_stat[]
 
-The {service_name} service can use a configured store via the global {env_store} environment variable.
+The {service_name} service can use a configured store via the global `{env_store}` environment variable.
 
 Note that for each global environment variable, a service-based one might be available additionally. For precedences see xref:deployment/services/env-var-note.adoc[Environment Variable Notes]. Check the configuration section below. Supported stores are:
+
 {empty} +
 {empty} +
 

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -29,6 +29,7 @@
 **** xref:deployment/services/ports-used.adoc[Ports Used]
 **** xref:deployment/services/tls.adoc[Transport Layer Security]
 *** List of Services
+**** xref:deployment/services/s-list/activitylog.adoc[Activitylog]
 **** xref:deployment/services/s-list/antivirus.adoc[Antivirus]
 **** xref:deployment/services/s-list/app-provider.adoc[App Provider]
 **** xref:deployment/services/s-list/app-registry.adoc[App Registry]


### PR DESCRIPTION
Fixes: #864 (Add Activitylog Service)

Adds the `activitylog` service to the admin docs.

NO backport.