### PR TITLE
Added custom ca chain to helm doc

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -807,18 +807,18 @@ kubectl apply -f builtin-user-mgmt-secrets.yaml
 
 . To apply secrets via your own `values.yaml`, add the content at `extraResources`. Proper yaml formatting is necessary.
 
-==== Custom CA chain
+==== Custom CA Chain
 
-If you're using a custom CA for some of your services like S3 or your mail server it can be necessary to add a custom CA chain to your deployment.
+If you are using a custom CA for some of your services like S3 or your mail server, it can be necessary to add a custom CA chain to your deployment.
 
 * When adding the custom CA chain, a secret with the CA chain must be present. Multiple chains can be part of this secret.
 +
+--
 [source,bash]
 ----
 kubectl create secret generic ocis-custom-ca-chain --from-file=/PATH/TO/FILE
 ----
 
-+
 [source,yaml]
 ----
 customCAChain:
@@ -827,6 +827,7 @@ customCAChain:
   # Name of existing secret
   existingSecret: "ocis-custom-ca-chain"
 ----
+--
 
 ==== External User Management Secrets
 

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -807,6 +807,27 @@ kubectl apply -f builtin-user-mgmt-secrets.yaml
 
 . To apply secrets via your own `values.yaml`, add the content at `extraResources`. Proper yaml formatting is necessary.
 
+==== Custom CA chain
+
+If you're using a custom CA for some of your services like S3 or your mail server it can be necessary to add a custom CA chain to your deployment.
+
+* When adding the custom CA chain, a secret with the CA chain must be present. Multiple chains can be part of this secret.
++
+[source,bash]
+----
+kubectl create secret generic ocis-custom-ca-chain --from-file=/PATH/TO/FILE
+----
+
++
+[source,yaml]
+----
+customCAChain:
+  # Adds custom CA Chain to pods
+  enabled: true
+  # Name of existing secret
+  existingSecret: "ocis-custom-ca-chain"
+----
+
 ==== External User Management Secrets
 
 If you're using external user management by setting `features.externalUserManagement.enabled` to `true`, you need to set these Secrets. Certificates are also required which should expire and therefore need a certificate rotation from time to time, for which we didn't document appropiate tooling yet.


### PR DESCRIPTION
Added documentation for the Helm chart for a new feature with custom CA chains.
https://github.com/owncloud/ocis-charts/pull/599

Needs Backport to 5.0