### PR TITLE
Correcting the latest ocis stable version rendered for 5.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -19,13 +19,13 @@ asciidoc:
     service_tab_1: 'docs-stable-5.0' # latest stable
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
-    service_tab_1_tab_text: '5.0.4' # latest stable including patch releases
+    service_tab_1_tab_text: '5.0.5' # latest stable including patch releases
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_tab_1: 'v5.0.4' # latest stable including patch releases like v5.0.0 (note the v !)
+    compose_tab_1: 'v5.0.5' # latest stable including patch releases like v5.0.0 (note the v !)
 
     # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    compose_tab_1_tab_text: '5.0.4' # latest stable including patch releases like 5.0.0 (must be without v !)
+    compose_tab_1_tab_text: '5.0.5' # latest stable including patch releases like 5.0.0 (must be without v !)
 
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc


### PR DESCRIPTION
Missed to correct the latest stable patch release for 5.0 --> 5.0.5

Only for the 5.0 branch !