### PR TITLE
[5.0] [PR 875] Correct the ocis-actual-version attribute for local builds

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -45,7 +45,7 @@ asciidoc:
     # These versions are just for printing like in docs-main release info, but not used in docs-ocis.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
-    ocis-actual-version: '5.0.4'
+    ocis-actual-version: '5.0.5'
     ocis-former-version: '4.0.7'
     ocis-compiled: '2024-05-14 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'


### PR DESCRIPTION
Backport of PR #875