### PR TITLE
Make banned passwords usecase more visible

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -50,7 +50,7 @@ When setting the `FRONTEND_AUTO_ACCEPT_SHARES` to `true`, all incoming shares wi
 
 === The Password Policy
 
-Note that the password policy currently impacts only *public link password validation*.
+IMPORTANT: Note that the password policy impacts only *public link password validation*.
 
 With the password policy, mandatory criteria for the password can be defined via the environment variables listed below.
 

--- a/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/sharing.adoc
@@ -14,6 +14,10 @@
 
 * Sharing listens on port 9150 by default.
 
+== Passwords
+
+For details on password management see the xref:{s-path}/frontend.adoc#passwords[Passwords] documentation. 
+
 == Event Bus Configuration
 
 include::partial$multi-location/event-bus.adoc[]


### PR DESCRIPTION
After falling into the pit not carefully reading the banned pwd list docs, I improved visibility that it is restriced to `public link password validation`.

Backport to 5.0