### PR TITLE
Revert "Added custom ca chain to helm doc"

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -807,28 +807,6 @@ kubectl apply -f builtin-user-mgmt-secrets.yaml
 
 . To apply secrets via your own `values.yaml`, add the content at `extraResources`. Proper yaml formatting is necessary.
 
-==== Custom CA Chain
-
-If you are using a custom CA for some of your services like S3 or your mail server, it can be necessary to add a custom CA chain to your deployment.
-
-* When adding the custom CA chain, a secret with the CA chain must be present. Multiple chains can be part of this secret.
-+
---
-[source,bash]
-----
-kubectl create secret generic ocis-custom-ca-chain --from-file=/PATH/TO/FILE
-----
-
-[source,yaml]
-----
-customCAChain:
-  # Adds custom CA Chain to pods
-  enabled: true
-  # Name of existing secret
-  existingSecret: "ocis-custom-ca-chain"
-----
---
-
 ==== External User Management Secrets
 
 If you're using external user management by setting `features.externalUserManagement.enabled` to `true`, you need to set these Secrets. Certificates are also required which should expire and therefore need a certificate rotation from time to time, for which we didn't document appropiate tooling yet.


### PR DESCRIPTION
Reverts owncloud/docs-ocis#871

This was merged too early as the corresponding charts PR is still not merged and has been changed a lot.

Note that it has been decided to remove the HC docs until those are a "product" but due to time constraints this had not happened so far.


@d7oc as discussed, it affects only master of the admin docs.
@b1schumacher fyi