### PR TITLE
Enable Rolling Releases in master (next)

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -19,6 +19,8 @@ asciidoc:
     service_tab_1: 'docs' # latest stable like docs-stable-5.0
 
     # service_tab_x_tab_text will be used as tab text shown for service_tab_x
+    # note when literally changing the word 'master' to something else, you also must adapt 'env-and-yaml.adoc'.
+    # this does not apply to branched releases using semver, only to the master branch! 
     service_tab_1_tab_text: 'master' # latest stable including patch releases like 5.0.0
 
     # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -73,6 +73,14 @@ NOTE: We highly recommend reading the xref:deployment/general/general-info.adoc[
 
 Configuration of Infinite Scale might be quite different to what you are used to but it's very simple. It works with environment variables and optional configuration files for you to create depending on your specific needs. The settings in configuration files can always be overruled by setting the respective environment variables manually on the command line.
 
+== Release Life Cycle
+
+Starting with version 6 of Infinite Scale, releases are now split into `production` and `rolling`. See the https://owncloud.dev/ocis/release_roadmap/[Developer Docs Release Life Cycle] page for more details and impacts.
+
+You can find more details on changes made in each release published in the https://doc.owncloud.com/ocis_release_notes.html[Infinite Scale Server Release Notes].
+
+IMPORTANT: Rolling releases are published in a cycle of 3 weeks. Due to this relative short cycle, you will find the actual development and the current published rolling release documentation *not* separated. They are both part of the `next` segment in the URL. Compared to production releases where the respective release number is used, the actual rolling release number published can be found e.g. in each service description in section "Environment Variables".
+
 == Try Online
 
 You can try Infinite Scale before you install it locally to get hands-on experience and a feeling for how things work and integrate. Our development provides several instances with different setups to test. The instances are reset on a regular basis. See our https://owncloud.dev/ocis/deployment/continuous_deployment/[Continuous Deployment,window=_blank] page for more details.

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -39,9 +39,19 @@ ifndef::no_deprecation[]
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
 endif::no_deprecation[]
 
+// define the text to be printed as tab text for the envvar table in services
+// this is only relevant for master as it prints the rolling version additionally
+// branched versions are not affected
+:tab_text: {service_tab_1_tab_text}
+ifeval::["{service_tab_1_tab_text}" == "master"]
+:tab_text: {service_tab_1_tab_text} + Rolling {ocis-rolling-version}
+endif::[]
+
+
 // conditionally render the envvar entry text, either with or without section header
 
 // text version 1
+
 ifndef::no_yaml[]
 === Environment Variables
 
@@ -49,6 +59,7 @@ The `{service_name}` service is configured via the following environment variabl
 endif::no_yaml[]
 
 // text version 2
+
 ifdef::no_yaml[]
 The `{service_name}` variables are defined in the following way. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 endif::no_yaml[]
@@ -57,7 +68,7 @@ endif::no_yaml[]
 
 [tabs]
 ====
-{service_tab_1_tab_text}::
+{tab_text}::
 +
 --
 include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
@@ -73,7 +84,7 @@ ifndef::no_yaml[]
 
 [tabs]
 ====
-{service_tab_1_tab_text}::
+{tab_text}::
 +
 --
 [source,yaml]

--- a/site.yml
+++ b/site.yml
@@ -48,7 +48,7 @@ asciidoc:
     ocis-actual-version: '5.0.5'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print the envvars table
-    ocis-rolling-version: '6.0.0'
+    ocis-rolling-version: '6.1.0'
     ocis-compiled: '2024-05-14 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
   extensions:

--- a/site.yml
+++ b/site.yml
@@ -47,6 +47,8 @@ asciidoc:
     # To do so, change the values in docs-ocis/antora.yml like compose_tab_1_tab_text.
     ocis-actual-version: '5.0.5'
     ocis-former-version: '4.0.7'
+    # Needed in docs-ocis to define which rolling release to print the envvars table
+    ocis-rolling-version: '6.0.0'
     ocis-compiled: '2024-05-14 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
   extensions:


### PR DESCRIPTION
Implement rolling and production releases in the ocis admin docs.
Note that any rolling version change only needs a change in the docs repo in site.yml
The rest is automated 😄 

Backport to 5.0

Here is a screenshot how it looks:
![image](https://github.com/owncloud/docs-ocis/assets/3321281/2fa34ac7-9a05-4329-9cba-1eb0f0c47104)
