### PR TITLE
Refactor attributes used

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -15,19 +15,26 @@ asciidoc:
     # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
     s-path: 'deployment/services/s-list'
 
-    # service_tab_x will be used to assemble the url accessing the link for the services
-    service_tab_1: 'docs' # latest stable like docs-stable-5.0
+    # note that service_url_component is used for services ONLY
+    # service_url_component will be used to assemble the url for services to include content (tables) sourced from the ocis repo.
+    service_url_component: 'docs' # docs for master or when stable, like docs-stable-5.0
 
-    # service_tab_x_tab_text will be used as tab text shown for service_tab_x
+    # service_tab_text will be used as tab text shown for the tables in services only
     # note when literally changing the word 'master' to something else, you also must adapt 'env-and-yaml.adoc'.
     # this does not apply to branched releases using semver, only to the master branch! 
-    service_tab_1_tab_text: 'master' # latest stable including patch releases like 5.0.0
+    service_tab_text: 'master' # latest stable including patch releases like 5.0.0
 
-    # compose_tab_x will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_tab_1: 'master' # latest stable including patch releases like v5.0.0 (note the v !)
+    # note that compose_url_component is used for compose examples and for the EULA ONLY
+    # compose_url_component will be used to assemble the url (tag) accessing the link for the services (tag)
+    compose_url_component: 'master' # latest stable including patch releases like v5.0.0 (note the v ! as it is tagged)
 
-    # compose_tab_x_tab_text will be used as tab text shown for tab_x
-    compose_tab_1_tab_text: 'master' # latest stable including patch releases like 5.0.0 (must be without v !)
+    # compose_tab_text will be used as tab text for examples and all other stuff but not servcies 
+    compose_tab_text: 'master' # latest stable including patch releases like 5.0.0
+
+    # use this attribute to define the branch name for git clone
+    # the value is usually identical to compose_tab_text, but it should be separatable to be independent
+    # note that you must define a value and not an attribute from above 
+    compose_git_name: 'master' # latest stable including patch releases like 5.0.0 (must be without v !)
 
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc
@@ -50,11 +57,15 @@ asciidoc:
     ocis-charts-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis-charts/'
     values-versions-url: '/charts/ocis/docs/values.adoc.yaml'
     values-desc-versions-url: '/charts/ocis/docs/values-desc-table.adoc'
-    composer-url: 'https://github.com/owncloud/ocis/tree/'
-    composer-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis/'
-    composer-final-path: '/deployments/examples'
-    docker-ocis-url: https://hub.docker.com/r/owncloud/ocis
+    compose_url: 'https://github.com/owncloud/ocis/tree/'
+    compose_raw_url: 'https://raw.githubusercontent.com/owncloud/ocis/'
+    compose_final_path: '/deployments/examples'
 
-    # used in deployment/services via partials/env-and-yaml.adoc
-    ocis-services-raw-url: 'https://raw.githubusercontent.com/owncloud/ocis/'
-    ocis-services-final-path: '/services/_includes/'
+    # production and rolling have separate paths when it comes to download from docker
+    docker_ocis_prod_url: https://hub.docker.com/r/owncloud/ocis
+    docker_ocis_rolling_url: https://hub.docker.com/r/owncloud/ocis-rolling
+
+    # only used in deployment/services via partials/env-and-yaml.adoc
+    # static path components, used to assemble the final path depedend on service_url_component to include services
+    ocis_services_raw_url: 'https://raw.githubusercontent.com/owncloud/ocis/'
+    ocis_services_final_path: '/services/_includes/'

--- a/modules/ROOT/pages/conf-examples/office/ext-files/app-registry.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/app-registry.adoc
@@ -11,9 +11,9 @@ We need to allow substitution of attributes first, then macros.
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/ocis/app-registry.yaml[]
+.Source: link:{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/config/ocis/app-registry.yaml[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/ocis/app-registry.yaml[]
+include::{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/config/ocis/app-registry.yaml[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/ext-files/docker-compose.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/docker-compose.adoc
@@ -11,9 +11,9 @@ We need to allow substitution of attributes first, then macros.
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/docker-compose.yml[]
+.Source: link:{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/docker-compose.yml[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/docker-compose.yml[]
+include::{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/docker-compose.yml[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/ext-files/env.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/env.adoc
@@ -11,9 +11,9 @@ We need to allow substitution of attributes first, then macros
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/.env[]
+.Source: link:{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/.env[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/.env[]
+include::{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/.env[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/ext-files/wopiserver.adoc
+++ b/modules/ROOT/pages/conf-examples/office/ext-files/wopiserver.adoc
@@ -11,9 +11,9 @@ We need to allow substitution of attributes first, then macros.
 :noindex:
 
 [caption=]
-.Source: link:{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
+.Source: link:{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
 {empty}
 [source,yaml]
 ----
-include::{composer-raw-url}{compose_tab_1}{composer-final-path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
+include::{compose_raw_url}{compose_url_component}{compose_final_path}/ocis_wopi/config/wopiserver/wopiserver.conf.dist[]
 ----

--- a/modules/ROOT/pages/conf-examples/office/office-integration.adoc
+++ b/modules/ROOT/pages/conf-examples/office/office-integration.adoc
@@ -12,7 +12,7 @@
 
 {description}
 
-For this purpose, ownCloud offers Docker containers with sample configurations available on {composer-url}{compose_tab_1}{composer-final-path}{wopi_subdir}[GitHub,window=_blank].
+For this purpose, ownCloud offers Docker containers with sample configurations available on {compose_url}{compose_url_component}{compose_final_path}{wopi_subdir}[GitHub,window=_blank].
 
 For details on how WOPI integrates with Infinite Scale see: xref:deployment/wopi/wopi.adoc[Office Applications using WOPI].
 

--- a/modules/ROOT/pages/deployment/container/container-setup.adoc
+++ b/modules/ROOT/pages/deployment/container/container-setup.adoc
@@ -28,7 +28,7 @@
 
 == Introduction
 
-{description} See the latest or stable images from {docker-ocis-url}[Docker Hub].
+{description} See the latest or stable images from {docker_ocis_prod_url}[Docker Hub].
 
 This description mainly focuses on Docker which you can take as template or starting point if you are using different container managing software products.
 
@@ -93,7 +93,7 @@ If the group does not exist or you are not a member, continue with {docker-post-
 
 To give some terminology guidance, images are unchangeable snapshots of live containers, while containers are running (or stopped) instances of an image.
 
-* To download the {docker-ocis-url}[latest Infinite Scale image], run the following command. Note that this command will download the correct image suitable for your OS if available. For Windows, Infinite Scale Docker images are not available, but might be in the future. If not explicitly declared otherwise, the _latest_ tag is implicitely used and always reflects the current master branch. Consider using a stable release when planning ocis for production:
+* To download the {docker_ocis_prod_url}[latest Infinite Scale image], run the following command. Note that this command will download the correct image suitable for your OS if available. For Windows, Infinite Scale Docker images are not available, but might be in the future. If not explicitly declared otherwise, the _latest_ tag is implicitely used and always reflects the current master branch. Consider using a stable release when planning ocis for production:
 +
 [source,bash]
 ----
@@ -132,7 +132,7 @@ latest
 
 === Update an Image
 
-First check the current version of the image used with the command above and compare it with the versions available on {docker-ocis-url}[Docker Hub]. When a new image is available use these steps to upgrade the image.
+First check the current version of the image used with the command above and compare it with the versions available on {docker_ocis_prod_url}[Docker Hub]. When a new image is available use these steps to upgrade the image.
 
 NOTE: Read the ocis release notes before upgrading to avoid missing notes about possible breaking changes.
 

--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -99,12 +99,12 @@ When done, create a project directory like `ocis-compose` in your home directory
 +
 [tabs]
 ====
-{compose_tab_1_tab_text}::
+{compose_tab_text}::
 +
 --
-{composer-url}{compose_tab_1}{composer-final-path}[Docker Compose deployment examples directory,window=_blank]
+{compose_url}{compose_url_component}{compose_final_path}[Docker Compose deployment examples directory,window=_blank]
 
-Using git version name: `{compose_tab_1}`
+Using git version name: `{compose_url_component}`
 --
 ====
 +
@@ -115,7 +115,7 @@ Note that github will not let you download a single directory easily. You can ge
 +
 [source,bash,subs="attributes+"]
 ----
-git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_1_tab_text}
+git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_git_name}
 ----
 
 // https://stackoverflow.com/questions/7106012/download-a-single-folder-or-directory-from-a-github-repo
@@ -124,7 +124,7 @@ git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_1_tab_t
 +
 [source,plaintext,subs="attributes+"]
 ----
-{download-gh-directory-url}?url={composer-url}{compose_tab_1}{composer-final-path}
+{download-gh-directory-url}?url={compose_url}{compose_url_component}{compose_final_path}
 ----
 --
 

--- a/modules/ROOT/pages/deployment/services/env-var-changes.adoc
+++ b/modules/ROOT/pages/deployment/services/env-var-changes.adoc
@@ -2,7 +2,7 @@
 :toc: right
 :description: This page contains tables with added and removed environment variables between Infinite Scale version 4.0.0 and 5.0.0.
 
-:source_path: {ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/env-var-deltas/
+:source_path: {ocis_services_raw_url}{service_url_component}{ocis_services_final_path}adoc/env-var-deltas/
 // https://raw.githubusercontent.com/owncloud/ocis/docs-stable-5.0/services/_includes/adoc/env-var-deltas/
 
 == Introduction

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -19,7 +19,7 @@ Examples:
 // their source is in: https://github.com/owncloud/ocis/blob/master/ocis-pkg/config/config.go
 // at 'type Runtime struct'
 
-The following environment variables are only available with the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
+The following environment variables are only available when using a binary deployment. For an example see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 
 include::partial$deployment/services/env-and-yaml.adoc[tag=special_envvars]
 

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -154,12 +154,12 @@ The policies service contains a set of preconfigured example policies. See the d
 
 [tabs]
 ====
-{compose_tab_1_tab_text}::
+{compose_tab_text}::
 +
 --
-{composer-url}{compose_tab_1}{composer-final-path}[Rego policies deployment examples directory,window=_blank]
+{compose_url}{compose_url_component}{compose_final_path}[Rego policies deployment examples directory,window=_blank]
 
-Using git version name: `{compose_tab_1}`
+Using git version name: `{compose_url_component}`
 --
 ====
 

--- a/modules/ROOT/pages/deployment/wopi/wopi.adoc
+++ b/modules/ROOT/pages/deployment/wopi/wopi.adoc
@@ -68,12 +68,12 @@ image::deployment/wopi/wopi-overview.svg[WOPI Overview Diagram,width=500]
 +
 [tabs]
 ====
-{compose_tab_1_tab_text}::
+{compose_tab_text}::
 +
 --
-{composer-url}{compose_tab_1}{composer-final-path}{wopi_subdir}[Docker Compose WOPI deployment examples directory,window=_blank]
+{compose_url}{compose_url_component}{compose_final_path}{wopi_subdir}[Docker Compose WOPI deployment examples directory,window=_blank]
 
-Using git version name: `{compose_tab_1}`
+Using git version name: `{compose_url_component}`
 --
 ====
 +
@@ -84,7 +84,7 @@ Note that github will not let you download a single directory easily. You can ge
 +
 [source,bash,subs="attributes+"]
 ----
-git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_1_tab_text}
+git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_git_name}
 ----
 
 // https://stackoverflow.com/questions/7106012/download-a-single-folder-or-directory-from-a-github-repo
@@ -93,6 +93,6 @@ git clone --depth 1 https://github.com/owncloud/ocis.git -b {compose_tab_1_tab_t
 +
 [source,plaintext,subs="attributes+"]
 ----
-{download-gh-directory-url}?url={composer-url}{compose_tab_1}{composer-final-path}{wopi_subdir}
+{download-gh-directory-url}?url={compose_url}{compose_url_component}{compose_final_path}{wopi_subdir}
 ----
 --

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -87,7 +87,7 @@ You can try Infinite Scale before you install it locally to get hands-on experie
 
 == End-User License Agreement (EULA)
 
-ownCloud provides an EULA to clarify, among various topics, who can use this software and which conditions apply to the groups of users defined. See the actual {composer-raw-url}{compose_tab_1}/assets/End-User-License-Agreement-for-ownCloud-Infinite-Scale.pdf[EULA] for details.
+ownCloud provides an EULA to clarify, among various topics, who can use this software and which conditions apply to the groups of users defined. See the actual {compose_raw_url}{compose_url_component}/assets/End-User-License-Agreement-for-ownCloud-Infinite-Scale.pdf[EULA] for details.
 
 ////
 

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -7,7 +7,7 @@
 
 {description}
 
-NOTE: For any Infinite Scale version to upgrade to, see {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank] or {docker-ocis-url}[Infinite Scale image] to get the right version.
+NOTE: For any Infinite Scale version to upgrade to, see {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank] or {docker_ocis_prod_url}[Infinite Scale image] to get the right version.
 
 IMPORTANT: Before starting any upgrade, make a xref:maintenance/b-r/backup.adoc[backup] first.
 

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -26,6 +26,8 @@ include::partial$multi-location/tab-text.adoc[]
 {tab_text}::
 +
 --
+[caption=]
+.Environment variables only available for binary deployments
 [width="100%",cols="30%,70%",options="header"]
 |===
 | Name
@@ -61,7 +63,7 @@ include::partial$multi-location/tab-text.adoc[]
 The `{service_name}` service is configured via the following environment variables. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 
 // load the deprecation activation file. this will overwrite the above.
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_deprecation.adoc[]
+include::{ocis_services_raw_url}{service_url_component}{ocis_services_final_path}adoc/{service_name}_deprecation.adoc[]
 
 [tabs]
 ====
@@ -69,7 +71,7 @@ include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{s
 +
 --
 // if deprecation activation is true, it will also show the deprecation content.
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
+include::{ocis_services_raw_url}{service_url_component}{ocis_services_final_path}adoc/{service_name}_configvars.adoc[]
 --
 ====
 
@@ -86,7 +88,7 @@ include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{s
 --
 [source,yaml]
 ----
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}{service_name}-config-example.yaml[]
+include::{ocis_services_raw_url}{service_url_component}{ocis_services_final_path}{service_name}-config-example.yaml[]
 ----
 --
 ====
@@ -116,7 +118,7 @@ The `{service_name}` variables are defined in the following way. Read the xref:d
 {tab_text}::
 +
 --
-include::{ocis-services-raw-url}{service_tab_1}{ocis-services-final-path}adoc/{service_name}_configvars.adoc[]
+include::{ocis_services_raw_url}{service_url_component}{ocis_services_final_path}adoc/{service_name}_configvars.adoc[]
 --
 ====
 

--- a/modules/ROOT/partials/multi-location/compose-version.adoc
+++ b/modules/ROOT/partials/multi-location/compose-version.adoc
@@ -1,8 +1,8 @@
 ////
-'compose_tab_1_tab_text' from the version (branch) can be 'master'. in this case we must use the site.yml's 'ocis-actual-version' to point to a number and not master. this is necessary to dynamically have a version number used and never master as this does not work with docker! we also cant use 'latest' as we have to stick to the referenced stable version.
+'compose_tab_text' from the version (branch) can be 'master'. in this case we must use the site.yml's 'ocis-actual-version' to point to a number and not master. this is necessary to dynamically have a version number used and never master as this does not work with docker! we also cant use 'latest' as we have to stick to the referenced stable version.
 ////
 
-:compose_version: {compose_tab_1_tab_text}
-ifeval::["{compose_tab_1_tab_text}" == "master"]
+:compose_version: {compose_tab_text}
+ifeval::["{compose_tab_text}" == "master"]
 :compose_version: {ocis-actual-version}
 endif::[]

--- a/modules/ROOT/partials/multi-location/tab-text.adoc
+++ b/modules/ROOT/partials/multi-location/tab-text.adoc
@@ -4,8 +4,8 @@ or it is the value of the name as defined in antora.yml
 ////
 
 // compute the correct tab text
-:tab_text: {service_tab_1_tab_text}
+:tab_text: {service_tab_text}
 
-ifeval::["{service_tab_1_tab_text}" == "master"]
-:tab_text: {service_tab_1_tab_text} + Rolling {ocis-rolling-version}
+ifeval::["{service_tab_text}" == "master"]
+:tab_text: {service_tab_text} + Rolling {ocis-rolling-version}
 endif::[]


### PR DESCRIPTION
References: #903 (Slim down and reduce complexity of the 'env-and-yaml' handling)

Attributes used needed a refactoring as there were some legacy things still present and attribute name to usage intention was not longer 1:1

With this PR, these changes help to read and understand some internal structures and usages much better. It is now also future proof.

Backport to 5.0