### PR TITLE
Autoprovisioning documentation

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -50,7 +50,7 @@ The name of an OIDC claim whose value should be used for the `displayname` attri
 * `PROXY_AUTOPROVISION_CLAIM_GROUPS` +
 The name of an OIDC claim whose value should be used to maintain a user's group membership. The claim value should contain a list of group names the user should be a member of. Defaults to `groups`.
 * `PROXY_USER_OIDC_CLAIM` +
-When resolving and authenticated OIDC user, the value of this claims is used to lookup the user in the users service. For auto provisioning setups this usually is the same claims as set via `PROXY_AUTOPROVISION_CLAIM_USERNAME`.
+When resolving an authenticated OIDC user, the value of this claim is used to lookup the user in the users service. For auto provisioning setups this usually is the same claims as set via `PROXY_AUTOPROVISION_CLAIM_USERNAME`.
 * `PROXY_USER_CS3_CLAIM` +
 This is the name of the user attribute in ocis that is used to lookup the user by the value of the `PROXY_USER_OIDC_CLAIM`. For auto provisioning setups this usually needs to be set to `username`.
 
@@ -58,7 +58,7 @@ This is the name of the user attribute in ocis that is used to lookup the user b
 
 When a user logs into ownCloud Infinite Scale for the first time, the proxy checks if that user already exists. This is done by querying the `users` service for users, where the attribute set in `PROXY_USER_CS3_CLAIM` matches the value of the OIDC claim configured in `PROXY_USER_OIDC_CLAIM`.
 
-If the users does not exist, the proxy will create a new user via the `graph` service using the claim values configured in
+If the user does not exist, the proxy will create a new user via the `graph` service using the claim values configured in
 `PROXY_AUTOPROVISION_CLAIM_USERNAME`, `PROXY_AUTOPROVISION_CLAIM_EMAIL` and `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME`.
 
 If the user does already exist, the proxy will check if the user's email or displayname has changed and updates those accordingly via `graph` service.

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -23,6 +23,49 @@ The following request authentication schemes are implemented:
 -   Signed URL
 -   Public Share Token
 
+== Automatic User and Group Provisioning
+
+When using an external OpenID Connect IDP, the proxy can be configured to automatically provision users upon their first login.
+
+=== Prequisites
+
+A number of prerequisites must be met for automatic user provisioning to work:
+
+* Infinite Scale must be configured to use an external OpenID Connect IDP.
+* The `graph` service must be configured to allow updating users and groups (`GRAPH_LDAP_SERVER_WRITE_ENABLED`).
+* The IDP must return a unique value in the user's claims (as part of the userinfo response and/or the access tokens) that can be used to identify the user. This claim needs to be stable and cannot be changed for the whole lifetime of the user. That means, if a claim like `email` or `preferred_username` is used, you must ensure that the user's email address or username never changes.
+
+=== Configuration
+
+To enable automatic user provisioning, the following environment variables must be set for the proxy service:
+
+* `PROXY_AUTOPROVISION_ACCOUNTS` +
+Set to `true` to enable automatic user provisioning.
+* `PROXY_AUTOPROVISION_CLAIM_USERNAME` +
+The name of an OIDC claim whose value should be used as the username for the autoprovsioned user in ownCloud Infinite Scale. Defaults to `preferred_username`. Can also be set to e.g. `sub` to guarantee a unique and stable username.
+* `PROXY_AUTOPROVISION_CLAIM_EMAIL` +
+The name of an OIDC claim whose value should be used for the `mail` attribute of the autoprovisioned user in ownCloud Infinite Scale. Defaults to `email`.
+* `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME` +
+The name of an OIDC claim whose value should be used for the `displayname` attribute of the autoprovisioned user in ownCloud Infinite Scale. Defaults to `name`.
+* `PROXY_AUTOPROVISION_CLAIM_GROUPS` +
+The name of an OIDC claim whose value should be used to maintain a user's group membership. The claim value should contain a list of group names the user should be a member of. Defaults to `groups`.
+* `PROXY_USER_OIDC_CLAIM` +
+When resolving and authenticated OIDC user, the value of this claims is used to lookup the user in the users service. For auto provisioning setups this usually is the same claims as set via `PROXY_AUTOPROVISION_CLAIM_USERNAME`.
+* `PROXY_USER_CS3_CLAIM` +
+This is the name of the user attribute in ocis that is used to lookup the user by the value of the `PROXY_USER_OIDC_CLAIM`. For auto provisioning setups this usually needs to be set to `username`.
+
+=== How it Works
+
+When a user logs into ownCloud Infinite Scale for the first time, the proxy checks if that user already exists. This is done by querying the `users` service for users, where the attribute set in `PROXY_USER_CS3_CLAIM` matches the value of the OIDC claim configured in `PROXY_USER_OIDC_CLAIM`.
+
+If the users does not exist, the proxy will create a new user via the `graph` service using the claim values configured in
+`PROXY_AUTOPROVISION_CLAIM_USERNAME`, `PROXY_AUTOPROVISION_CLAIM_EMAIL` and `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME`.
+
+If the user does already exist, the proxy will check if the user's email or displayname has changed and updates those accordingly via `graph` service.
+
+Next, the proxy will check if the user is a member of the groups configured in `PROXY_AUTOPROVISION_CLAIM_GROUPS`. It will add the user to the groups listed via the OIDC claim that holds the groups defined in the envvar and removes it from
+all other groups that he is currently a member of. Groups that do not exist in the external IDP yet will be created. Note: This can be a somewhat costly operation, especially if the user is a member of a large number of groups. If the group memberships of a user are changed in the IDP after the first login, it can take up to 5 minutes until the changes are reflected in Infinite Scale.
+
 == Automatic Quota Assignments
 
 It is possible to automatically assign a specific quota to new users depending on their role. To do this, you need to configure a mapping between roles defined by their ID and the quota in bytes. The assignment can only be done via a `yaml` configuration and not via environment variables. See the following `proxy.yaml` config snippet for a configuration example.

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -33,7 +33,7 @@ A number of prerequisites must be met for automatic user provisioning to work:
 
 * Infinite Scale must be configured to use an external OpenID Connect IDP.
 * The `graph` service must be configured to allow updating users and groups (`GRAPH_LDAP_SERVER_WRITE_ENABLED`).
-* The IDP must return a unique value in the user's claims (as part of the userinfo response and/or the access tokens) that can be used to identify the user. This claim needs to be stable and cannot be changed for the whole lifetime of the user. That means, if a claim like `email` or `preferred_username` is used, you must ensure that the user's email address or username never changes.
+* One of the claim values returned by the IDP as part of the userinfo response or the access token must be unique and stable for the user. I.e. the value must not change for the whole lifetime of the user. This claim is configured via the `PROXY_USER_OIDC_CLAIM` environment variable (see below). A natural choice would e.g. be the `sub` claim which is guaranteed to be unique and stable per IDP. If a claim like `email` or `preferred_username` is used, you have to ensure that the user's email address or username never changes.
 
 === Configuration
 
@@ -61,7 +61,9 @@ When a user logs into ownCloud Infinite Scale for the first time, the proxy chec
 If the user does not exist, the proxy will create a new user via the `graph` service using the claim values configured in
 `PROXY_AUTOPROVISION_CLAIM_USERNAME`, `PROXY_AUTOPROVISION_CLAIM_EMAIL` and `PROXY_AUTOPROVISION_CLAIM_DISPLAYNAME`.
 
-If the user does already exist, the proxy will check if the user's email or displayname has changed and updates those accordingly via `graph` service.
+If the user does already exist, the proxy checks if the displayname has changed and updates that accordingly via `graph` service.
+
+Unless the claim configured via `PROXY_AUTOPROVISION_CLAIM_EMAIL` is the same as the one set via `PROXY_USER_OIDC_CLAIM` the proxy will also check if the email address has changed and update that as well.
 
 Next, the proxy will check if the user is a member of the groups configured in `PROXY_AUTOPROVISION_CLAIM_GROUPS`. It will add the user to the groups listed via the OIDC claim that holds the groups defined in the envvar and removes it from
 all other groups that he is currently a member of. Groups that do not exist in the external IDP yet will be created. Note: This can be a somewhat costly operation, especially if the user is a member of a large number of groups. If the group memberships of a user are changed in the IDP after the first login, it can take up to 5 minutes until the changes are reflected in Infinite Scale.


### PR DESCRIPTION
Fixes: #888 (Autoprovisioning envvars documentation)

Add a proxy service documentation about `Automatic User and Group Provisioning`

No backport.