### PR TITLE
Add offline CLI commands to maintenence

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/backup-consistency.adoc
+++ b/modules/ROOT/pages/maintenance/commands/backup-consistency.adoc
@@ -1,0 +1,31 @@
+= Backup Consistency
+
+The backup consistency command allows inspecting the consistency of an Infinite Scale storage:
+
+[source,bash]
+----
+ocis backup consistency -p /base/path/storage/users
+----
+
+This will check the consistency of the storage and output a list of inconsistencies. Inconsistencies can be:
+
+* *Orphaned Blobs* +
+A blob in the blobstore that is not referenced by any file metadata.
+* *Missing Blobs* +
+A blob referenced by file metadata that is not present in the blobstore.
+* *Missing Nodes* +
+A node that is referenced by a symlink but doesn't exist.
+* *Missing Link* +
+A node that is not referenced by any symlink but should be.
+* *Missing Files* +
+A node that is missing essential files (such as the `.mpk` metadata file).
+* *Missing/Malformed Metadata* +
+A node that doesn't have any (or malformed) metadata.
+
+This command provides additional options:
+
+* `-b` / `--blobstore` +
+Allows specifying the blobstore to use. Defaults to `ocis`. Empty blobs will not be checked. Can also be switched to `s3ng`, but needs addtional envvar configuration (see the `storage-users` service for more details).
+
+* `--fail` +
+Exits with non-zero exit code if inconsistencies are found. Useful for automation.

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -54,7 +54,7 @@ If you need to reset the admin password from the command line, follow the xref:d
 
 == Online Only Commands
 
-Compared to offline commands that can be issued when Infinite Scale is shut down, online commands must be issued if Infinite Scale and the respective service(es) are running.
+Compared to offline commands that can be issued when Infinite Scale is shut down, online commands must be issued when Infinite Scale and the respective service(es) are running.
 
 === Manage Expired Uploads
 

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -16,45 +16,81 @@
 This could happen if services are developed which are not shipped as part of the single binary.
 ====
 
-== Reset the Admin Password
+== Offline Commands
+
+Compared to online commands that need to be issued during operation of Infinite Scale, offline commands can, and somtimes must only be issued if Infinite Scale is not running.
+
+=== Common Path Parameter
+
+Infinite Scale offers a variety of offline CLI commands to monitor or repair Infinite Scale installations. Many of these commands have a common mandatory parameter: `--basePath` (or `-p`) which needs to point to a storage provider. Example paths are:
+
+----
+.ocis/storage/users          # bare metal deployment
+
+/var/tmp/ocis/storage/users  # docker deployment
+
+...
+----
+
+These paths can vary depending on your Infinite Scale installation.
+
+=== Backup Consistency
+
+Infinite Scale provides a xref:maintenance/commands/backup-consistency.adoc[CLI command] with which you can inspect the consistency of an Infinite Scale storage.
+
+NOTE: This command MUST only be issued when Infinite Scale is offline and no services are running. This command will report false positives when issued during normal operation.
+
+=== Revisions Cleanup
+
+Infinite Scale provides a xref:maintenance/commands/revisions-cleanup.adoc[CLI command] which allows removing revisions of files in the storage.
+
+=== Trash Purge
+
+Infinite Scale provides a xref:maintenance/commands/trash.adoc[CLI command] with which you can remove empty folders from the trashbin.
+
+=== Reset the Admin Password
 
 If you need to reset the admin password from the command line, follow the xref:deployment/general/general-info.adoc#password-reset-for-the-admin-user[Password Reset for the Admin User].
 
-== Manage Expired Uploads
+== Online Only Commands
+
+Compared to offline commands that can be issued when Infinite Scale is shut down, online commands must be issued if Infinite Scale and the respective service(es) are running.
+
+=== Manage Expired Uploads
 
 Compared to unfinished uploads which are handled by the system, managing expired uploads can be a necessity as those files can pile up, blocking storage resources and need to be removed by command regularly. See the xref:{s-path}/storage-users.adoc#manage-unfinished-uploads[Manage Unfinished Uploads] section at the _Storage Users_ service for details.
 
-== Purge Expired Space Trash-Bin Items
+=== Purge Expired Space Trash-Bin Items
 
 This command is about purging old trash-bin items of `project` spaces (spaces that have been created manually) and `personal` spaces. See the xref:{s-path}/storage-users.adoc##purge-expired-space-trash-bin-items[Purge Expired Space Trash-Bin Items] section at the _Storage Users_ service for details.
 
-== Reindex a Space for Search
+=== Reindex a Space for Search
 
 In rare circumstances, it can be necessary to initiate indexing manually for a given space or user. Though the search service handles exception cases automatically, it can happen that the search service was not able to complete indexing due to a dirty shut-down of the service or because of a bug. Re-indexing should *only* be run on explicit request and supervision by ownCloud support. See the xref:{s-path}/search.adoc#manually-trigger-re-indexing-a-space[Manually Trigger Re-Indexing a Space] section at the _Search_ service for details.
 
-== Resume Post-Processing
+=== Resume Post-Processing
 
 If post-processing fails in one step due to an unforeseen error, current uploads will not be retried automatically. A system administrator can instead run a xref:{s-path}/postprocessing.adoc#resume-post-processing[CLI command] to retry the failed upload.
 
-== Inspect and Manipulate Node Metadata
+=== Inspect and Manipulate Node Metadata
 
 Infinite Scale provides a xref:maintenance/commands/node-metadata.adoc[CLI command] with which you can inspect and manipulate node metadata.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
-== Inspect and Repair Node Tree Sizes
+=== Inspect and Repair Node Tree Sizes
 
 Infinite Scale provides a xref:maintenance/commands/node-tree-size.adoc[CLI command] with which you can inspect and repair node tree sizes. This command can be necessary in very rare cases where spaces or files are shown in the Web UI with a size not matching reality. For the repair option Infinite Scale must be shut down.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
-== Roll Back / Roll Forward Decomposedfs Migrations
+=== Roll Back / Roll Forward Decomposedfs Migrations
 
 A xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 
-== Repair and Migrate jsoncs3 Indexes
+=== Repair and Migrate jsoncs3 Indexes
 
 A xref:maintenance/commands/rebuild-jsoncs3-indexes.adoc[CLI command] is provided to repair and migrate jsoncs3 indexes. In rare circumstances the data for shares from the "Shared with others" and "Shared with me" index can be corrupted though no data is lost. When using this command, you can recreate that index and migrate it to a new layout which fixes the issue.
 

--- a/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
+++ b/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
@@ -7,7 +7,7 @@ The revisions command allows removing the revisions of files in the storage.
 ocis revisions purge -p /base/path/storage/users
 ----
 
-It takes the `--resource-id` (or `--r`) parameter which specify the scope of the command:
+It takes the `--resource-id` (or `--r`) parameter which specifies the scope of the command:
 
 * An empty string (default) removes all revisions from all spaces.
 * A spaceID (like `d419032c-65b9-4f4e-b1e4-0c69a946181d\$44b5a63b-540c-4002-a674-0e9c833bbe49`) removes all revisions in that space.

--- a/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
+++ b/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
@@ -1,0 +1,25 @@
+= Revisions Cleanup
+
+The revisions command allows removing the revisions of files in the storage.
+
+[source,bash]
+----
+ocis revisions purge -p /base/path/storage/users
+----
+
+It takes the `--resource-id` (or `--r`) parameter which specify the scope of the command:
+
+* An empty string (default) removes all revisions from all spaces.
+* A spaceID (like `d419032c-65b9-4f4e-b1e4-0c69a946181d\$44b5a63b-540c-4002-a674-0e9c833bbe49`) removes all revisions in that space.
+* A resourceID (e.g. `d419032c-65b9-4f4e-b1e4-0c69a946181d\$44b5a63b-540c-4002-a674-0e9c833bbe49\!e8a73d49-2e00-4322-9f34-9d7f178577b2`) removes all revisions from that specific file.
+
+This command provides additional options:
+
+* `--dry-run` (default: `true`) +
+Do not remove any revisions but print the revisions that would be removed.
+
+* `-b` / `--blobstore` +
+Allows specifying the blobstore to use. Defaults to `ocis`. Can be switched to `s3ng` but needs addtional envvar configuration (see the `storage-users` service for more details).
+
+* `-v` / `--verbose` +
+Prints additional information about the revisions that are removed.

--- a/modules/ROOT/pages/maintenance/commands/trash.adoc
+++ b/modules/ROOT/pages/maintenance/commands/trash.adoc
@@ -1,6 +1,6 @@
 = Revisions Cleanup
 
-The trash cli allows removing empty folders from the trashbin. This should be used to speed up trash bin operations.
+The trash cli command allows removing empty folders from the trashbin. This should be used to speed up trash bin operations.
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/maintenance/commands/trash.adoc
+++ b/modules/ROOT/pages/maintenance/commands/trash.adoc
@@ -1,4 +1,4 @@
-= Revisions Cleanup
+= Trash CLI
 
 The trash cli command allows removing empty folders from the trashbin. This should be used to speed up trash bin operations.
 

--- a/modules/ROOT/pages/maintenance/commands/trash.adoc
+++ b/modules/ROOT/pages/maintenance/commands/trash.adoc
@@ -1,0 +1,13 @@
+= Revisions Cleanup
+
+The trash cli allows removing empty folders from the trashbin. This should be used to speed up trash bin operations.
+
+[source,bash]
+----
+ocis trash purge-empty-dirs -p /base/path/storage/users
+----
+
+This command provides additional options:
+
+* `--dry-run` (default: `true`) +
+Do not remove any empty folders but print the empty folders that would be removed.


### PR DESCRIPTION
Fixes: #887 (Purge-Revision CLI)

* Make the maintenance page devided into `offline` and `online` command sections.
* Add storage path explanation
* Add 3 CLI commands
* Move the reset pwd command into the offline section

No backport!