### PR TITLE
Add Auth-App service

### DIFF
--- a/modules/ROOT/pages/deployment/services/ports-used.adoc
+++ b/modules/ROOT/pages/deployment/services/ports-used.adoc
@@ -53,7 +53,7 @@ The following port ranges are used by services:
 | 9230-9234  | xref:{s-path}/nats.adoc[nats]
 | 9235-9239  | xref:{s-path}/idm.adoc[idm]
 | 9240-9244  | xref:{s-path}/app-registry.adoc[app-registry]
-| 9245-9249  | FREE
+| 9245-9249  | xref:{s-path}/auth-app.adoc[auth-app]
 | 9250-9254  | https://github.com/owncloud/ocis/tree/master/ocis/pkg/runtime[ocis server (runtime)]
 | 9255-9259  | xref:{s-path}/postprocessing.adoc[postprocessing]
 | 9260-9264  | xref:{s-path}/clientlog.adoc[clientlog]

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -1,0 +1,44 @@
+= Auth App Service Configuration
+:toc: right
+
+:service_name: auth-app
+
+:description: The Infinite Scale Auth App service provides authentication for 3rd party apps.
+
+== Introduction
+
+{description}
+
+With the `auth-app` service, you can create tokens that can be used to authenticate 3rd party apps accessing Infinite Scale.
+
+== Default Values
+
+* Auth Basic listens on port 9245 by default.
+
+include::partial$deployment/services/auth-service-family.adoc[]
+
+== Service Startup
+
+Because this service is not started automatically, a manual start needs to be initiated which can be done in several ways. To configure the service usage, an environment variable for the proxy service needs to be set to allow app authentication.
+
+[source,bash]
+----
+OCIS_ADD_RUN_SERVICES=auth-app  # deployment specific. Add the service to the manual startup list, use with binary deployments. Alternatively you can start the service explicitly via the command line.
+
+PROXY_ENABLE_APP_AUTH=true      # mandatory, allow app authentication. In case of a distributed environment, this envvar needs to be set in the the proxy service.
+----
+
+== App Tokens
+
+App Tokens are used to authenticate 3rd party access via https like when using curl (apps) to access an API endpoint. These apps need to authenticate themselve, as no logged in user authenticates the request. To be able to use an app token, one must first create a token via the cli. Replace the `user-name` with an existing Infinite Scale user. For the `token-expiration`, you can use any time abbreviation from the following list: `h, m, s`. Examples: `72h` or `1h` or `1m` or `1s.` Default is `72h`.
+
+[source,bash]
+----
+ocis auth-app create --user-name={user-name} --expiration={token-expiration}
+----
+
+Once generated, these tokens can be used to authenticate requests to ocis. They are passed as part of the request as `Basic Auth` header.
+
+== Configuration
+
+include::partial$deployment/services/env-and-yaml.adoc[tag=envvars-yaml]

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -25,12 +25,12 @@ Because this service is not started automatically, a manual start needs to be in
 ----
 OCIS_ADD_RUN_SERVICES=auth-app  # deployment specific. Add the service to the manual startup list, use with binary deployments. Alternatively you can start the service explicitly via the command line.
 
-PROXY_ENABLE_APP_AUTH=true      # mandatory, allow app authentication. In case of a distributed environment, this envvar needs to be set in the the proxy service.
+PROXY_ENABLE_APP_AUTH=true      # mandatory, allow app authentication. In case of a distributed environment, this envvar needs to be set in the proxy service.
 ----
 
 == App Tokens
 
-App Tokens are used to authenticate 3rd party access via https like when using curl (apps) to access an API endpoint. These apps need to authenticate themselve, as no logged in user authenticates the request. To be able to use an app token, one must first create a token via the cli. Replace the `user-name` with an existing Infinite Scale user. For the `token-expiration`, you can use any time abbreviation from the following list: `h, m, s`. Examples: `72h` or `1h` or `1m` or `1s.` Default is `72h`.
+App Tokens are used to authenticate 3rd party access via https like when using curl (apps) to access an API endpoint. These apps need to authenticate themselves, as no logged in user authenticates the request. To be able to use an app token, one must first create a token via the cli. Replace the `user-name` with an existing Infinite Scale user. For the `token-expiration`, you can use any time abbreviation from the following list: `h, m, s`. Examples: `72h` or `1h` or `1m` or `1s.` Default is `72h`.
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -21,7 +21,8 @@ include::partial$deployment/services/auth-service-family.adoc[]
 
 == Service Startup
 
-Because this service is not started automatically, a manual start needs to be initiated which can be done in several ways. To configure the service usage, an environment variable for the proxy service needs to be set to allow app authentication.
+* Because this service is not started automatically, a manual start needs to be initiated which can be done in several ways, only one example is shown below. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+* To configure the service usage, an environment variable for the proxy service needs to be set to allow app authentication.
 
 [source,bash]
 ----

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -11,6 +11,8 @@
 
 With the `auth-app` service, you can create tokens that can be used to authenticate 3rd party apps accessing Infinite Scale.
 
+To enable `{service_name}`, you first must set `PROXY_ENABLE_APP_AUTH` to `true`.
+
 == Default Values
 
 * Auth Basic listens on port 9245 by default.

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -26,7 +26,7 @@ include::partial$deployment/services/auth-service-family.adoc[]
 
 [source,bash]
 ----
-OCIS_ADD_RUN_SERVICES=auth-app  # deployment specific. Add the service to the manual startup list, use with binary deployments. Alternatively you can start the service explicitly via the command line.
+OCIS_ADD_RUN_SERVICES=auth-app  # deployment specific. Alternatively you can start the service explicitly via the command line.
 
 PROXY_ENABLE_APP_AUTH=true      # mandatory, allow app authentication. In case of a distributed environment, this envvar needs to be set in the proxy service.
 ----

--- a/modules/ROOT/pages/deployment/services/services.adoc
+++ b/modules/ROOT/pages/deployment/services/services.adoc
@@ -25,6 +25,9 @@ The following services have been introduced with the releases listed:
 | Service
 | Description
 
+| xref:{s-path}/auth-app.adoc[Auth-App]
+| The Auth-App provides authentication for 3rd party apps.
+
 | xref:{s-path}/activitylog.adoc[Activitylog]
 | The Activitylog service is responsible for storing events (activities) per resource.
 

--- a/modules/ROOT/partials/deployment/services/auth-service-family.adoc
+++ b/modules/ROOT/partials/deployment/services/auth-service-family.adoc
@@ -7,6 +7,9 @@ Infinite Scale uses several authentication services for different use cases. All
 [width=80%,cols="20%,80%",options="header"]
 |====
 2+^| As of now, these `auth` services exist
+| xref:{s-path}/auth-app.adoc[auth-app]
+| Handles *3rd party app* authentication.
+
 | xref:{s-path}/auth-basic.adoc[auth-basic]
 | Handles *basic* authentication.
 

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -34,6 +34,7 @@
 **** xref:deployment/services/s-list/app-provider.adoc[App Provider]
 **** xref:deployment/services/s-list/app-registry.adoc[App Registry]
 **** xref:deployment/services/s-list/audit.adoc[Audit]
+**** xref:deployment/services/s-list/auth-app.adoc[Auth App]
 **** xref:deployment/services/s-list/auth-basic.adoc[Auth Basic]
 **** xref:deployment/services/s-list/auth-bearer.adoc[Auth Bearer]
 **** xref:deployment/services/s-list/auth-machine.adoc[Auth Machine]


### PR DESCRIPTION
Fixes: #913 (New service: auth-app)

The `Auth-App` service is added with this PR.

**Note**: Merge when the auth-app service has been merged in ocis.

No Backport.
