### PR TITLE
Add --all-spaces to search command

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/search.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/search.adoc
@@ -81,7 +81,6 @@ The search service consists of two main parts which are file `indexing` and file
 
 Every time a resource changes its state, a corresponding event is triggered. Based on the event, the search service processes the file and adds the result to its index. There are a few more steps between accepting the file and updating the index.
 
-// we need to use searching as the word search seems to be rendered to a button due to a customizing ages ago.
 === Searching
 
 A query via the search service will return results based on the index created.
@@ -134,16 +133,19 @@ This case only triggers indexing if `async post processing` is disabled. If so, 
 
 This is exactly the same as xref:file-uploaded-synchronous[File uploaded - synchronous] with the only difference that it is used for asynchronous uploads.
 
-== Manually Trigger Re-Indexing a Space
+== Manually Trigger Re-Indexing Spaces
 
-The service includes a command-line interface to trigger re-indexing a space:
+The service includes a command-line interface to trigger re-indexing spaces:
 
 [source,bash]
 ----
-ocis search index --space $SPACE_ID --user $USER_ID
+ocis search index --space $SPACE_ID --all-spaces --user $USER_ID
 ----
 
-Note that not names but IDs are necessary and that the specified user ID needs access to the space to be indexed.
+* IDs but not names are necessary as parameter.
+** See the xref:maintenance/space-ids/space-ids.adoc[Listing Space IDs] for how to retrieve a space ID.
+** The specified user ID needs to have access to the space to be indexed.
+* The arguments `-space` and `--all-spaces` are mutual exclusive , but one must be provided.
 
 == Notes
 

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -64,9 +64,9 @@ Compared to unfinished uploads which are handled by the system, managing expired
 
 This command is about purging old trash-bin items of `project` spaces (spaces that have been created manually) and `personal` spaces. See the xref:{s-path}/storage-users.adoc##purge-expired-space-trash-bin-items[Purge Expired Space Trash-Bin Items] section at the _Storage Users_ service for details.
 
-=== Reindex a Space for Search
+=== Reindex Spaces for Search
 
-In rare circumstances, it can be necessary to initiate indexing manually for a given space or user. Though the search service handles exception cases automatically, it can happen that the search service was not able to complete indexing due to a dirty shut-down of the service or because of a bug. Re-indexing should *only* be run on explicit request and supervision by ownCloud support. See the xref:{s-path}/search.adoc#manually-trigger-re-indexing-a-space[Manually Trigger Re-Indexing a Space] section at the _Search_ service for details.
+In rare circumstances, it can be necessary to initiate indexing manually for a given space a user has access to or all spaces. Though the search service handles exception cases automatically, it can happen that the search service was not able to complete indexing due to a dirty shut-down of the service or because of a bug. Re-indexing should *only* be run on explicit request and supervision by ownCloud support. See the xref:{s-path}/search.adoc#manually-trigger-re-indexing-spaces[Manually Trigger Re-Indexing Spaces] section at the _Search_ service for details.
 
 === Resume Post-Processing
 

--- a/modules/ROOT/pages/maintenance/space-ids/space-ids.adoc
+++ b/modules/ROOT/pages/maintenance/space-ids/space-ids.adoc
@@ -4,7 +4,7 @@
 
 == Introduction
 
-{description} As an example of a use case, see the xref:deployment/services/s-list/storage-users.adoc#manage-trash-bin-items[Manage Trash-Bin Items] command set.
+{description} As an example of a use case, see the xref:deployment/services/s-list/storage-users.adoc#manage-trash-bin-items[Manage Trash-Bin Items] command set or the xref:{s-path}/search.adoc#manually-trigger-re-indexing-spaces[Manually Trigger Re-Indexing Spaces].
 
 Space IDs can currently not be listed by the administrator via the WebUI. They can only be listed via the shell using an authenticated curl GET command accessing the Infinite Scale https://owncloud.dev/apis/[API].
 


### PR DESCRIPTION
Fixes: #878 (Allow reindexing all spaces)

Add a new argument to the reindex search command.

No backport.