### PR TITLE
Fix missing special envvars

### DIFF
--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -210,7 +210,7 @@ See the respective shell documentation for how to manage processes respectively 
 
 Infinite Scale can be configured via environment variables, see the following sections for more information and details:
 
-* xref:deployment/general/general-info.adoc#starting-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables]
+* xref:deployment/general/general-info.adoc#start-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables]
 * xref:deployment/general/general-info.adoc#configurations-to-access-the-web-ui[Configurations to Access the Web UI]
 
 NOTE: You cannot instantiate runtime services though you can define which services should start or be excluded from starting. See xref:deployment/general/general-info.adoc#managing-services[Managing Services] for more details.

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -12,7 +12,7 @@ IMPORTANT: We highly recommend reading this document first before you start sett
 
 The example commands shown need to be adjusted depending on whether you are using the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment] or a xref:deployment/container/container-setup.adoc[Container Setup].
 
-When using global options on startup, you can always use command line options or environment variables. Run `ocis help` and see xref:starting-infinite-scale-with-environment-variables[] for details.
+When using global options on startup, you can always use command line options or environment variables. Run `ocis help` and see xref:start-infinite-scale-with-environment-variables[] for details.
 
 == Embedded Supervisor (Runtime)
 
@@ -308,9 +308,11 @@ IMPORTANT: The command line option `--force-overwrite` is only intended for deve
 
 To reinitialize Infinite Scale, you have to delete your config and your data and start from scratch.
 
-== Start Infinite Scale With All Predefined Services
+== Start Infinite Scale
 
-When you type `ocis server`, the embedded supervisor is automatically used and starts available predefined services automatically. The supervisor starts by default on port 9250 and listens for commands regarding the lifecycle of the supervised services.
+=== Start Infinite Scale With All Predefined Services
+
+When you type `ocis server`, the embedded supervisor is automatically used and the runtime starts available predefined services automatically. The supervisor starts by default on port 9250 and listens for commands regarding the lifecycle of the supervised services.
 
 To list the started predefined services, type:
 
@@ -319,7 +321,7 @@ To list the started predefined services, type:
 ocis list
 ----
 
-This will print an output like:
+This will print an output like the following (subject of change):
 
 [source,plaintext]
 ----
@@ -363,11 +365,7 @@ This will print an output like:
 +--------------------+
 ----
 
-== Start Infinite Scale With Defined Services
-
-Infinite Scale can be started with a defined set of services which can deviate from the default list. To do so, environment variables can be set as described below. The environment variables relevant to define which services will be started are described in the xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[Special Environment Variables].
-
-== Starting Infinite Scale With Environment Variables
+=== Start Infinite Scale With Environment Variables
 
 You can use environment variables to define or overwrite config parameters which will be used when starting Infinite Scale like:
 
@@ -384,6 +382,99 @@ PROXY_HTTP_ADDR=0.0.0.0:5555 \
 PROXY_DEBUG_ADDR=0.0.0.0:6666 \
 ocis server
 ----
+
+=== Start Infinite Scale With Defined Services
+
+Infinite Scale can be started with a defined set of services which can deviate from the default list. To do so, environment variables can be set as described above. The environment variables relevant to define which services will be started are described in the xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[Special Environment Variables].
+
+When a runtime has already been started either with a service that is not automatically started or with an explicitly excluded service and you want to start that service manually, you can achieve this the following ways, the search service selected is just an example:
+
+Use multiple runtimes::
+This method is beneficial if you want to start multiple services managed by a supervisor.
++
+--
+.First we start the runtime but exclude the search service.
+[source,bash]
+----
+OCIS_EXCLUDE_RUN_SERVICES="search" \
+ocis server &
+----
+
+.Then we start the runtime with defined services (multiple servcies can be added separated by comma).
+[source,bash]
+----
+OCIS_RUN_SERVICES="search" \
+OCIS_RUNTIME_PORT=9251 \
+ocis server &
+----
+
+Note as defined in the example above, when starting the runtime multiple times, you _must_ specify a new port for the runtime to not conflict with already running ones.
+
+Now, when listing the services started, you only get them listed per runtime which requires the port to be added if that differs from the default.
+
+.List running services from the runtime using the default port.
+[source,bash]
+----
+ocis list
+----
+
+Output as in the list example above.
+
+.List running services from a defined runtime.
+[source,bash]
+----
+OCIS_RUNTIME_PORT=9251 \
+ocis list
+----
+
+[source,plaintext]
+----
++---------------+
+|    SERVICE    |
++---------------+
+| search        |
++---------------+
+----
+--
+
+{empty}
+
+Use a single runtime::
+This method is beneficial if you want to start services managed by a supervisor and add individual independent started services not covered by a supervisor.
++
+--
+.First we start the runtime but exclude the search service.
+[source,bash]
+----
+OCIS_EXCLUDE_RUN_SERVICES="search" \
+ocis server &
+----
+
+.Then we start the formerly excluded search service individually and not covered by a supervisor.
+[source,bash]
+----
+ocis search server &
+----
+
+Notes:
+
+* Only one service can be started per command at a time.
+* Use `ocis list` to list started services of the runtime.
+* You _cant_ use `ocis list` to list any individually started service. This is only possible using the `ps` command (shortened):
++
+.Print running ocis instances.
+[source,bash]
+----
+ps ax | grep ocis
+----
++
+.Output example
+[source,bash]
+----
+ocis server
+ocis search server
+----
+--
 
 === Globally Shared Logging Values
 

--- a/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
+++ b/modules/ROOT/pages/deployment/services/env-vars-special-scope.adoc
@@ -19,7 +19,7 @@ Examples:
 // their source is in: https://github.com/owncloud/ocis/blob/master/ocis-pkg/config/config.go
 // at 'type Runtime struct'
 
-The following environment variables are only available when using a binary deployment. For an example see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
+The following environment variables are only available when using a binary deployment. For additional information read the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] documentation. Read the xref:deployment/services/envvar-types-description.adoc[Environment Variable Types] documentation for important details.
 
 include::partial$deployment/services/env-and-yaml.adoc[tag=special_envvars]
 

--- a/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
+++ b/modules/ROOT/partials/deployment/services/env-and-yaml.adoc
@@ -41,6 +41,12 @@ include::partial$multi-location/tab-text.adoc[]
 
 | `OCIS_ADD_RUN_SERVICES`
 | A comma-separated list of service names. Will add the listed services to the default configuration. Has no effect when `OCIS_RUN_SERVICES` is set. Note that one can add services not started by the default list and exclude services from the default list by using both envvars at the same time.
+
+| `OCIS_RUNTIME_PORT`
+| The port where the runtime will start. Defaults to 9250. Only necessary when multiple runtimes are started in parallel. Each runtime must have its own port exclusively.
+
+| `OCIS_RUNTIME_HOST`
+| The hostname the runtime will listen to. Defaults to `localhost`.
 |===
 
 Note to get the current list of services started by default, you need to run `ocis server` without restriction which services to start and run afterwards `ocis list`.

--- a/modules/ROOT/partials/multi-location/idm-https-reverse-proxy.adoc
+++ b/modules/ROOT/partials/multi-location/idm-https-reverse-proxy.adoc
@@ -7,7 +7,7 @@ If you want to reuse an already configured _minimized_ setup for any _other_ add
 * When accessing the server using the hostname or IP:
 ** You *must* start Infinite Scale using the environment variable `OCIS_URL=<hostname or IP>`. +
 See the following sections for more details and information:
-*** xref:deployment/general/general-info.adoc#starting-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables] and 
+*** xref:deployment/general/general-info.adoc#start-infinite-scale-with-environment-variables[Starting Infinite Scale With Environment Variables] and 
 *** xref:deployment/general/general-info.adoc#configurations-to-access-the-web-ui[Configurations to Access the Web UI].
 
 * When accessing the server using a dedicated domain name:


### PR DESCRIPTION
Two special envvars `OCIS_RUNTIME_PORT` and `OCIS_RUNTIME_HOST` were missing in the docs + description.

Backport to 5.0