### PR TITLE
No autostart for notification service

### DIFF
--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -342,7 +342,6 @@ This will print an output like the following (subject of change):
 | idm                |
 | idp                |
 | nats               |
-| notifications      |
 | ocdav              |
 | ocm                |
 | ocs                |

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -9,6 +9,8 @@
 
 {description} To do this, it hooks into the event system and listens for certain events that the users need to be informed about. As an example, when a user is added to a share, a notification email will be sent to the user.
 
+Note that the {service_name} service does not start automatically when using the binary deployment. The service must be started manually. For details how to do so see the xref:deployment/general/general-info.adoc#start-infinite-scale-with-defined-services[Start Infinite Scale With Defined Services].
+
 == Default Values
 
 * Notifications listens on port 9170 by default.

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -9,7 +9,7 @@
 
 {description} To do this, it hooks into the event system and listens for certain events that the users need to be informed about. As an example, when a user is added to a share, a notification email will be sent to the user.
 
-Note that the {service_name} service does not start automatically when using the binary deployment. The service must be started manually. For details how to do so see the xref:deployment/general/general-info.adoc#start-infinite-scale-with-defined-services[Start Infinite Scale With Defined Services].
+Note that the {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
 
 == Default Values
 


### PR DESCRIPTION
Fixes: #883 (Update the Notifications service doc)

Add a note that the notifications service will not start automatically anymore and must be started manually.

No backport.
