### PR TITLE
Update ocis.init (prepare for --diff)

### DIFF
--- a/modules/ROOT/pages/deployment/general/ocis-init.adoc
+++ b/modules/ROOT/pages/deployment/general/ocis-init.adoc
@@ -10,9 +10,9 @@
 
 In general, the xref:deployment/general/general-info.adoc#initialize-infinite-scale[ocis init] command initializes ocis _for the first run_ and creates an `ocis.yaml` configuration file. See xref:deployment/general/general-info.adoc#configuration-rules[Configuration Rules] for the file location. This command is helpful if you do not provide the necessary settings manually, but some rules apply.
 
-=== Minimal Bare Metal Deployment
+=== Binary Deployment
 
-When using the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment], the command *is recommended* to be run manually once before first usage, though you can also fully configure the initial setup manually.
+When using the a binary deployment like described in the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment], the command *is recommended* to be run manually once before first usage, though you can also fully configure the initial setup manually.
 
 * The following command line parameters or their equivalent environment variables can be defined to configure the `ocis init` command. When using environment variables the following structure is used; multiple variables are allowed:
 +
@@ -20,7 +20,7 @@ When using the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Dep
 ----
 <variable1>=<value1> \
 <variable2>=<value2> \
-...
+... \
 ocis init
 ----
 
@@ -54,13 +54,26 @@ WARNING: When setting this environment variable, the existing configuration will
 
 === Container Setup
 
-When using the xref:deployment/container/container-setup.adoc[Container Setup], the command *runs automatically* when starting the container and no configuration file can be found. It skips the initialization step if an `ocis.yaml` config file was found.
+When deploying via `docker run` as described in xref:deployment/container/container-setup.adoc[Container Setup], initialisation needs to be triggerd once before the first full start. See the referenced page how to do so.
 
 === Container Orchestration
  
-When using xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] like with Docker Compose or Kubernetes with Helm Charts, the `ocis init` command *MUST NOT* be used and all configuration parameters must be handed over either via environment variables and/or via the Helm Chart / yaml files. Use the provided Helm Charts as your configuration base and adjust for Docker Compose as needed.
+==== Docker Compose
 
-== When Not to Use
+When deploying via `docker compose` as described in xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration], you will find in the examples provided the following command:
+
+[source,bash]
+----
+command: ["-c", "ocis init || true; ocis server"]
+----
+
+When executed, this command will run `ocis init`, but skips initialisation if there is a configuration found. In case it is not found, `ocis.yaml` will be created and any output of the initialisation will get logged.
+
+==== Kubernetes
+
+When deploying via Kuberentes and Helm Charts as described in xref:deployment/container/orchestration/orchestration.adoc[Container Orchestration] you can run the `ocis init` command once to get the minimum configuration parameters, but any configuration must be handed over either via environment variables and/or via the Helm Chart / yaml files! Use the provided Helm Charts as your configuration base and adjust as needed.
+
+== Command Notes
 
 Whenever there is a change in the existing configuration, independent of whether `ocis init` was run before, `ocis init` will:
 
@@ -68,8 +81,12 @@ Whenever there is a change in the existing configuration, independent of whether
 * *not update* any existing configuration.
 * overwrite an existing configuration when using the `--force-overwrite` command option - *which is intended for development purposes only*. For a brief overview see the   xref:deployment/general/general-info.adoc#initialize-infinite-scale[ocis init] description in the General Information documentation.
 
-== How to Apply Changes
+== How to Apply Manual Changes
 
-* If changes are necessary *after* running `ocis init`, these changes must be applied via environment variables and/or yaml files to take effect.
+If changes are necessary *after* running `ocis init`, these changes can be applied in differernt ways:
 
-* To see which configurations are available, see the xref:deployment/services/services.adoc[services] descriptions.
+* Adding changes in `ocis.yaml`.
+* Providing changes via environment variables.
+* Providing changes via yaml files.
+
+In any case, after changes have been applied, Infinite Scale bust be restartet to make changes effective.

--- a/modules/ROOT/pages/deployment/general/ocis-init.adoc
+++ b/modules/ROOT/pages/deployment/general/ocis-init.adoc
@@ -54,7 +54,7 @@ WARNING: When setting this environment variable, the existing configuration will
 
 === Container Setup
 
-When deploying via `docker run` as described in xref:deployment/container/container-setup.adoc[Container Setup], initialisation needs to be triggerd once before the first full start. See the referenced page how to do so.
+When deploying via `docker run` as described in xref:deployment/container/container-setup.adoc[Container Setup], initialisation needs to be triggered once before the first full start. See the referenced page how to do so.
 
 === Container Orchestration
  
@@ -83,10 +83,10 @@ Whenever there is a change in the existing configuration, independent of whether
 
 == How to Apply Manual Changes
 
-If changes are necessary *after* running `ocis init`, these changes can be applied in differernt ways:
+If changes are necessary *after* running `ocis init`, these changes can be applied in different ways:
 
 * Adding changes in `ocis.yaml`.
 * Providing changes via environment variables.
 * Providing changes via yaml files.
 
-In any case, after changes have been applied, Infinite Scale bust be restartet to make changes effective.
+In any case, after changes have been applied, Infinite Scale bust be restarted to make changes effective.


### PR DESCRIPTION
This is a preparation for the next PR which will implement `--diff`.

Backport to 5.0