### PR TITLE
Add the ocis init --diff command argument

### DIFF
--- a/modules/ROOT/pages/deployment/general/ocis-init.adoc
+++ b/modules/ROOT/pages/deployment/general/ocis-init.adoc
@@ -93,7 +93,7 @@ In any case, after changes have been applied, Infinite Scale bust be restarted t
 
 == Diff Mode
 
-`ocis init` provides an a additinal argument whith which you can generate a patchable diff file. The `--diff` argument can be used when you update to a new Infinite Scale version and want to see which changes to mandatory settings have appeared. Using the diff argument is safe, as the command never changes any settings.
+`ocis init` provides an a additional argument with which you can generate a patchable diff file. The `--diff` argument can be used when you update to a new Infinite Scale version and want to see which changes to mandatory settings have appeared. Using the diff argument is safe, as the command never changes any settings.
 
 The diff is stored in the xref:deployment/general/general-info.adoc#default-paths[config folder] as `ocis.config.patch` file and can either be applied to `ocis.yaml` using the linux `patch` command or you can apply the changes manually.
 
@@ -103,7 +103,7 @@ The diff is stored in the xref:deployment/general/general-info.adoc#default-path
 ocis init --diff
 ----
 
-.Example diff file like when upgrading from 5 (production) to 6 (rolling)
+.Example diff file when upgrading from 5 (production) to 6 (rolling)
 [source,diff]
 ----
 --- /home/user_1/.ocis/config/ocis.yaml        2024-08-02 12:31:45.892704129 +0200

--- a/modules/ROOT/pages/deployment/general/ocis-init.adoc
+++ b/modules/ROOT/pages/deployment/general/ocis-init.adoc
@@ -90,3 +90,42 @@ If changes are necessary *after* running `ocis init`, these changes can be appli
 * Providing changes via yaml files.
 
 In any case, after changes have been applied, Infinite Scale bust be restarted to make changes effective.
+
+== Diff Mode
+
+`ocis init` provides an a additinal argument whith which you can generate a patchable diff file. The `--diff` argument can be used when you update to a new Infinite Scale version and want to see which changes to mandatory settings have appeared. Using the diff argument is safe, as the command never changes any settings.
+
+The diff is stored in the xref:deployment/general/general-info.adoc#default-paths[config folder] as `ocis.config.patch` file and can either be applied to `ocis.yaml` using the linux `patch` command or you can apply the changes manually.
+
+.Example diff command
+[source,bash]
+----
+ocis init --diff
+----
+
+.Example diff file like when upgrading from 5 (production) to 6 (rolling)
+[source,diff]
+----
+--- /home/user_1/.ocis/config/ocis.yaml        2024-08-02 12:31:45.892704129 +0200
++++ /home/user_1/.ocis/config/ocis.yaml.tmp    2024-08-02 12:34:07.881151244 +0200
+@@ -27,6 +27,11 @@
+     idm_password: W&U!5HMYKe^Kjb@bZQ9hK1+IQ*3C.eZ0
+     reva_password: .5RpDorc*5L$kox#J-0PL@h^H+6V=Ezv
+     idp_password: eGP$Of5C7$#%^ikG6K8p%LO9arNRnHEA
++collaboration:
++  wopi:
++    secret: ""
++  app:
++    insecure: true
+ proxy:
+   oidc:
+     insecure: true
+@@ -116,3 +121,7 @@
+   service_account:
+     service_account_id: 433d9b85-6a54-4ef0-87ff-b1c419eedcb8
+     service_account_secret: 9&SO@a$t%G7wHup^QtQ^qXDqfDzo7TM&
++activitylog:
++  service_account:
++    service_account_id: 433d9b85-6a54-4ef0-87ff-b1c419eedcb8
++    service_account_secret: 9&SO@a$t%G7wHup^QtQ^qXDqfDzo7TM&
+----

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -15,6 +15,8 @@ IMPORTANT: If not explicitly mentioned, any upgrade is forward only and a backst
 
 IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrade steps from each release must be taken in order and none can be skipped.  
 
+IMPORTANT: When upgrading from an older release to the desired one, mandatory configuration settings may have been added or removed. To see the changes required, you can run `ocis init --diff` after upgrading but before finally starting. For more details, see the xref:deployment/general/ocis-init.adoc[ocis init command] description.
+
 == Version 4.0.0 to 5.0.0
 
 === Notable Changes Requiring Manual Intervention


### PR DESCRIPTION
Fixes: #935 (Add a --diff mode to ocis init)

The --diff argument has been added in ocis master.

* Add a description in `ocis init`
* Add a note in the upgrade guide

NO backport !