### PR TITLE
Add custom roles in the settings service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -67,9 +67,9 @@ The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` ser
 
 == Custom Roles
 
-It is possible to _replace_ the default Infinite Scale roles (`admin`, `user`) with custom roles that contain custom permissions. One can set `SETTINGS_BUNDLES_PATH` to the path of a `json` file containing the new roles.
+It is possible to *replace* the default Infinite Scale roles (`admin`, `user`) with custom roles that contain custom permissions. One can set `SETTINGS_BUNDLES_PATH` to the path of a `json` file containing the new role definition.
 
-.Role Example:
+.Role Example (shortned):
 [source,json]
 ----
 [
@@ -93,7 +93,7 @@ To create custom roles:
 * Copy the role example to a `json` file.
 * Change `id`, `name`, and `displayName` according your requirements.
 * Copy the desired permissions from the `user-all-permissions` example to the `settings` array of the role.
-* Set the `SETTINGS_BUNDLE_PATH` environment variable to the path/json-file and start Infinite Scale.
+* Set the `SETTINGS_BUNDLE_PATH` environment variable to the path/json-file and (re)start Infinite Scale.
 
 See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] json example in the developer documentation for more details.
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -92,10 +92,10 @@ To create custom roles:
 
 * Copy the role example to a `json` file.
 * Change `id`, `name`, and `displayName` according your requirements.
-* Copy the desired permissions from the `user-all-permissions` example to the `settings` array of the role.
-* Set the `SETTINGS_BUNDLE_PATH` environment variable to the path/json-file and start Infinite Scale.
+* Copy the desired permissions from the `user-all-permissions` example below to the `settings` array of the role.
+* Set the `SETTINGS_BUNDLE_PATH` envvar to the path of the json file and start Infinite Scale.
 
-See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] json example in the developer documentation for more details.
+See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] example in the developer documentation for more details.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -92,10 +92,10 @@ To create custom roles:
 
 * Copy the role example to a `json` file.
 * Change `id`, `name`, and `displayName` according your requirements.
-* Copy the desired permissions from the `user-all-permissions` example below to the `settings` array of the role.
-* Set the `SETTINGS_BUNDLE_PATH` envvar to the path of the json file and start Infinite Scale.
+* Copy the desired permissions from the `user-all-permissions` example to the `settings` array of the role.
+* Set the `SETTINGS_BUNDLE_PATH` environment variable to the path/json-file and start Infinite Scale.
 
-See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] example in the developer documentation for more details.
+See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] json example in the developer documentation for more details.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -65,6 +65,38 @@ The `OCIS_DEFAULT_LANGUAGE` setting impacts the `notification` and `userlog` ser
 ** The `notification` and `userlog` services and the Web UI use `OCIS_DEFAULT_LANGUAGE` by default, until a user sets another language in the Web UI via menu:Account[Language].
 ** If a user sets another language in the Web UI in menu:Account[Language], the `notification` and `userlog` services and Web UI use the language defined by the user. If no translation is found, it falls back to `OCIS_DEFAULT_LANGUAGE` and then to English.
 
+== Custom Roles
+
+It is possible to _replace_ the default Infinite Scale roles (`admin`, `user`) with custom roles that contain custom permissions. One can set `SETTINGS_BUNDLES_PATH` to the path of a `json` file containing the new roles.
+
+.Role Example:
+[source,json]
+----
+[
+    {
+        "id": "38071a68-456a-4553-846a-fa67bf5596cc", // ID of the role. Recommendation is to use a random uuidv4. But any unique string will do.
+        "name": "user-light",                         // Internal name of the role. This is used by the system to identify the role. Any string will do here, but it should be unique among the other roles.
+        "type": "TYPE_ROLE",                          // Always use `TYPE_ROLE`
+        "extension": "ocis-roles",                    // Always use `ocis-roles`
+        "displayName": "User Light",                  // DisplayName of the role used in webui
+        "settings": [
+        ],                                            // Permissions attached to the role. See Details below.
+        "resource": {
+            "type": "TYPE_SYSTEM"                     // Always use `TYPE_SYSTEM`
+        }
+    }
+]
+----
+
+To create custom roles:
+
+* Copy the role example to a `json` file.
+* Change `id`, `name`, and `displayName` according your requirements.
+* Copy the desired permissions from the `user-all-permissions` example below to the `settings` array of the role.
+* Set the `SETTINGS_BUNDLE_PATH` envvar to the path of the json file and start Infinite Scale.
+
+See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] example in the developer documentation for more details.
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[tag=envvars-yaml]


### PR DESCRIPTION
Fixes: #852 (Add custom roles (settings service))

Add the custom roles description sourced from the ocis repo.
The full example is not added but linked to the dev docs.

No backport.