### PR TITLE
[5.0] Selective backport: confingurable volumes in deployment example

### DIFF
--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc
@@ -35,7 +35,7 @@ This guide describes an installation of Infinite Scale on the Hetzner Cloud usin
 ====
 * Disk space +
 About 2.8GB of disk space is needed as you not only get Infinite Scale but also office packages for online collaboration and other required software to run this setup.
-** Depending on Hetzner's offers, an embedded diskspace of 40GB is included as part of the server. When the server is reset, the diskspace and ALL of its data is lost. Consider configuring independent volumes which can be sized according your needs but are at an extra monthly charge. Note that you can start with embedded disk space and reconfigure afterwards. Any migration of data from embedded disk space to a volume is *not covered* here.
+** Depending on Hetzner's offers, an embedded diskspace of 40GB is included as part of the server. When the server is reset, the diskspace and ALL of its data is lost. Consider configuring independent volumes which can be sized according your needs but are at an extra monthly charge. Note that you can start with embedded disk space and reconfigure afterwards.
 
 * Memory +
 We recommend at minimum 4-6GB of memory. 
@@ -82,11 +82,5 @@ For the OS, *Ubuntu LTS 24.04* has been selected.
 
 include::partial$depl-examples/ubuntu-compose/shared-setup.adoc[tags=shared_1;hetzner_only_1;shared_2]
 // tags=shared_1;shared_2
-
-== Updating
-
-Note that this deploymment can only be updated within Infinite Scale v5.
-
-If a new Infinite Scale v5 version is available, just down the compose environment and bring it back up. Containers will update automatically and you can continue using Infinite Scale as usual.
 
 {empty} +

--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
@@ -89,10 +89,4 @@ Note that this guide expects:
 include::partial$depl-examples/ubuntu-compose/shared-setup.adoc[tags=shared_1;shared_2]
 // tags=shared_1;hetzner_only_1;shared_2
 
-== Updating
-
-Note that this deploymment can only be updated within Infinite Scale v5.
-
-If a new Infinite Scale v5 version is available, just down the compose environment and bring it back up. Containers will update automatically and you can continue using Infinite Scale as usual.
-
 {empty} +

--- a/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
+++ b/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
@@ -517,7 +517,7 @@ docker compose up
 [source,bash,subs="attributes+"]
 ----
 docker volume ls
-docker volume rm {ocis_wopi}_ocis-config {ocis_wopi}_ocis-data`
+docker volume rm {ocis_wopi}_ocis-config {ocis_wopi}_ocis-data
 ----
 
 == Updating

--- a/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
+++ b/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
@@ -274,6 +274,9 @@ Set the CAServer to staging, see the note below.
 * `OCIS_DOMAIN`, `COLLABORA_DOMAIN` and `WOPISERVER_DOMAIN` +
 Set the domain names as defined in xref:domain-names[Domain Names].
 
+* `OCIS_CONFIG_DIR` and `OCIS_DATA_DIR` +
+If you expect a higher amount of data in the instance, consider using own paths instead of using docker internal volumes.
+
 * `SMTP_xxx` +
 Define these settings according to your eMail configuration. With the settings defined, Infinite Scale is able to send notifications to users. If the settings are not defined, Infinite Scale will start, but notifications can't be sent.
 
@@ -451,5 +454,76 @@ If no password can be identified, you must reset the admin password via the comm
 === Command Line Password Reset
 
 To change the admin password from the command line, which you can do at any time, follow the guide described in xref:deployment/general/general-info.adoc#password-reset-for-the-admin-user[Password Reset for the Admin User].
+
+== Volume Migration
+
+This section gives some guidance if you want to migrate the Infinite Scale docker internal volumes to docker volumes using a local path. For example, this can be required to separate the container from its data or if a high data volume is expected. See additional documentation in the xref:deployment/tips/useful_mount_tip.adoc[Start a Service After a Resource is Mounted] if you want to use network mounts like NFS or iSCSI for the data directory.
+
+* Prepare two directories which will provide the mount point for Infinite Scale `data` and `config`. +
+The example will use the local path `/mnt/data` and `mnt/config`, adapt according your environment.
+
+* For the following steps, the compose setup _must be_ in the `up` state, the containers must provide a container ID for copying.
+
+** Stop the running instance. By doing so, the instance gets stopped but containers are not removed compared to when downing it:
++
+[source,bash]
+----
+docker compose stop
+----
+
+** Get the `ocis` container ID using one of the xref:container[maintenance - Container] commands.
+
+** Copy both the content of the docker internal `ocis-config` and `ocis-data` volume to their new local location by issuing the following commands, replace `<CONTAINER ID>` accordingly:
++
+[source,bash]
+----
+docker cp <CONTAINER ID>:/etc/ocis/. /mnt/config
+docker cp <CONTAINER ID>:/var/lib/ocis/. /mnt/data
+----
+
+** Change the ownership of the new source folders recursively. This step is _very important_ because the user inside the container is `1000` and will mostly not match the user who copied the folders:
++
+[source,bash]
+----
+chown -R 1000:1000 /mnt/config /mnt/data
+----
+
+* Down the compose instance by issuing:
++
+[source,bash]
+----
+docker compose down
+----
+
+** In the `.env` file, set the paths:
++
+[source,.env]
+----
+OCIS_DATA_DIR=/mnt/data
+OCIS_CONFIG_DIR=/mnt/config
+----
+
+* Bring the compose environment `up` with:
++
+[source,bash]
+----
+docker compose up
+----
+
+** If the containers come up without reporting issues, you have successfully moved your Infinite Scale docker internal volumes to local paths.
+
+* Finally, you can remove the docker internal volumes for `config` and `data`:
++
+[source,bash,subs="attributes+"]
+----
+docker volume ls
+docker volume rm {ocis_wopi}_ocis-config {ocis_wopi}_ocis-data`
+----
+
+== Updating
+
+Note that this deploymment can currently only be updated within Infinite Scale v5.
+
+If a new Infinite Scale v5 version is available, just down the compose environment and bring it back up. Containers will update automatically and you can continue using Infinite Scale as usual.
 
 end::shared_2[]


### PR DESCRIPTION
Same as we (will) have in the rolling deployment example #948, the docker volumes got configurable for 5.0, see: https://github.com/owncloud/ocis/pull/9847 ([docs-only][stable-5.0] ocis_wopi deployment example, make data and config volumes configurable). This PR updates the deployment example to reflect the new capability. In addition, the upgrade section is moved into the shared content as it is the same for both setups. Note that the texts are just copied from #948.

Because this PR mandatory needs ocis 5.0.7 to be released, hopefully soon, I put it on draft to avoid accidentially merging. 