### PR TITLE
Streamline the Web UI documentation

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/web.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/web.adoc
@@ -16,15 +16,34 @@ The web service also provides a minimal API for branding functionality like chan
 
 * Web listens on port 9100 by default.
 
-== Custom Compiled Web Assets
+== Web UI Configuration
 
-If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See https://owncloud.dev/clients/web/getting-started/[ownCloud Web / Getting Started] and https://owncloud.dev/clients/web/backend-ocis/[ownCloud Web / Setup with oCIS] in the developer documentation for more details.
+* Single configuration settings of the embedded web UI can be defined via `WEB_OPTION_xxx` environment variables.
+* A json based configuration file can be used via the `WEB_UI_CONFIG_FILE` environment variable.
+* If a json based configuration file is used, these configurations take precedence over single options set.
+
+=== Web UI Options
+
+Beside theming, see below, the behavior of the web UI can be configured via options. Behavior customization can be achieved by setting environment variables. Look for environment variables starting with `WEB_OPTION_xxx` for more details.
+
+=== Web UI Config File
+
+When defined via the `WEB_UI_CONFIG_FILE`, the configuration of the web UI can be made with a json based file. See the https://github.com/owncloud/web/tree/master/config[link,window=_blank] for examples.
+
+== Embedding Web
+
+Web can be consumed by another application in a stripped-down version called “Embed mode”. This mode is supposed to be used in the context of selecting or sharing resources. For more details refer to the developer documentation https://owncloud.dev/clients/web/embed-mode/[ownCloud Web / Embed Mode]. See the environment variables: `WEB_OPTION_MODE` and `WEB_OPTION_EMBED_TARGET` to configure the embedded mode.
 
 == Customize the Web UI Configuration
 
-See the xref:deployment/webui/webui.adoc[Web UI] documentation for how to configure theming and customization or how to embed Web into another application.
+See the xref:deployment/webui/webui-customisation.adoc[ownCloud Web with Custom Configuration] documentation for details if you want:
 
-// you will find `Web UI Configuration`, `Web UI Options` and `Embedding Web` from the dev docs in that link.
+* Custom Compiled Web Assets
+* Extend Web UI With Apps
+
+== Custom Theming for the Web UI
+
+See the xref:deployment/webui/webui-theming.adoc[ownCloud Web with Custom Theming] for more details.
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/webui/webui-customisation.adoc
+++ b/modules/ROOT/pages/deployment/webui/webui-customisation.adoc
@@ -26,7 +26,7 @@ This also applies for the `manifest.json` file, if the administrator wants to pr
 
 == Extend Web UI With Apps
 
-The Infinite Scale administrator is capable of providing custom web applications to the users. This feature is useful for organizations that want to provide third party or custom apps to their users.
+The Infinite Scale administrator is capable of providing custom web applications to the users. This feature is useful for organizations that want to provide third party or custom apps to their users. See the https://github.com/owncloud/web-extensions[WebUI extensions] repository for examples.
 
 It's important to note, that the feature is at the moment only capable of providing static (js, mjs, e.g.) web applications and does not support injection of dynamic web applications (custom dynamic backends).
 

--- a/modules/ROOT/pages/deployment/webui/webui-customisation.adoc
+++ b/modules/ROOT/pages/deployment/webui/webui-customisation.adoc
@@ -1,32 +1,32 @@
 = ownCloud Web with Custom Configuration
 :toc: right
+:page-aliases: deployment/webui/webui.adoc
 :description: The behavior of the embedded web frontend named ownCloud Web can be configured. This guide shows you how to do so.
 
 == Introduction
 
 {description}
 
-== Web UI Configuration
+== Custom Compiled Web Assets
 
-* Single configuration settings of the embedded web UI can be defined via `WEB_OPTION_xxx` environment variables.
-* A json based configuration file can be used via the `WEB_UI_CONFIG_FILE` environment variable.
-* If a json based configuration file is used, these configurations take precedence over single options set.
+If you want to use your custom compiled web client assets instead of the embedded ones, then you can do that by setting the `WEB_ASSET_PATH` variable to point to your compiled files. See https://owncloud.dev/clients/web/getting-started/[ownCloud Web / Getting Started] and https://owncloud.dev/clients/web/backend-ocis/[ownCloud Web / Setup with oCIS] in the developer documentation for more details.
 
-=== Web UI Options
+=== Using Custom Assets
 
-Beside theming, the behavior of the web UI can be configured via options. Behavior customization can be achieved by setting environment variables in the xref:{s-path}/web.adoc[Web service]. Look for environment variables starting with `WEB_OPTION_xxx` for more details.
+Besides the configuration and application registration, in the process of loading the application assets, the system uses a mechanism to load custom assets.
 
-=== Web UI Config File
+This is very useful for cases where just a single asset should be overwritten, like a logo or similar.
 
-When defined via the `WEB_UI_CONFIG_FILE` xref:{s-path}/web.adoc[environment variable], the configuration of the web UI can be made with a json based file. See the https://github.com/owncloud/web/tree/master/config[link,window=_blank] for examples.
+Consider the following: Infinite Scale is shipped with a default web app named `image-viewer-dfx` which contains a logo,
+but the administrator wants to provide a custom logo for that application.
 
-== Embedding Web
+This can be achieved using the path defined via `WEB_ASSET_APPS_PATH` and adding a custom structure like `WEB_ASSET_APPS_PATH/image-viewer-dfx/`. Here you can add all custom assets to load like `logo.png`. On loading the web app, custom assets defined overwrite default ones.
 
-Web can be consumed by another application in a stripped-down version called “Embed mode”. This mode is supposed to be used in the context of selecting or sharing resources. For more details refer to the developer documentation https://owncloud.dev/clients/web/embed-mode/[ownCloud Web / Embed Mode]. See the environment variables: `WEB_OPTION_MODE` and `WEB_OPTION_EMBED_TARGET` to configure the embedded mode.
+This also applies for the `manifest.json` file, if the administrator wants to provide a custom one.
 
-== Web Apps
+== Extend Web UI With Apps
 
-The administrator of the environment is capable of providing custom web applications to the users. This feature is useful for organizations that want to provide third party or custom apps to their users.
+The Infinite Scale administrator is capable of providing custom web applications to the users. This feature is useful for organizations that want to provide third party or custom apps to their users.
 
 It's important to note, that the feature is at the moment only capable of providing static (js, mjs, e.g.) web applications and does not support injection of dynamic web applications (custom dynamic backends).
 
@@ -40,8 +40,8 @@ This environment variable defaults to the Infinite Scale xref:deployment/general
 
 The final list of available applications is composed of the built-in and the custom applications provided by the administrator via `WEB_ASSET_APPS_PATH`.
 
-For example, if Infinite Scale would contain a built-in extension named `image-viewer-dfx` and the administrator provides a custom application named `image-viewer-obj` via the `WEB_ASSET_APPS_PATH` directory, the user will be able to access both
-applications from the WebUI.
+For example, if Infinite Scale would contain a built-in app named `image-viewer-dfx` and the administrator provides a custom application named `image-viewer-obj` via the `WEB_ASSET_APPS_PATH` directory, the user will be able to access both
+applications from the Web UI.
 
 === Application Structure
 
@@ -116,19 +116,6 @@ Defaults to `false`. If set to `true`, the application will not be loaded.
 {empty}
 
 NOTE: A local provided configuration yaml will always override the shipped application manifest configuration.
-
-=== Using Custom Assets
-
-Besides the configuration and application registration, in the process of loading the application assets, the system uses a mechanism to load custom assets.
-
-This is very useful for cases where just a single asset should be overwritten, like a logo or similar.
-
-Consider the following: Infinite Scale is shipped with a default web app named `image-viewer-dfx` which contains a logo,
-but the administrator wants to provide a custom logo for that application.
-
-This can be achieved using the path defined via `WEB_ASSET_APPS_PATH` and adding a custom structure like `WEB_ASSET_APPS_PATH/image-viewer-dfx/`. Here you can add all custom assets to load like `logo.png`. On loading the web app, custom assets defined overwrite default ones.
-
-This also applies for the `manifest.json` file, if the administrator wants to provide a custom one.
 
 == Miscellaneous
 

--- a/modules/ROOT/pages/deployment/webui/webui.adoc
+++ b/modules/ROOT/pages/deployment/webui/webui.adoc
@@ -1,9 +1,0 @@
-= Web UI
-:toc: right
-:description: Infinite Scale ships with an embedded web frontend named ownCloud Web. This web UI can be configured and themed.
-
-== Introduction
-
-{description}
-
-While theming handles the look and feel, you can manage behavior with customization.

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -72,7 +72,7 @@
 **** xref:deployment/services/s-list/web.adoc[Web]
 **** xref:deployment/services/s-list/webdav.adoc[WebDAV]
 **** xref:deployment/services/s-list/webfinger.adoc[Webfinger]
-** xref:deployment/webui/webui.adoc[Web UI]
+** Web UI
 *** xref:deployment/webui/webui-customisation.adoc[Custom Configuration]
 *** xref:deployment/webui/webui-theming.adoc[Custom Theming]
 * Maintenance


### PR DESCRIPTION
The current Web UI documentation urgently needed some care, especially with rolling 6 which provides many apps.

* Remove the not necessary Web UI intro page, three line content is much to less
Keep an alias so nothing breaks
* Collect and order all remaining Configuration and Theming content from web into their respective individual pages
* From web, link the content pages

Compared to the ocis repo/ocis dev, web reads here much easier as it is not overloaded, this is by design.

Textwise, except adding a link to the extensions repo, nothing got changed but moved only.

No backport