### PR TITLE
Add Graph service translation and default language

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -90,6 +90,10 @@ The client that is used to authenticate with Keycloak has to be able to list use
 
 Note that these roles are only available to assign if the client is in the `master` realm.
 
+
+:envvar_name: GRAPH_TRANSLATION_PATH
+include::partial$deployment/services/translations.adoc[]
+
 == Event Bus Configuration
 
 include::partial$multi-location/event-bus.adoc[]


### PR DESCRIPTION
Referencing: https://github.com/owncloud/ocis/pull/9902 (Add TRANSLATION_PATH envvar to graph service)

Add the description for the translation and default language.

Only merge after the referenced PR got merged.

No Backport