### PR TITLE
Add glob/worker to revision purge CLI

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
+++ b/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
@@ -23,3 +23,6 @@ Allows specifying the blobstore to use. Defaults to `ocis`. Can be switched to `
 
 * `-v` / `--verbose` +
 Prints additional information about the revisions that are removed.
+
+* `--glob-mechanism` (default: `glob` +
+(advanced) Allows specifying the mechanism to use for globbing. Can be `glob`, `list` or `workers`. In most cases the default `glob` does not need to be changed. If large spaces need to be purged, `list` or `workers` can be used to improve performace at the cost of higher cpu and ram usage. `list` will spawn 10 threads that list folder contents in parallel. `workers` will use a special globbing mechanism and multiple threads to achieve the best performance for the highest cost.

--- a/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
+++ b/modules/ROOT/pages/maintenance/commands/revisions-cleanup.adoc
@@ -25,4 +25,4 @@ Allows specifying the blobstore to use. Defaults to `ocis`. Can be switched to `
 Prints additional information about the revisions that are removed.
 
 * `--glob-mechanism` (default: `glob` +
-(advanced) Allows specifying the mechanism to use for globbing. Can be `glob`, `list` or `workers`. In most cases the default `glob` does not need to be changed. If large spaces need to be purged, `list` or `workers` can be used to improve performace at the cost of higher cpu and ram usage. `list` will spawn 10 threads that list folder contents in parallel. `workers` will use a special globbing mechanism and multiple threads to achieve the best performance for the highest cost.
+(advanced) Allows specifying the mechanism to use for globbing. Can be `glob`, `list` or `workers`. In most cases the default `glob` does not need to be changed. If large spaces need to be purged, `list` or `workers` can be used to improve performance at the cost of higher cpu and ram usage. `list` will spawn 10 threads that list folder contents in parallel. `workers` will use a special globbing mechanism and multiple threads to achieve the best performance for the highest cost.


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/9904 ([docs-only] Forgotten revisions purge docs)

Add command parameter to revision purge.

Only merge after the referenced PR gor merged.

No Backport