### PR TITLE
Small gateway service description fix

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -1,12 +1,12 @@
 = Gateway Service Configuration
 :toc: right
-:description: The Infinite Scale Gateway service is responsible for passing requests to the storage providers. Other services never talk to the storage providers directly but will always send their requests via the `gateway` service.
+:description: The Infinite Scale Gateway service is responsible for passing requests to the storage providers.
 
 :service_name: gateway
 
 == Introduction
 
-{description}
+{description} Other services never talk to storage providers directly but will always send their requests via this service.
 
 // fixme: source description is still missing, and a better description is needed
 


### PR DESCRIPTION
Fixes: #683 ([5.0] The gateway service has changed caching settings)

Small text fix, the caching changes have already been implemented for both branches.

Backport to 5.0 