### PR TITLE
Local only, ocis 5.0.7

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -45,7 +45,7 @@ asciidoc:
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '5.0.6'
+    ocis-actual-version: '5.0.7'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
     ocis-rolling-version: '6.3.0'


### PR DESCRIPTION
Referencing: https://github.com/owncloud/docs/pull/4985 (Make ocis 5.0.7 as default production)

Only for local building the docs here.

Only merge after release notes have been merged - setting to draft therefore.

Backport to 5.0 