### PR TITLE
Reordering some text in notifications to improve readability

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -17,9 +17,11 @@ Note that the {service_name} service does not start automatically and must be st
 
 == Email Notification Templates
 
-The `notifications` service has embedded email text and html body templates. Email templates can use the placeholders `{{ .Greeting }}`, `{{ .MessageBody }}` and `{{ .CallToAction }}` which are replaced with translations when sent, see the xref:translations[Translations] section for more details.
+The `notifications` service has embedded email text and html body templates.
 
-Depending on the email purpose, placeholders will contain different strings. An individual translatable string is available for each purpose, to be resolved via the placeholder. Though the email subject is also part of translations, it has no placeholder as it is a mandatory email component. The embedded templates are available for all deployment scenarios.
+Email templates can use the placeholders `{{ .Greeting }}`, `{{ .MessageBody }}` and `{{ .CallToAction }}` which are replaced with translations when sent, see the xref:translations[Translations] section for more details. Though the email subject is also part of translations, it has no placeholder as it is a mandatory email component. 
+
+Depending on the email purpose, placeholders will contain different strings. An individual translatable string is available for each purpose, to be resolved via the placeholder. The embedded templates are available for all deployment scenarios.
 
 [source,plaintext]
 ----


### PR DESCRIPTION
The placeholder text in notfications need an update to ease readability.
There is no content change but reordering only.

Will fix that in the ocis repo too.

Backport to 5.0