### PR TITLE
Set 5.0.7 as default in the 5.0 branch

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,19 +22,19 @@ asciidoc:
     # service_tab_text will be used as tab text shown for the tables in services only
     # note when literally changing the word 'master' to something else, you also must adapt 'env-and-yaml.adoc'.
     # this does not apply to branched releases using semver, only to the master branch! 
-    service_tab_text: '5.0.6' # latest stable including patch releases like 5.0.0
+    service_tab_text: '5.0.7' # latest stable including patch releases like 5.0.0
 
     # note that compose_url_component is used for compose examples and for the EULA ONLY
     # compose_url_component will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_url_component: 'v5.0.6' # latest stable including patch releases like v5.0.0 (note the v ! as it is tagged)
+    compose_url_component: 'v5.0.7' # latest stable including patch releases like v5.0.0 (note the v ! as it is tagged)
 
     # compose_tab_text will be used as tab text for examples and all other stuff but not servcies 
-    compose_tab_text: '5.0.6' # latest stable including patch releases like 5.0.0
+    compose_tab_text: '5.0.7' # latest stable including patch releases like 5.0.0
 
     # use this attribute to define the branch name for git clone
     # the value is usually identical to compose_tab_text, but it should be separatable to be independent
     # note that you must define a value and not an attribute from above 
-    compose_git_name: '5.0.6' # latest stable including patch releases like 5.0.0 (must be without v !)
+    compose_git_name: '5.0.7' # latest stable including patch releases like 5.0.0 (must be without v !)
 
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc


### PR DESCRIPTION
Need to set the actual ocis production version to 5.0.7 in the 5.0 branch needed for the build process.