### PR TITLE
fix migration command

### DIFF
--- a/modules/ROOT/pages/maintenance/commands/rolling-back-and-forward.adoc
+++ b/modules/ROOT/pages/maintenance/commands/rolling-back-and-forward.adoc
@@ -16,13 +16,16 @@ NAME:
    ocis migrate decomposedfs - run a decomposedfs migration
 
 USAGE:
-   ocis migrate decomposedfs [command options] [arguments...]
+   ocis migrate decomposedfs command [command options] 
+
+COMMANDS:
+   list     list decomposedfs migrations
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-   --direction value, -d value  direction of the migration to run ('up' or 'down') (default: "up")
+   --direction value, -d value  direction of the migration to run ('migrate' or 'rollback') (default: "migrate")
    --migration value, -m value  ID of the migration to run
    --root value, -r value       Path to the root directory of the decomposedfs
-   --list, -l                   Print a list of migrations incl. their state (default: false)
    --help, -h                   show help
 ----
 
@@ -30,7 +33,7 @@ Example Command 1::
 
 [source,bash]
 ----
-ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ -l
+ocis migrate decomposedfs -r /home/andre/.ocis/storage/users/ list
 
 +-----------+-----------+---------+
 | Migration |   State   | Message |


### PR DESCRIPTION
the `-l` option does not exist (at least not on 6.1.0)
I believe it should be `list`

also other details of the output fixed