### PR TITLE
Only files and foldes can be shared with OCM

### DIFF
--- a/modules/ROOT/pages/depl-examples/federation/sciencemesh.adoc
+++ b/modules/ROOT/pages/depl-examples/federation/sciencemesh.adoc
@@ -103,7 +103,7 @@ image:depl-examples/federation/science_mesh/sm_federation_b_setup.png[Federated 
 
 After the federation has been finally setup, federated users can now share resources. Note that a user must have accepted the invitaion to be selectable in the sharing dialogue.
 
-* In menu:Files App[Space or file or folder > Sharing Icon], switch to `external` and start typing the user name. When found, select it:
+* In menu:Files App[Inside a Space > File or Folder > Sharing Icon], switch to `external` and start typing the user name. When found, select it:
 +
 image:depl-examples/federation/science_mesh/sm_user_share_resource_search.png[Search Federation User, width=250]
 +
@@ -112,8 +112,9 @@ image:depl-examples/federation/science_mesh/sm_user_share_resource_search.png[Se
 As rule of thumb:
 
 * You cannot share your personal space.
+* You cannot share a project space.
 * You should not share files from your personal space for security reasons.
-* Only share project spaces or files inside project spaces.
+* Only share files and folders inside project spaces.
 ====
 
 * If you have more federations, you can add more users. With the three vertical dots, you can select additional options. When done, click btn:[Share]

--- a/modules/ROOT/pages/deployment/services/s-list/ocm.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/ocm.adoc
@@ -15,6 +15,8 @@ Overview:
 
 Both API's have their roots in CERN where providing resources to trusted partners in an easy way is a key for their daily scientific work.
 
+See the xref:depl-examples/federation/sciencemesh.adoc[Setup Federations Using ScienceMesh] for details on how to setup sharing between users via a federation using OCM. 
+
 == Default Values
 
 * OCM listens on port 9280 by default.


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/10060 (prevent adding the federated users as members of the space)

New: federated users can only share files and folders but not spaces.

No backport.