### PR TITLE
[5.0] Fix using the correct attribute

### DIFF
--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
@@ -21,7 +21,7 @@ toc::[]
 
 IMPORTANT: *Some decisions and steps need to be taken in order when setting up and configuring the server. We therefore highly recommend reading the guide and not just trying to copy paste commands.*
 
-NOTE: This guide references the latest {version-type} version of Infinite Scale.
+NOTE: This guide references the latest {compose_version} version of Infinite Scale.
 
 NOTE: With this setup, each deployment only contains one instance of Infinite Scale.
 


### PR DESCRIPTION
References: #996 ([5.0] [PR 992] Update compose deployments based on feedback)

Introduced with the referenced PR, an attribute got overwritten that is different in master, fixed now.

Found by running a full local docs build:

```
[10:29:10.394] WARN (asciidoctor): skipping reference to missing attribute: version-type
    file: modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
    source: https://github.com/owncloud/docs-ocis.git (branch: 5.0)
```