### PR TITLE
Add a title text to the envvars list block in auth-app startup

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -26,7 +26,7 @@ include::partial$deployment/services/auth-service-family.adoc[]
 
 {empty}
 
-.Enironment variables related to starting the {service_name} service
+.Environment variables related to starting the {service_name} service
 [source,bash]
 ----
 OCIS_ADD_RUN_SERVICES=auth-app  # deployment specific. Alternatively you can start the service explicitly via the command line.

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -21,9 +21,12 @@ include::partial$deployment/services/auth-service-family.adoc[]
 
 == Service Startup
 
-* Because this service is not started automatically, a manual start needs to be initiated which can be done in several ways, only one example is shown below. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+* Because this service is not started automatically, a manual start needs to be initiated which can be done in several ways, only one example using an environment variable is shown below. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
 * To configure the service usage, an environment variable for the proxy service needs to be set to allow app authentication.
 
+{empty}
+
+.Enironment variables related to starting the {service_name} service
 [source,bash]
 ----
 OCIS_ADD_RUN_SERVICES=auth-app  # deployment specific. Alternatively you can start the service explicitly via the command line.


### PR DESCRIPTION
Missed a title text to the envvars list block in auth-app startup - fixed.

No backport