### PR TITLE
Make ocm sharing docs less confusing

### DIFF
--- a/modules/ROOT/pages/depl-examples/federation/sciencemesh.adoc
+++ b/modules/ROOT/pages/depl-examples/federation/sciencemesh.adoc
@@ -43,7 +43,7 @@ Finally, depending on the deployment, either all federation instances or each oc
 
 === Setup a Federation Between Users
 
-Before sharing resources, a sharer must first invite a parter to join a federation. This only needs to be done one time per invitor/acceptor pair. This pair is now called a federation. After setting up the federation, sharing resources can mutually be created.
+Before sharing resources, a sharer must first invite a parter to join a federation. This only needs to be done one time per invitor/acceptor pair of users. After setting up the federation, shared resources can mutually be created.
  
 The following can be carried out by any user of the trusted instances. When xref:deployment/general/general-info.adoc#demo-users-and-groups[demo users] have been setup, which should not be present in production, one federation partner must be a user that has been created manually.
 


### PR DESCRIPTION
- I disagree with the terminology:  The pair of users that trust each other is called "a federation". I'd rather call that a remote or federated trust relationship.
  Maybe we can give an authorative definition of the term "Federation" here?
- "carried out by any user" is untrue. A user without a remote trust relationship cannot.
- "should not be present in production" ? That introduces a whole new topic (dev, staging, production) - but what is the point of federation, when it is not for production?
- one federation partner must be a user that has been manually created. I don't think so. Two ldap users should be fine too. No?
