### PR TITLE
Fix ocis-downloadpage-url attribute usage

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -69,7 +69,7 @@ Note that this URL must resolve to the server running this installation.
 
 === Install and configure the Infinite Scale Binary
 
-* Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file.
+* Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file.
 +
 [source,bash,subs="attributes+"]
 ----

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -55,7 +55,7 @@ For those who want to skip reading the full document, use this summary of comman
 
 IMPORTANT: With this approach, the system you install Infinite Scale on *must* have a GUI present. A headless system has different requirements and needs an extended setup, see xref:accessing-infinite-scale-other-than-localhost[Accessing Infinite Scale Other Than Localhost].
 
-Define a stable binary to use as replacement for `<file_url>` via {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank].
+Define a stable binary to use as replacement for `<file_url>` via {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank].
 
 [source,bash,subs="attributes+"]
 ----
@@ -83,7 +83,7 @@ Congratulations, you now have access to your Infinite Scale instance.
 
 == Installation
 
-* To get the stable binary from ownCloud, visit {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`.
+* To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`.
 +
 --
 To download use:

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -7,7 +7,7 @@
 
 {description}
 
-NOTE: For any Infinite Scale version to upgrade to, see {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank] or {docker_ocis_prod_url}[Infinite Scale image] to get the right version.
+NOTE: For any Infinite Scale version to upgrade to, see {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank] or {docker_ocis_prod_url}[Infinite Scale image] to get the right version.
 
 IMPORTANT: Before starting any upgrade, make a xref:maintenance/b-r/backup.adoc[backup] first.
 

--- a/modules/ROOT/pages/migration/upgrading_2.0.0_3.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_2.0.0_3.0.0.adoc
@@ -21,7 +21,7 @@ IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#in
 docker pull owncloud/ocis:3.0.0
 ----
 
-* or get the binary from {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank].
+* or get the binary from {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank].
 --
 
 . Manually add the xref:{s-path}/graph.adoc#environment-variables[GRAPH_APPLICATION_ID,window=_blank] to the config. The value can be any text string using characters defined by the https://en.wikipedia.org/wiki/Universally_unique_identifier[UUID definition] and is preferably a UUID4 string.

--- a/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_3.0.0_4.0.0.adoc
@@ -21,7 +21,7 @@ IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#in
 docker pull owncloud/ocis:4.0.0
 ----
 
-* or get the binary from {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank].
+* or get the binary from {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank].
 --
 
 . Migrate the Space Index to Messagepack: +

--- a/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_4.0.0_5.0.0.adoc
@@ -25,7 +25,7 @@ IMPORTANT: Check below, if you are affected by breaking changes and prepare all 
 docker pull owncloud/ocis:{compose_version}
 ----
 
-* or get the binary from {ocis-downloadpage-url}?sort=time&order=desc[download.owncloud.com,window=_blank].
+* or get the binary from {ocis-downloadpage-url}/stable/?sort=time&order=desc[download.owncloud.com,window=_blank].
 --
 
 == Manage Breaking Changes

--- a/modules/ROOT/pages/quickguide/quickguide.adoc
+++ b/modules/ROOT/pages/quickguide/quickguide.adoc
@@ -17,7 +17,7 @@ Open a shell and copy/paste the following commands:
 [source,bash,subs="attributes+"]
 ----
 sudo wget -O /usr/local/bin/ocis \
-  {ocis-downloadpage-url}{ocis-actual-version}/ocis-{ocis-actual-version}-linux-amd64
+  {ocis-downloadpage-url}/stable/{ocis-actual-version}/ocis-{ocis-actual-version}-linux-amd64
 ----
 
 [source,bash]

--- a/site.yml
+++ b/site.yml
@@ -45,12 +45,12 @@ asciidoc:
     # Versions mainly for printing like in docs-main release info and in docs-ocis to define the latest production version.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '5.0.7'
+    ocis-actual-version: '5.0.8'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table or in deployment examples
-    ocis-rolling-version: '6.4.0'
+    ocis-rolling-version: '6.5.0'
     ocis-compiled: '2024-09-12 00:00:00 +0000 UTC'
-    ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis/stable/'
+    ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
   extensions:
     - ./ext-asciidoc/tabs.js
     - ./ext-asciidoc/remote-include-processor.js


### PR DESCRIPTION
References: #1010 (Make the dynamics of stable/production more robust)

This are the changes relevant for 5.0 driven by the referenced PR. It is a partial mini backport.