### PR TITLE
New thumbnail generator for container deployments

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -24,9 +24,11 @@ include::partial$multi-location/compose-version.adoc[]
 
 {description}
 
-This deployment example addresses a small production environment. For a minimal test and development environment, see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. The main differences between the setup described in this document and a minimal test environment is, the use of systemd, letsencrypt and a reverse proxy.
+This deployment example addresses a small production environment without running online office applications etc. For a minimal test and development environment, see the xref:depl-examples/minimal-bare-metal.adoc[Minimal Bare Metal Deployment]. The main differences between the setup described in this document and a minimal test environment is, the use of systemd, letsencrypt and a reverse proxy. If you intend to run a complete setup using online office, full text search etc., see the *Ubuntu with Docker Compose* deployment examples.
 
 Note that this guide expects that prerequisite of a computer with an installed Linux distribution of choice is met and required software other than Infinite Scale is installed and preconfigured. There is no detailed explanation but, where possible, links for more information are provided.
+
+Note that there is a difference in internal thumbnail processing when using binary vs container deployments. For details see the xref:{s-path}/thumbnails.adoc#thumbnailing-performance[thumbnails] service.
 
 This guide was tested on a Debian 11 (bullseye) host but should work on any other modern Linux system with systemd.
 

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -17,9 +17,11 @@ include::partial$multi-location/compose-version.adoc[]
 
 == Introduction
 
-{description} It does not cover extended deployment tasks or how to manage trusted certificates etc. and is intended to get a first hands-on experience of the system.
+{description} It does not cover extended deployment tasks, how to manage trusted certificates, run online office applications etc. and is intended to get a first hands-on experience of the system only.
 
 For a small production environment using the binary installation approach, see the xref:depl-examples/bare-metal.adoc[Bare Metal Deployment with systemd]. The main differences between this setup and the small production environment using the binary installation is, in a nutshell, the use of systemd, LetsEncrypt and a reverse proxy.
+
+Note that there is a difference in internal thumbnail processing when using binary vs container deployments. For details see the xref:{s-path}/thumbnails.adoc#thumbnailing-performance[thumbnails] service.
 
 [IMPORTANT]
 ====

--- a/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
@@ -17,7 +17,7 @@ Note for developers, more information is available with regards to querying thum
 
 == Thumbnailing Performance
 
-Thumbnail generation can consume considerably resources. For thumbnailing, two libraries are available where one is embedded in the thumbnail service and one is external. The external shared library is not only much faster, but also provides more image types that can be converted. While the internal library is only available with the binary deployment, the external library is built and preconfigured with the container deployment only. Note, if required, you can manually add the shared library and build Infinite Scale for the binary deployment on your own using this library. To do so see, the https://owncloud.dev/services/thumbnails/[developer documentation, window=_blank] for more details.
+Thumbnail generation can consume considerably resources. For thumbnailing, two libraries are available. One library is embedded in the thumbnail service and statically linked where the other one is an external shared library, dynamically linked and must be available via the OS when accessing. The external shared library is not only much faster, but also provides more possible image types that can be converted. While the embedded library is only available with the binary deployment, the external library is built and preconfigured with the container deployment only. Note, if required, you can manually add the shared library to your OS and build Infinite Scale for the binary deployment on your own. To do so, see the https://owncloud.dev/services/thumbnails/[developer documentation, window=_blank] for more details.
 
 == Configuration Hints
 

--- a/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
@@ -17,7 +17,7 @@ Note for developers, more information is available with regards to querying thum
 
 == Thumbnailing Performance
 
-Thumbnail generation can consume considerably resources. For thumbnailing, two libraries are available where one is embedded in the thumbnail service and one is external. The external shared library is not only much faster, but also provides more image types that can be converted. While the internal library is only available with the binary deployment available for download, the external library is built and preconfigured with the container deployment only. Note, if required, you can manually add the shared library and build Infinite Scale for the binary deployment on your own using this library. To do so see, the https://owncloud.dev/services/thumbnails/[developer documentation, window=_blank] for more details.
+Thumbnail generation can consume considerably resources. For thumbnailing, two libraries are available where one is embedded in the thumbnail service and one is external. The external shared library is not only much faster, but also provides more image types that can be converted. While the internal library is only available with the binary deployment, the external library is built and preconfigured with the container deployment only. Note, if required, you can manually add the shared library and build Infinite Scale for the binary deployment on your own using this library. To do so see, the https://owncloud.dev/services/thumbnails/[developer documentation, window=_blank] for more details.
 
 == Configuration Hints
 

--- a/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/thumbnails.adoc
@@ -1,12 +1,12 @@
 = Thumbnails Service Configuration
 :toc: right
-:description: The thumbnails service provides methods to generate thumbnails for various files and resolutions based on requests.
+:description: The thumbnails service provides methods to generate thumbnails for various files and resolutions based on requests,
 
 :service_name: thumbnails
 
 == Introduction
 
-{description} It retrieves the sources at the location where the user files are stored and saves the thumbnails where system files are stored. Those locations have defaults but can be manually defined via environment variables.
+{description} and is also responsible for presenting images, not only thumbnails to the client. It retrieves the sources at the location where the user files are stored and saves the thumbnails where system files are stored. Those locations have defaults but can be manually defined via environment variables.
 
 Note for developers, more information is available with regards to querying thumbnails in the services section of the https://owncloud.dev/services/thumbnails/[Developer Documentation].
 
@@ -14,6 +14,10 @@ Note for developers, more information is available with regards to querying thum
 
 * Thumbnails listens on port 9185 by default.
 * The default location storing thumbnails is $OCIS_BASE_DATA_PATH/thumbnails
+
+== Thumbnailing Performance
+
+Thumbnail generation can consume considerably resources. For thumbnailing, two libraries are available where one is embedded in the thumbnail service and one is external. The external shared library is not only much faster, but also provides more image types that can be converted. While the internal library is only available with the binary deployment available for download, the external library is built and preconfigured with the container deployment only. Note, if required, you can manually add the shared library and build Infinite Scale for the binary deployment on your own using this library. To do so see, the https://owncloud.dev/services/thumbnails/[developer documentation, window=_blank] for more details.
 
 == Configuration Hints
 


### PR DESCRIPTION
Fixes: #1009 (Thumbnail generator changes)

* Adding an admin relevant text to the thumbnail service because container deployments use an external shared libraries.
* Also add a text to the bare metal deployment examples referencing to thumbnail service.
* Some small text improvements in the bare metal deployments and the thumbnail service.

No backport.