### PR TITLE
Fix envvar name in collaboration service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
@@ -48,7 +48,7 @@ There are a few variables that you need to set:
 * `COLLABORATION_APP_INSECURE`: +
   In case you are using a self signed certificate for the WOPI app you can tell the collaboration service to allow an insecure connection.
 
-* `COLLABORATION_APP_WOPISRC`: +
+* `COLLABORATION_WOPI_SRC`: +
   The external address of the collaboration service. The target app (onlyoffice, collabora, etc) will use this address to read and write files from Infinite Scale. +
   For example: `\https://wopi.example.com`.
 


### PR DESCRIPTION
Fixes: #1013 (Documentation for collaboration refers to COLLABORATION_APP_WOPISRC instead of COLLABORATION_WOPI_SRC)

The envvar name was wrong, needs fixing in the dev docs too.