### PR TITLE
Prepare for ocis 6.6.0 (local build relevant only)

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -48,8 +48,8 @@ asciidoc:
     ocis-actual-version: '5.0.8'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table
-    ocis-rolling-version: '6.5.0'
-    ocis-compiled: '2024-09-12 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.6.0'
+    ocis-compiled: '2024-10-22 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
   extensions:
     - ./ext-asciidoc/tabs.js


### PR DESCRIPTION
Set the attribute to use ocis 6.6.0 - local build relevant only.

Only merge when the release has been published!!