### PR TITLE
Add SSE keep alive

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/sse.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/sse.adoc
@@ -18,6 +18,10 @@ include::partial$deployment/services/log-service-ecosystem.adoc[]
 
 Clients can subscribe to the `/sse` endpoint to be informed by the server when an event happens. The `sse` endpoint will respect language changes of the user without needing to reconnect. Note that sse has a limitation of six open connections per browser which can be reached if one has opened various tabs of the Web UI pointing to the same Infinite Scale instance.
 
+== Keep SSE Connections Alive
+
+Some intermediate proxies drop connections after an idle time with no activity. If this is the case, configure the `SSE_KEEPALIVE_INTERVAL` envvar. This will send periodic SSE comments to keep connections open.
+
 == Event Bus Configuration
 
 include::partial$multi-location/event-bus.adoc[]


### PR DESCRIPTION
Fixes: #1023 (Add SSE keep alive info)

Add explaining text for the SSE keep alive envvar.
Text 1:1 from the referenced ocis PR.

Only merge when the referenced ocis PR got merged.