### PR TITLE
Proper naming of store attribute/partial

### DIFF
--- a/modules/ROOT/pages/deployment/services/caching.adoc
+++ b/modules/ROOT/pages/deployment/services/caching.adoc
@@ -40,7 +40,7 @@ The following table gives an overview of store types available in Infinite Scale
 
 {empty}
 
-include::partial$multi-location/caching-list.adoc[tag=store-types-list]
+include::partial$multi-location/cache-store.adoc[tag=store-types-list]
 
 === Local vs Global Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/activitylog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/activitylog.adoc
@@ -16,10 +16,10 @@ include::partial$deployment/services/log-service-ecosystem.adoc[]
 
 == Storing
 
-// renders dependent on is_cache or is_stat
-:is_stat: true
+// renders dependent on is_cache or is_store
+:is_store: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 :envvar_name: ACTIVITYLOG_TRANSLATION_PATH
 include::partial$deployment/services/translations.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
@@ -59,12 +59,12 @@ The rest of the configuration options available can be left with the default val
 
 == Storing
 
-// renders dependent on is_cache or is_stat
-:is_stat: true
+// renders dependent on is_cache or is_store
+:is_store: true
 // add a manual anchor + text because the service does not use the event bus
 :no_event_bus: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -22,10 +22,10 @@ The `eventhistory` services consumes all events from the configured event system
 
 === Storing
 
-// renders dependent on is_cache or is_stat
-:is_stat: true
+// renders dependent on is_cache or is_store
+:is_store: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 === Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -115,10 +115,10 @@ A lot of user management is done via the standardized LibreGraph API. Depending 
 
 == Caching
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -16,10 +16,10 @@
 
 == Caching
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -119,10 +119,10 @@ include::partial$deployment/services/translations.adoc[]
 
 == Caching
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -99,12 +99,12 @@ ocis postprocessing restart -s "virusscan" # Restart all uploads currently in vi
 
 == Storing
 
-// renders dependent on is_cache or is_stat
-:is_stat: true
+// renders dependent on is_cache or is_store
+:is_store: true
 
 The `postprocessing` service needs to store some metadata about uploads to be able to orchestrate post-processing. When running in single binary mode, the default in-memory implementation will be just fine. In distributed deployments it is recommended to use a persistent store, see below for more details.
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -200,10 +200,10 @@ For details on monitoring see the xref:monitoring/prometheus.adoc[Metrics for Pr
 
 Important, also see section xref:presigned-urls[Presigned Urls] below.
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -90,12 +90,12 @@ See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] 
 
 == Caching
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
 When using `SETTINGS_STORE_TYPE=metadata`, the `settings` service caches the results of queries against the storage backend to provide faster responses. The content of this cache is independent of the cache used in the `storage-system` service as it caches directory listing and settings content stored in files.
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -14,10 +14,10 @@
 
 == Caching
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -283,12 +283,12 @@ See the xref:deployment/storage/general-considerations.adoc#resource-optimisatio
 
 == Caching
 
-// renders dependent on is_cache or is_stat
+// renders dependent on is_cache or is_store
 :is_cache: true
 
 The `storage-users` service caches stat, metadata and uuids of files and folders via the configured stores.
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -78,10 +78,10 @@ include::partial$deployment/services/translations.adoc[]
 
 == Storing
 
-// renders dependent on is_cache or is_stat
-:is_stat: true
+// renders dependent on is_cache or is_store
+:is_store: true
 
-include::partial$multi-location/caching-list.adoc[]
+include::partial$multi-location/cache-store.adoc[]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/partials/multi-location/cache-store.adoc
+++ b/modules/ROOT/partials/multi-location/cache-store.adoc
@@ -8,10 +8,10 @@ ifdef::is_cache[]
 :env_nodes: OCIS_CACHE_STORE_NODES
 endif::is_cache[]
 
-ifdef::is_stat[]
+ifdef::is_store[]
 :env_store: OCIS_PERSISTENT_STORE
 :env_nodes: OCIS_PERSISTENT_STORE_NODES
-endif::is_stat[]
+endif::is_store[]
 
 The {service_name} service can use a configured store via the global `{env_store}` environment variable.
 


### PR DESCRIPTION
This PR implemants:

* A better naming for the store attribute `is_stat` --> `is_store`.
* Renames the partial to reflect it is about cache and store

No backport
(if we went to go for this, we need to do a partial backport, because 7 has more services than 5)

Locally tested, no build errors, renders as before.