### PR TITLE
ocis 6.6.1 rolling (local build relevant only)

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -48,8 +48,8 @@ asciidoc:
     ocis-actual-version: '5.0.8'
     ocis-former-version: '4.0.7'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table
-    ocis-rolling-version: '6.6.0'
-    ocis-compiled: '2024-10-22 00:00:00 +0000 UTC'
+    ocis-rolling-version: '6.6.1'
+    ocis-compiled: '2024-10-24 00:00:00 +0000 UTC'
     ocis-downloadpage-url: 'https://download.owncloud.com/ocis/ocis'
   extensions:
     - ./ext-asciidoc/tabs.js


### PR DESCRIPTION
References: https://github.com/owncloud/docs/pull/4994 (Add ocis rolling 6.6.1)

Only relevant for local building

Backport to 5.0