### PR TITLE
Use tag filtering and add comment in various pages

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/activitylog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/activitylog.adoc
@@ -14,15 +14,17 @@
 
 include::partial$deployment/services/log-service-ecosystem.adoc[]
 
+// include common translations text
+:envvar_name: ACTIVITYLOG_TRANSLATION_PATH
+include::partial$deployment/services/translations.adoc[]
+
 == Storing
 
 // renders dependent on is_cache or is_store
 :is_store: true
 
-include::partial$multi-location/cache-store.adoc[]
-
-:envvar_name: ACTIVITYLOG_TRANSLATION_PATH
-include::partial$deployment/services/translations.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
@@ -64,7 +64,8 @@ The rest of the configuration options available can be left with the default val
 // add a manual anchor + text because the service does not use the event bus
 :no_event_bus: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/eventhistory.adoc
@@ -25,7 +25,8 @@ The `eventhistory` services consumes all events from the configured event system
 // renders dependent on is_cache or is_store
 :is_store: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 === Retrieving
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -118,7 +118,8 @@ A lot of user management is done via the standardized LibreGraph API. Depending 
 // renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/gateway.adoc
@@ -19,7 +19,8 @@
 // renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -113,7 +113,7 @@ The client that is used to authenticate with Keycloak has to be able to list use
 
 Note that these roles are only available to assign if the client is in the `master` realm.
 
-
+// include common translations text
 :envvar_name: GRAPH_TRANSLATION_PATH
 include::partial$deployment/services/translations.adoc[]
 
@@ -122,7 +122,8 @@ include::partial$deployment/services/translations.adoc[]
 // renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -79,6 +79,7 @@ or embedded as a CID source like:
 
 In the latter case, image files must be located in the `templates/html/img` subfolder. Supported embedded image types are `png`, `jpeg`, and `gif`. Consider that embedding images via a CID resource may not be fully supported in all email web clients.
 
+// include common translations text
 :envvar_name: NOTIFICATIONS_TRANSLATION_PATH
 include::partial$deployment/services/translations.adoc[]
 

--- a/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/postprocessing.adoc
@@ -104,7 +104,8 @@ ocis postprocessing restart -s "virusscan" # Restart all uploads currently in vi
 
 The `postprocessing` service needs to store some metadata about uploads to be able to orchestrate post-processing. When running in single binary mode, the default in-memory implementation will be just fine. In distributed deployments it is recommended to use a persistent store, see below for more details.
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -203,7 +203,8 @@ Important, also see section xref:presigned-urls[Presigned Urls] below.
 // renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -95,7 +95,8 @@ See the full https://owncloud.dev/services/settings/#custom-roles[Custom Roles] 
 
 When using `SETTINGS_STORE_TYPE=metadata`, the `settings` service caches the results of queries against the storage backend to provide faster responses. The content of this cache is independent of the cache used in the `storage-system` service as it caches directory listing and settings content stored in files.
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-system.adoc
@@ -17,7 +17,8 @@
 // renders dependent on is_cache or is_store
 :is_cache: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -288,7 +288,8 @@ See the xref:deployment/storage/general-considerations.adoc#resource-optimisatio
 
 The `storage-users` service caches stat, metadata and uuids of files and folders via the configured stores.
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -73,6 +73,7 @@ https://<your-ocis-instance>/ocs/v2.php/apps/notifications/api/v1/notifications/
 to remove a global message is a restricted action, see the xref:authentication[Authentication] section for more details.
 --
 
+// include common translations text
 :envvar_name: USERLOG_TRANSLATION_PATH
 include::partial$deployment/services/translations.adoc[]
 
@@ -81,7 +82,8 @@ include::partial$deployment/services/translations.adoc[]
 // renders dependent on is_cache or is_store
 :is_store: true
 
-include::partial$multi-location/cache-store.adoc[]
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
 
 == Event Bus Configuration
 

--- a/modules/ROOT/partials/multi-location/cache-store.adoc
+++ b/modules/ROOT/partials/multi-location/cache-store.adoc
@@ -1,6 +1,10 @@
 ////
 This partial contains the commonly used list of caches and stores plus notes.
 It is used as partial so when there is a change, we only need to do it in one place
+
+Note that if you include the whole page and not only the tagged region, you must use tag filtering with
+tag=** in the include definition to select all the lines in the document except for lines that contain a tag directive, see:
+https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/#tag-filtering
 ////
 
 ifdef::is_cache[]
@@ -19,9 +23,7 @@ Note that for each global environment variable, an independent service-based one
 
 {empty}
 
-// note *in this case* the comment for the tag block is NECCESSARY: https://asciidoc.zulipchat.com/#narrow/stream/335214-general/topic/Tag.20region.20question.20-.20rendering.20issue.20in.20some.20cases
-
-// tag::store-types-list[]
+tag::store-types-list[]
 
 [width=100%,cols="25%,85%",options=header]
 |===
@@ -43,7 +45,7 @@ Usually the default for stores, see the store environment variable for which one
 | Stores nothing. Useful for testing. Not recommended in production environments.
 |===
 
-// end::store-types-list[]
+end::store-types-list[]
 
 NOTE: The {service_name} service can only be scaled if not using the `memory` store and the stores are configured identically over all instances!
 


### PR DESCRIPTION
This PR changes two things:

* Use [tag filtering](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/#tag-filtering) instead using commented tags
* Add a comment above the include for translations making it easier to identify

No text changes

No backport