### PR TITLE
[docs] add step to configure externalDomain

### DIFF
--- a/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
+++ b/modules/ROOT/pages/deployment/container/orchestration/orchestration.adoc
@@ -352,6 +352,13 @@ minikube tunnel
 :t1_text: Helm chart with default configurations.
 :t2_text: Description of the values.yaml file.
 
+* Add accessible oCIS domain to `externalDomain` in `values.yaml`
++
+[source,yaml]
+----
+externalDomain: "ocis.kube.owncloud.test"
+----
+
 * When installing Infinite Scale in Minikube on MacOS, you need to set the `hostAliases` option:
 +
 [source,yaml]


### PR DESCRIPTION
### Description
Added an extra step to add accessible oCIS domain in `externalDomain`.
The value of the `externalDomain` was removed in PR https://github.com/owncloud/ocis-charts/pull/562.

If the `externalDomain` is not provided we get the following error:
```console
Error: INSTALLATION FAILED: execution error at (ocis/templates/webfinger/deployment.yaml:61:33): externalDomain needs to be set
```