### PR TITLE
[docs] fix secrets name for s3 credential

### DIFF
--- a/modules/ROOT/examples/deployment/container/orchestration/s3ng-s3-access-key-id-secret-tab-1.yaml
+++ b/modules/ROOT/examples/deployment/container/orchestration/s3ng-s3-access-key-id-secret-tab-1.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: notifications-smtp-secret # default of `secretRefs.s3CredentialsSecretRef`
+  name: s3-credentials-secret # default of `secretRefs.s3CredentialsSecretRef`
 type: Opaque
 data:
   # S3 access key.

--- a/modules/ROOT/examples/deployment/container/orchestration/s3ng-s3-access-key-id-secret-tab-2.yaml
+++ b/modules/ROOT/examples/deployment/container/orchestration/s3ng-s3-access-key-id-secret-tab-2.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: notifications-smtp-secret # default of `secretRefs.s3CredentialsSecretRef`
+  name: s3-credentials-secret # default of `secretRefs.s3CredentialsSecretRef`
 type: Opaque
 data:
   # S3 access key.

--- a/modules/ROOT/examples/deployment/container/orchestration/s3ng-s3-access-key-id-secret-tab-3.yaml
+++ b/modules/ROOT/examples/deployment/container/orchestration/s3ng-s3-access-key-id-secret-tab-3.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: notifications-smtp-secret # default of `secretRefs.s3CredentialsSecretRef`
+  name: s3-credentials-secret # default of `secretRefs.s3CredentialsSecretRef`
 type: Opaque
 data:
   # S3 access key.


### PR DESCRIPTION
### Desctiption
This PR updates the secret name for s3ng storage configuration. The secret name was set same as Email Notification config. So, updated the secret name to `s3-credentials-secret`.