### PR TITLE
Update bare metal deployments

### DIFF
--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -73,7 +73,7 @@ Note that this URL must resolve to the server running this installation.
 
 === Install and configure the Infinite Scale Binary
 
-* Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Replace `<file_url>` and `<version>` in the commands accordingly.
+* Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Replace `<file_url>` and `<file_name>` in the commands accordingly.
 +
 --
 Download the binary:
@@ -88,7 +88,7 @@ sudo wget -P {ocis_bin} <file_url>
 +
 [source,bash,subs="attributes+"]
 ----
-sudo chmod a+x {ocis_bin}/ocis-<version>
+sudo chmod a+x {ocis_bin}/<file_name>
 ----
 
 * Create a link from the versioned ocis binary name to the final executable named `ocis`: +
@@ -96,7 +96,7 @@ Note when using a symbolic link like this, upgrading and/or testing is much easi
 +
 [source,bash,subs="attributes+"]
 ----
-sudo ln -s {ocis_bin}/ocis-<version> {ocis_bin}/ocis
+sudo ln -s {ocis_bin}/<file_name> {ocis_bin}/ocis
 ----
 
 * Check the version installed:

--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -73,26 +73,38 @@ Note that this URL must resolve to the server running this installation.
 
 === Install and configure the Infinite Scale Binary
 
-* Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file.
+* Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Replace `<file_url>` and `<version>` in the commands accordingly.
 +
+--
+Download the source:
+
 [source,bash,subs="attributes+"]
 ----
-sudo wget -O {ocis_bin}/ocis <file_url>
+sudo wget -P {ocis_bin} <file_url>
 ----
+--
 
 * Make the binary executable with:
 +
 [source,bash,subs="attributes+"]
 ----
-sudo chmod +x {ocis_bin}/ocis
+sudo chmod a+x {ocis_bin}/ocis-<version>
+----
+
+* Create a link from the source to the final executable named `ocis`: +
+Note when using a link to the source, upgrading and/or testing is much easier.
++
+[source,bash,subs="attributes+"]
+----
+sudo ln -s {ocis_bin}/ocis-<version> {ocis_bin}/ocis
 ----
 
 * Check the version installed:
 +
 --
-[source,bash]
+[source,bash,subs="attributes+"]
 ----
-ocis version  --skip-services
+ocis version --skip-services
 ----
 
 The output looks like this:
@@ -102,7 +114,11 @@ The output looks like this:
 Version: {compose_version}
 Compiled: {ocis-compiled}
 ----
+
+Note that if you omit `--skip-services`, you will get additional information about services printed.
 --
+
+NOTE: If you already have a running instance, you must stop and restart the instance to activate the new version.
 
 === Create a Service User
 

--- a/modules/ROOT/pages/depl-examples/bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/bare-metal.adoc
@@ -76,7 +76,7 @@ Note that this URL must resolve to the server running this installation.
 * Download and install the Infinite Scale binary. To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Replace `<file_url>` and `<version>` in the commands accordingly.
 +
 --
-Download the source:
+Download the binary:
 
 [source,bash,subs="attributes+"]
 ----
@@ -91,8 +91,8 @@ sudo wget -P {ocis_bin} <file_url>
 sudo chmod a+x {ocis_bin}/ocis-<version>
 ----
 
-* Create a link from the source to the final executable named `ocis`: +
-Note when using a link to the source, upgrading and/or testing is much easier.
+* Create a link from the versioned ocis binary name to the final executable named `ocis`: +
+Note when using a symbolic link like this, upgrading and/or testing is much easier.
 +
 [source,bash,subs="attributes+"]
 ----

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -109,7 +109,7 @@ sudo wget -P {ocis_bin} <file_url>
 sudo chmod a+x {ocis_bin}/<file_name>
 ----
 
-* Create a link from the versione ocis binary to the final executable named `ocis`: +
+* Create a link from the versioned ocis binary to the final executable named `ocis`: +
 Note when using a symbolic link like this, upgrading and/or testing is much easier.
 +
 [source,bash,subs="attributes+"]

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -94,7 +94,7 @@ Congratulations, you now have access to your Infinite Scale instance.
 * To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`. Replace `<file_url>` and `<version>` in the commands accordingly.
 +
 --
-Download the source:
+Download the binary:
 
 [source,bash,subs="attributes+"]
 ----
@@ -109,8 +109,8 @@ sudo wget -P {ocis_bin} <file_url>
 sudo chmod a+x {ocis_bin}/ocis-<version>
 ----
 
-* Create a link from the source to the final executable named `ocis`: +
-Note when using a link to the source, upgrading and/or testing is much easier.
+* Create a link from the versione ocis binary to the final executable named `ocis`: +
+Note when using a symbolic link like this, upgrading and/or testing is much easier.
 +
 [source,bash,subs="attributes+"]
 ----

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -57,7 +57,7 @@ For those who want to skip reading the full document, use this summary of comman
 
 IMPORTANT: With this approach, the system you install Infinite Scale on *must* have a GUI present. A headless system has different requirements and needs an extended setup, see xref:accessing-infinite-scale-other-than-localhost[Accessing Infinite Scale Other Than Localhost].
 
-Define a stable binary to use as replacement for `<file_url>` via {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], replace `<version>` in the command accordingly.
+Define a stable binary to use as replacement for `<file_url>` via {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], replace `<file_name>` in the command accordingly.
 
 [source,bash,subs="attributes+"]
 ----
@@ -66,13 +66,13 @@ sudo wget -P {ocis_bin} <file_url>
 
 [source,bash,subs="attributes+"]
 ----
-sudo chmod a+x {ocis_bin}/ocis-<version>
+sudo chmod a+x {ocis_bin}/<file_name>
 ----
 
 [source,bash,subs="attributes+"]
 ----
 
-sudo ln -s {ocis_bin}/ocis-<version> {ocis_bin}/ocis
+sudo ln -s {ocis_bin}/<file_name> {ocis_bin}/ocis
 ----
 
 [source,bash]
@@ -91,7 +91,7 @@ Congratulations, you now have access to your Infinite Scale instance.
 
 == Installation
 
-* To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`. Replace `<file_url>` and `<version>` in the commands accordingly.
+* To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`. Replace `<file_url>` and `<file_name>` in the commands accordingly.
 +
 --
 Download the binary:
@@ -106,7 +106,7 @@ sudo wget -P {ocis_bin} <file_url>
 +
 [source,bash,subs="attributes+"]
 ----
-sudo chmod a+x {ocis_bin}/ocis-<version>
+sudo chmod a+x {ocis_bin}/<file_name>
 ----
 
 * Create a link from the versione ocis binary to the final executable named `ocis`: +
@@ -114,7 +114,7 @@ Note when using a symbolic link like this, upgrading and/or testing is much easi
 +
 [source,bash,subs="attributes+"]
 ----
-sudo ln -s {ocis_bin}/ocis-<version> {ocis_bin}/ocis
+sudo ln -s {ocis_bin}/<file_name> {ocis_bin}/ocis
 ----
 
 * Check the version installed:

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -66,7 +66,7 @@ sudo wget -P {ocis_bin} <file_url>
 
 [source,bash,subs="attributes+"]
 ----
-sudo chmod a+x {ocis_bin}/<version>
+sudo chmod a+x {ocis_bin}/ocis-<version>
 ----
 
 [source,bash,subs="attributes+"]

--- a/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
+++ b/modules/ROOT/pages/depl-examples/minimal-bare-metal.adoc
@@ -57,16 +57,22 @@ For those who want to skip reading the full document, use this summary of comman
 
 IMPORTANT: With this approach, the system you install Infinite Scale on *must* have a GUI present. A headless system has different requirements and needs an extended setup, see xref:accessing-infinite-scale-other-than-localhost[Accessing Infinite Scale Other Than Localhost].
 
-Define a stable binary to use as replacement for `<file_url>` via {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank].
+Define a stable binary to use as replacement for `<file_url>` via {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], replace `<version>` in the command accordingly.
 
 [source,bash,subs="attributes+"]
 ----
-sudo wget -O {ocis_bin}/ocis <file_url>
+sudo wget -P {ocis_bin} <file_url>
 ----
 
 [source,bash,subs="attributes+"]
 ----
-sudo chmod +x {ocis_bin}/ocis
+sudo chmod a+x {ocis_bin}/<version>
+----
+
+[source,bash,subs="attributes+"]
+----
+
+sudo ln -s {ocis_bin}/ocis-<version> {ocis_bin}/ocis
 ----
 
 [source,bash]
@@ -85,25 +91,31 @@ Congratulations, you now have access to your Infinite Scale instance.
 
 == Installation
 
-* To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`.
+* To get the stable binary from ownCloud, visit {ocis-downloadpage-url}/{download-type}/?sort=time&order=desc[download.owncloud.com,window=_blank], select the version and the platform of choice and copy the link of the file. Check the sort order on the modification date to get the most recent releases on top. Depending on your system and preferences, you may want to save the binary in `{ocis_bin}`. Replace `<file_url>` and `<version>` in the commands accordingly.
 +
 --
-To download use:
+Download the source:
 
 [source,bash,subs="attributes+"]
 ----
-sudo wget -O {ocis_bin}/ocis <file_url>
+sudo wget -P {ocis_bin} <file_url>
 ----
 --
 
 * Make the binary executable with:
 +
---
 [source,bash,subs="attributes+"]
 ----
-sudo chmod +x {ocis_bin}/ocis
+sudo chmod a+x {ocis_bin}/ocis-<version>
 ----
---
+
+* Create a link from the source to the final executable named `ocis`: +
+Note when using a link to the source, upgrading and/or testing is much easier.
++
+[source,bash,subs="attributes+"]
+----
+sudo ln -s {ocis_bin}/ocis-<version> {ocis_bin}/ocis
+----
 
 * Check the version installed:
 +
@@ -123,6 +135,8 @@ Compiled: {ocis-compiled}
 
 Note that if you omit `--skip-services`, you will get additional information about services printed.
 --
+
+NOTE: If you already have a running instance, you must stop and restart the instance to activate the new version.
 
 == Getting Command Line Help
 
@@ -237,46 +251,16 @@ ps ax | grep ocis | grep -v grep
 [source,plaintext]
 ----
  221297 pts/1    Sl     0:04 ocis server
- 221706 pts/0    Sl     0:00 ocis proxy
+ 221706 pts/0    Sl     0:00 ocis notifications
 ----
 
 == Stopping Infinite Scale
 
-Depending on what you want to stop, different commands need to be applied.
+To properly stop Infinite Scale, the signal `SIGTERM` (15) is used. Note that SIGTERM politely asks a process to terminate. It will terminate gracefully, cleaning up all resources (files, sockets, child processes, etc.), deleting temporary files and so on. Do not use `SIGKILL` (9) as this will initiate a dirty shutdown.
 
-If a service is being terminated with its PID, the signal `SIGTERM` (-15) is used. Note that SIGTERM politely asks a process to terminate. It will terminate gracefully, cleaning up all resources (files, sockets, child processes, etc.), deleting temporary files and so on. Do not use `SIGKILL` (-9) as this will initiate a dirty shutdown.
+The following command stops the runtime with all its services plus any extra started services which are not part of the runtime and have been started manually. Depending on the user you started `ocis` with and which user you are currently logged in as, you may need to use `sudo` for the killall command for proper permissions.
 
-Stopping the complete runtime with all its running services::
-Depending on the user you started `ocis` with and which user you are currently logged in as, you may need to use `sudo` for the kill command for proper permissions.
-+ 
 [source,bash]
 ----
-ps -ax | \
-   grep "ocis server" | \
-   grep -v grep | \
-   awk '{ print $1 }' | \
-   xargs sudo kill -15
-----
-
-Stopping a particular ocis PID::
-First identify which PID you want to terminate:
-+
-[source,bash]
-----
-ps ax | grep "ocis" | grep -v grep
-----
-+
-This may give an output like the following:
-+
-[source,plaintext]
-----
- 221297 pts/1    Sl     0:04 ocis server
- 221706 pts/0    Sl     0:00 ocis proxy
-----
-+
-To terminate the `ocis proxy` service type the following command, where `sudo` may not be necessary depending on the permissions of the logged-in user. Replace the PID according the output from above:
-+
-[source,bash]
-----
-sudo kill -15 221706
+killall -v -s 15 ocis
 ----


### PR DESCRIPTION
Fixes: #1052 ([QA] Upgrade procedure fails to shut down ocis when using systemd)
References: https://github.com/owncloud/docs-ocis/pull/1029#pullrequestreview-2436660166

This PR fixes:
* `killall` instead of `kill` for shutting down minimal bare metal
(not bare metal, this uses systemd)
* Improves the binary installation routine by using links

Backport to 5.0 