### PR TITLE
[5.0] Fix attributes which are treated different in this branch

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -15,6 +15,9 @@ asciidoc:
     # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
     s-path: 'deployment/services/s-list'
 
+    # the name of the sub directory that defines the sources used in the compose deployment examples
+    ocis_wopi: ocis_wopi
+
     # note that service_url_component is used for services ONLY
     # service_url_component will be used to assemble the url for services to include content (tables) sourced from the ocis repo.
     service_url_component: 'docs-stable-5.0' # docs for master or when stable, like docs-stable-5.0

--- a/antora.yml
+++ b/antora.yml
@@ -18,6 +18,9 @@ asciidoc:
     # the name of the sub directory that defines the sources used in the compose deployment examples
     ocis_wopi: ocis_wopi
 
+    # this is statically in 5.0 only but computed in master and higher releases 
+    download-type: stable
+
     # note that service_url_component is used for services ONLY
     # service_url_component will be used to assemble the url for services to include content (tables) sourced from the ocis repo.
     service_url_component: 'docs-stable-5.0' # docs for master or when stable, like docs-stable-5.0

--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc
@@ -4,9 +4,6 @@
 :keywords: docker compose, raspberry pi, install, ocis, infinite scale, letsencrypt
 :description: Install Infinite Scale using Docker Compose on the Hetzner Cloud for production use.
 
-// the folder to use for the example
-:ocis_wopi: ocis_wopi
-
 include::partial$multi-location/compose-version.adoc[]
 
 image:depl-examples/ubuntu-compose/ubuntu-basic-teaser-image.png[Teaser Image, width=650]

--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
@@ -4,9 +4,6 @@
 :keywords: docker compose, raspberry pi, install, ocis, infinite scale, letsencrypt
 :description: Install Infinite Scale using Docker Compose on a server for production use.
 
-// the folder to use for the example
-:ocis_wopi: ocis_wopi
-
 include::partial$multi-location/compose-version.adoc[]
 
 image:depl-examples/ubuntu-compose/ubuntu-basic-teaser-image.png[Teaser Image, width=650]


### PR DESCRIPTION
The attribute `download-type` is computed dynamically in master and higher, but are static in 5.0.

The attribute `ocis_wopi` is moved to `antora.yml`. In master and higher it is also in antora.yml but with a different value.