### PR TITLE
Make SMTP_SENDER a mandatory setting

### DIFF
--- a/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
+++ b/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
@@ -63,8 +63,8 @@ The following data needs to be available to configure the Infinite Scale eMail s
 
 [NOTE]
 ====
-* Note that you must configure at minimum the `SMTP_SENDER`, even it is a dummy email like `noreply@example.com`, the deployment will not startup otherwise.
-* Note that if all other data is not available, Infinite Scale will start but no notifications can be sent.
+* You must configure at minimum the `SMTP_SENDER`, even it is a dummy email like `noreply@example.com`, the deployment will not startup otherwise.
+* If all other email data is not available, Infinite Scale will start but no notifications can be sent.
 ====
 
 * `SMTP_HOST` +

--- a/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
+++ b/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
@@ -57,10 +57,16 @@ To access Infinite Scale from the internet, you *must*:
 Note that you can use any domain provider of choice.
 --
 
-eMail (Optional)::
-The following data needs to be available to configure the Infinite Scale eMail setup, see the xref:{s-path}/notifications.adoc[notifications service] for more details. Note that if this data is not available, Infinite Scale will start but no notifications can be sent.
-+
+eMail::
 --
+The following data needs to be available to configure the Infinite Scale eMail setup, see the xref:{s-path}/notifications.adoc[notifications service] for more details.
+
+[NOTE]
+====
+* Note that you must configure at minimum the `SMTP_SENDER`, even it is a dummy email like `noreply@example.com`, the deployment will not startup otherwise.
+* Note that if all other data is not available, Infinite Scale will start but no notifications can be sent.
+====
+
 * `SMTP_HOST` +
 SMTP host to connect to.
 * `SMTP_PORT` +


### PR DESCRIPTION
Change the compose guides to make the SMTP_SENDER a mandatory setting.

As discussed with @kobergj 

Backport to 5.0
