### PR TITLE
Add a note for all services that must be started manually

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -8,6 +8,13 @@
 
 {description} 
 
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that it needs an external antivirus service available and configured.
+====
+
 == Antivirus Configuration
 
 === Antivirus Scanner Type

--- a/modules/ROOT/pages/deployment/services/s-list/audit.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/audit.adoc
@@ -8,6 +8,13 @@
 
 {description} 
 
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that you only need it when you plan to implement auditing.
+====
+
 Supported log formats are `json` or a `minimal` human-readable format. The audit service takes note of actions conducted by users and administrators.
 
 Example minimal format::

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -13,6 +13,15 @@ With the `auth-app` service, you can create tokens that can be used to authentic
 
 To enable `{service_name}`, you first must set `PROXY_ENABLE_APP_AUTH` to `true`.
 
+// just for reference: https://github.com/owncloud/ocis/blob/master/ocis/pkg/runtime/service/service.go#L313-L347
+
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that generating access tokens is security relevant.
+====
+
 == Default Values
 
 * Auth Basic listens on port 9245 by default.

--- a/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/collaboration.adoc
@@ -10,6 +10,13 @@
 
 IMPORTANT: Since this service requires an external document server, it won't start by default when using `ocis server` (xref:deployment/general/general-info.adoc#infinite-scale-supervised-services[supervised mode]). You must start it manually with the `ocis collaboration server` command.
 
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that the service may need to be started multiple times but with own configs for each web office document server used.
+====
+
 Because the collaboration service needs to be started manually, the following prerequisite applies: On collaboration service startup, particular environment variables are required to be populated. If environment variables have a default like the MICRO_REGISTRY_ADDRESS, the default will be used, if not set otherwise. Use for all others the instance values as defined. If these environment variables are not provided or misconfigured, the collaboration service will not start up.
 
 Required environment variables:

--- a/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/invitations.adoc
@@ -11,6 +11,13 @@
 *   Users invited via the Invitation Manager (via the LibreGraph API) will have the `userType="Guest"`.
 *   Users belonging to the organization have the `userType="Member"`.
 
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that you need upfront a business decision if your organisation will allow inviting external users.
+====
+
 == Provisioning Backends
 
 When Infinite Scale is used via the IDM service for the user management, users are created using the `/graph/v1.0/users` endpoint via the LibreGraph API. For larger deployments, the Keycloak admin API can be used to provision users. In a future step, the endpoint, credentials and body might be made configurable using templates.

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -9,7 +9,12 @@
 
 {description} To do this, it hooks into the event system and listens for certain events that the users need to be informed about. As an example, when a user is added to a share, a notification email will be sent to the user.
 
-Note that the {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that the service will block starting up all other services if the `NOTIFICATIONS_SMTP_SENDER` environment variable is not set. The value can be the real or a placeholder email address for startup testing purposes. 
+====
 
 == Default Values
 

--- a/modules/ROOT/pages/deployment/services/s-list/policies.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/policies.adoc
@@ -8,6 +8,13 @@
 
 {description} 
 
+[NOTE]
+====
+* The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
+
+* The reason for excluding the {service_name} service from autostart is, that you must have a defined rulset available. If the ruleset is not available, the {service_name} service will prevent other services from starting up.
+====
+
 Policies are written in the https://www.openpolicyagent.org/docs/latest/policy-language/[Rego query language, window=_blank]. The location of the Rego files can be configured via yaml. A configuration using environment variables is not possible.
 
 == Default Values


### PR DESCRIPTION
This PR adds a note to all services that are excluded from autostart and must be started manually.

Here is the [code reference](https://github.com/owncloud/ocis/blob/master/ocis/pkg/runtime/service/service.go#L313-L347) in the ocis repo.

No backport, because half of the services did not exist in 5.0