### PR TITLE
The antivirtus service has additional memory requirements

### DIFF
--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc
@@ -40,8 +40,9 @@ At minimum and at the time of writing, type _CX22_ (2 shared Intel CPU's with 4G
 About 2.4GB of disk space is needed for the default enabled services as you not only get Infinite Scale but also office packages for online collaboration and other required software to run this setup.
 ** Depending on Hetzner's offers, an embedded diskspace of 40GB is included as part of the server. When the server is reset, the diskspace and ALL of its data is lost. Consider configuring independent volumes which can be sized according your needs but are at an extra monthly charge. Note that you can start with embedded disk space and reconfigure afterwards. See the xref:volumes[Volumes] description for an explanation of the term volume.
 
-* Memory +
-We recommend at minimum 4-6GB of memory. 
+* Memory
+** We recommend at minimum 4-6GB of memory.
+** If you plan to enable antivirus scanning, see the memory consideration section in the xref:{s-path}/antivirus.adoc[antivirus] service for additional memory requirements.
 ====
 
 === Knowledge Stack

--- a/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
+++ b/modules/ROOT/pages/depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc
@@ -38,8 +38,9 @@ This guide describes an installation of Infinite Scale based on Ubuntu LTS and d
 * Disk space +
 About 2.4GB of disk space is needed for the default enabled services as you not only get Infinite Scale but also office packages for online collaboration and other required software to run this setup. If not otherwise defined, this guide uses docker managed volumes. See the xref:volumes[Volumes] description for an explanation of the term volume.
 
-* Memory +
-We recommend at minimum 4-6GB of memory. 
+* Memory
+** We recommend at minimum 4-6GB of memory.
+** If you plan to enable antivirus scanning, see the memory consideration section in the xref:{s-path}/antivirus.adoc[antivirus] service for additional memory requirements. 
 ====
 
 === Knowledge Stack

--- a/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/antivirus.adoc
@@ -15,6 +15,22 @@
 * The reason for excluding the {service_name} service from autostart is, that it needs an external antivirus service available and configured.
 ====
 
+== Memory Considerations
+
+The antivirus service can consume considerably amounts of memory. This is relevant to provide or define sufficient memory for the deployment selected. To avoid out of memory (OOM) situations, the following equation gives a rough overview based on experiences made. The memory calculation comes without any guarantee, is intended as overview only and subject of change.
+
+`memory limit` = `max file size` x `workers` x `factor 8 - 14`
+
+With:
+
+`ANTIVIRUS_WORKERS` == 1
+
+[source,plaintext]
+----
+ 50MB file --> factor 14   --> 700MB memory
+844MB file --> factor  8,3 -->   7GB memory
+----
+
 == Antivirus Configuration
 
 === Antivirus Scanner Type


### PR DESCRIPTION
Fixes: #1042 (Antivirus and memory consumption)
References: https://github.com/owncloud/ocis/pull/10681 ([docs-only] Add memory considerations to the antivirus service)

This info is necessary for any deployment and in particular referenced in the compose deployment examples.