### PR TITLE
[5.0] [PR 1073] Add metrics info for stand alone services

### DIFF
--- a/modules/ROOT/pages/monitoring/prometheus.adoc
+++ b/modules/ROOT/pages/monitoring/prometheus.adoc
@@ -18,7 +18,7 @@ In single process mode, all Infinite Scale services are running inside a single 
 
 Standalone Mode::
 // grep -rl metrics.Metrics | sort | sed 's/\/.*$//' | uniq
-In this mode, a servic has been started independent and outside the single process mode. Either via an own defined service startup or a startup as own container via docker. The metrics of the following services are exposed on their own metrics endpoint:
+In this mode, a service has been started independently and outside the single process mode. Either via an own defined service startup or a startup as own container via docker. The metrics of the following services are exposed on their own metrics endpoint:
 +
 [source,plaintext]
 ----

--- a/modules/ROOT/pages/monitoring/prometheus.adoc
+++ b/modules/ROOT/pages/monitoring/prometheus.adoc
@@ -11,13 +11,32 @@
 The Infinite Scale proxy service exposes metrics in the prometheus format. These metrics are exposed on the `/metrics` endpoint. There are two ways to run the ocis proxy service which has an impact on the number of metrics exposed.
 
 Single Process Mode::
-In the single process mode, all Infinite Scale services are running inside a single process. This is the default mode when using the `ocis server` command to start the services. In this mode, the proxy service exposes metrics about the proxy service itself and about the services it is proxying. This is due to the nature of the prometheus registry which is a singleton.
+In single process mode, all Infinite Scale services are running inside a single process. This is the default mode when using the `ocis server` command. It is also partially true with the docker compose examples (There, both the single process and standalone mode is used). In this mode, the proxy service exposes metrics about the proxy service itself and about the services it is proxying. This is due to the nature of the prometheus registry which is a singleton.
 
 * Metrics exposed by the proxy service itself are prefixed with `ocis_proxy_`.
 * Metrics exposed by other ocis services are prefixed with `ocis_<service-name>_`.
 
 Standalone Mode::
-In this mode, the proxy service only exposes its own metrics. The metrics of the other ocis services are exposed on their own metrics endpoints.
+// grep -rl metrics.Metrics | sort | sed 's/\/.*$//' | uniq
+In this mode, a servic has been started independent and outside the single process mode. Either via an own defined service startup or a startup as own container via docker. The metrics of the following services are exposed on their own metrics endpoint:
++
+[source,plaintext]
+----
+activitylog
+eventhistory
+graph
+idp
+invitations
+ocs
+proxy
+search
+settings
+thumbnails
+userlog
+webdav
+webfinger
+web
+----
 
 === Available Metrics
 

--- a/modules/ROOT/pages/monitoring/prometheus.adoc
+++ b/modules/ROOT/pages/monitoring/prometheus.adoc
@@ -22,7 +22,6 @@ In this mode, a service has been started independently and outside the single pr
 +
 [source,plaintext]
 ----
-activitylog
 eventhistory
 graph
 idp


### PR DESCRIPTION
Backport of #1073

The activitylog has been removed because it is not present in 5.0