### PR TITLE
Update auth-app: API access

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -45,6 +45,8 @@ PROXY_ENABLE_APP_AUTH=true      # mandatory, allow app authentication. In case o
 
 == App Tokens
 
+=== Via CLI 
+
 App Tokens are used to authenticate 3rd party access via https like when using curl (apps) to access an API endpoint. These apps need to authenticate themselves, as no logged in user authenticates the request. To be able to use an app token, one must first create a token via the cli. Replace the `user-name` with an existing Infinite Scale user. For the `token-expiration`, you can use any time abbreviation from the following list: `h, m, s`. Examples: `72h` or `1h` or `1m` or `1s.` Default is `72h`.
 
 [source,bash]
@@ -53,6 +55,100 @@ ocis auth-app create --user-name={user-name} --expiration={token-expiration}
 ----
 
 Once generated, these tokens can be used to authenticate requests to ocis. They are passed as part of the request as `Basic Auth` header.
+
+=== Via API
+
+An in-depth method to manage tokens is to use the API, which needs a bit more preperation, but offers more possibilities. 
+
+The `auth-app` service provides an API to create (POST), list (GET) and delete (DELETE) tokens at the `/auth-app/tokens` endpoint.
+
+When using curl for the respective command, you need to authenticate with a header. To do so, get from the browsers developer console the currently active bearer token. Consider that this token has a short lifetime. In any example, replace `<your host[:port]>` with the URL:port of your Infinite Scale instance, and `\{token}`  `\{value}` accordingly.
+
+IMPORTANT: The active bearer token authenticates the user the token was issued for. Which means that any action taken and any output printed is only valid for the user authenticated.
+
+* **Create a token** +
+It is likely more convenient to generate a user token with the ocis command described above. +
+The POST request requires:
+** An `expiry` key/value pair in the form of `expiry=<number><h|m|s>` +
+   Example: `expiry=72h`
+** An active bearer token. +
+To get an active bearer token, see the xref:maintenance/space-ids/space-ids.adoc#via-cli[Preparation] section of the referenced document for more details.
+
++
+--
+.Command
+[source,bash]
+----
+curl --request POST 'https://<your host:9200>/auth-app/tokens?expiry={value}' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer {token}'
+----
+
+.Example output:
+[source,plaintext]
+----
+{
+"token": "3s2K7816M4vuSpd5",
+"expiration_date": "2024-08-08T13:42:42.796888022+02:00",
+"created_date": "2024-08-07T13:42:42+02:00",
+"label": "Generated via API"
+}
+----
+--
+
+* **List tokens** +
+The GET request only requires an active bearer token for authentication.
++
+--
+To get an active bearer token, see the xref:maintenance/space-ids/space-ids.adoc#via-cli[Preparation] section of the referenced document for more details.
+
+Note that `--request GET` is technically not required because it is curl default. 
+
+.Command
+[source,bash]
+----
+curl --request GET 'https://<your host:9200>/auth-app/tokens' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer {token}'
+----
+
+.Example output:
+[source,plaintext]
+----
+[
+  {
+    "token": "$2a$11$EyudDGAJ18bBf5NG6PL9Ru9gygZAu0oPyLawdieNjGozcbXyyuUhG",
+    "expiration_date": "2024-08-08T13:44:31.025199075+02:00",
+    "created_date": "2024-08-07T13:44:31+02:00",
+    "label": "Generated via Impersonation API"
+  },
+  {
+    "token": "$2a$11$dfRBQrxRMPg8fvyvkFwaX.IPoIUiokvhzK.YNI/pCafk0us3MyPzy",
+    "expiration_date": "2024-08-08T13:46:41.936052281+02:00",
+    "created_date": "2024-08-07T13:46:42+02:00",
+    "label": "Generated via Impersonation API"
+  }
+]
+----
+--
+
+* **Delete a token** +
+  The DELETE request requires:
+** A `token` key/value pair in the form of `token=<token_issued>` +
+    Example: `token=Z3s2K7816M4vuSpd5`
+** An active bearer token +
+To get an active bearer token, see the xref:maintenance/space-ids/space-ids.adoc#via-cli[Preparation] section of the referenced document for more details.
+
++
+--
+.Command
+[source,bash]
+----
+curl --request DELETE 'https://<your host:9200>/auth-app/tokens?token={value}' \
+     --header 'accept: application/json' \
+     --header 'authorization: Bearer {token}'
+----
+--
 
 == Configuration
 

--- a/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/auth-app.adoc
@@ -135,7 +135,7 @@ curl --request GET 'https://<your host:9200>/auth-app/tokens' \
 * **Delete a token** +
   The DELETE request requires:
 ** A `token` key/value pair in the form of `token=<token_issued>` +
-    Example: `token=Z3s2K7816M4vuSpd5`
+    Example: `token=$2a$11$EyudDGAJ18bBf5NG6PL9Ru9gygZAu0oPyLawdieNjGozcbXyyuUhG`
 ** An active bearer token +
 To get an active bearer token, see the xref:maintenance/space-ids/space-ids.adoc#via-cli[Preparation] section of the referenced document for more details.
 


### PR DESCRIPTION
References: https://github.com/owncloud/ocis/pull/10620 ([docs-only] Describe CLI-API commands in auth-app to manage tokens)

The auth-app can manage tokens via the API. Content is taken from the dev docs + adaptions for admin docs.