### PR TITLE
Changes necessary for ocis 7.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "master"
+    latest_version = "7.0"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 7.0 branch.

* The 7.0 branch is already pushed and prepared and is included in the branch protection rules.

@phil-davis
Post merging this, we need to backport all relevant changes to 7.0