### PR TITLE
Changes necessary for 7.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "7.0"
+    latest_version = "7.1"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/antora.yml
+++ b/antora.yml
@@ -51,7 +51,7 @@ asciidoc:
 
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc
-    env_var_delta_name: '5.0.0-7.0.0'
+    env_var_delta_name: '7.0.0-7.1.0'
 
     # helm_tab_x will be used to assemble the url (tag) accessing the raw content for helm charts (tag)
     # note that tab 2 always contains the actual release and tab 3 the former

--- a/site.yml
+++ b/site.yml
@@ -30,8 +30,8 @@ asciidoc:
     # Versions mainly for printing like in docs-main release info.
     # Versions in the ocis docs need to be defined in the branch specific docs-ocis/antora.yaml file.
     # To do so, change the values in the branch of docs-ocis/antora.yml like service_xxx and compose_xxx.
-    ocis-actual-version: '7.0.0'
-    ocis-former-version: '5.0.9'
+    ocis-actual-version: '7.1.0'
+    ocis-former-version: '7.0.0'
     # Needed in docs-ocis to define which rolling release to print like in the envvars table
     ocis-rolling-version: '6.6.1'
   extensions:


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 7.1 branch.

* The 7.1 branch is already pushed and prepared and is included in the branch protection rules.

* When 7.1 is finally out, the 5.0 branch can be archived, see step 3 in [Create a New Version Branch](https://github.com/owncloud/docs-ocis/blob/master/docs/new-version-branch.md)

* Note, that the 7.1 branch in this repo is already created, but the `latest` pointer on the web will be set to it automatically when the tag in oics is set. This means, that in the docs homepage, `latest` will point to 7.0 until the tag in ocis is set accordingly. When merging the corresponding doc PR, 5.0 will be dropped from the web.

* Note that this PR must be merged **before** the 7.1 tag in ocis is set to avoid a 404 for `latest`.

* Note before merging this PR, we should take care that 5.0 has all necessary changes merged.

@kobergj fyi

@phil-davis
Post merging this, we need to backport all relevant changes to 7.1