### PR TITLE
Fix the delta range for envvars

### DIFF
--- a/modules/ROOT/pages/deployment/services/env-var-changes.adoc
+++ b/modules/ROOT/pages/deployment/services/env-var-changes.adoc
@@ -1,6 +1,6 @@
 # Changed Environment Variables in Versions
 :toc: right
-:description: This page contains tables with added and removed environment variables between Infinite Scale version 5.0.x and 7.0.0.
+:description: This page contains tables with added and removed environment variables between Infinite Scale version 7.0.0 and 7.1.0.
 
 :source_path: {ocis_services_raw_url}{service_url_component}{ocis_services_final_path}adoc/env-var-deltas/
 // https://raw.githubusercontent.com/owncloud/ocis/docs-stable-7.0/services/_includes/adoc/env-var-deltas/


### PR DESCRIPTION
As a first fix, the PR updates the delta range for changed envvars.

Backport to 7.1