### PR TITLE
Changes for 7.1

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -104,7 +104,7 @@ To initiate sending grouped emails like via a cron job, use the following comman
 ocis notifications send-email
 ----
 
-Note that the command *mandatory* requires at least one option which is `--daily` or `--weekly`. Note that both options can be used together.
+Note that at least one option, `--daily` or `--weekly`, must be provided. Both options can be used together.
 
 == Storing
 

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -88,6 +88,32 @@ In the latter case, image files must be located in the `templates/html/img` subf
 :envvar_name: NOTIFICATIONS_TRANSLATION_PATH
 include::partial$deployment/services/translations.adoc[]
 
+== Sending Grouped Emails
+
+
+The {service_name} service can initiate sending emails based on events stored in the configured store that are grouped into a `daily` or `weekly` bucket. These groups contain events that get populated e.g. when the user configures daily or weekly email notifications in his personal settings in the web UI. The notification settings are only visible in the web UI when enabled via the enironment variable xref:{s-path}/frontend.adoc[FRONTEND_CONFIGURABLE_NOTIFICATIONS]. If enabled and a user does not define any of the named groups for notification events, no event is stored.
+
+Grouped events are stored for the TTL defined in `OCIS_PERSISTENT_STORE_TTL`. This TTL can either be configured globally or individually for the notification service via the `NOTIFICATIONS_STORE_TTL` environment variable.
+
+Grouped events that have passed the TTL are removed automatically without further notice or sending!
+
+To initiate sending grouped emails like via a cron job, use the following command:
+
+[source,bash]
+----
+ocis notifications send-email
+----
+
+Note that the command *mandatory* requires at least one option which is `--daily` or `--weekly`. Note that both options can be used together.
+
+== Storing
+
+// renders dependent on is_cache or is_store
+:is_store: true
+
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
+
 == Event Bus Configuration
 
 include::partial$multi-location/event-bus.adoc[]

--- a/modules/ROOT/pages/deployment/services/s-list/settings.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/settings.adoc
@@ -42,6 +42,10 @@ Services can set or query Infinite Scale *setting values* of a user from setting
 
 The settings service needs to know the IDs of service accounts but it doesn't need their secrets. Currently only one service account can be configured which has the admin role. This can be set with the `SETTINGS_SERVICE_ACCOUNT_ID_ADMIN` envvar, but it will also pick up the global `OCIS_SERVICE_ACCOUNT_ID` envvar. Also see the xref:{s-path}/auth-service.adoc[auth-service] service description for additional details.
 
+// include common translations text
+:envvar_name: SETTINGS_TRANSLATION_PATH
+include::partial$deployment/services/translations.adoc[]
+
 == Default Language
 
 The default language can be defined via the `OCIS_DEFAULT_LANGUAGE` environment variable. If this variable is not defined, English will be used as default. The value has the ISO 639-1 format ("de", "en", etc.) and is limited to the list of supported languages. This setting can be used to set the default language for notification and invitation emails.

--- a/modules/ROOT/pages/maintenance/commands/changed-cli.adoc
+++ b/modules/ROOT/pages/maintenance/commands/changed-cli.adoc
@@ -1,6 +1,6 @@
 = Changed or Added CLI Commands
 :toc: right
-:description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 5.0.x and 7.0.0.
+:description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 7.0.0 and 7.1.0.
 
 == Introduction
 
@@ -10,34 +10,5 @@
 
 See the link for a detailed description of the respective CLI command if available.
 
-* xref:maintenance/commands/commands.adoc#auth-tokens[Auth-Tokens] +
+* xref:maintenance/commands/commands.adoc#sending-grouped-emails[Sending Grouped Emails] +
 The `ocis auth-app create` command allows creating tokens to authenticate 3rd party access.
-
-* xref:maintenance/commands/commands.adoc#cleanup-orphaned-shares[Cleanup Orphaned Shares] +
-The `ocis shares cleanup` command allows for removing share orphans that occur when a shared space or directory got deleted.
-
-* xref:maintenance/commands/commands.adoc#manage-expired-uploads[Manage Expired Uploads] +
-The `ocis storage-users uploads sessions --restart` command got an alternative `--resume` option. +
-Resume can be used in the same way as restart with a slightly different behavior.
-
-* xref:maintenance/commands/commands.adoc#purge-expired-space-trash-bin-items[Purge Expired Space Trash-Bin Items]  +
-The `ocis storage-users uploads` got restructured. +
-The deprecated `list` option is now removed, the `clean` option is now part of the `sessions command`.
-
-* xref:maintenance/commands/commands.adoc#resume-post-processing[Resume Post-Processing] +
-The `ocis postprocessing restart` command got an alternative `resume` option. +
-Resume can be used in the same way as restart with a slightly different behavior.
-
-* xref:maintenance/commands/commands.adoc#reset-password-for-idm-users[Reset Password for IDM Users] +
-The `ocis idm resetpassword` can now specify the user name via the `--user-name` (`-u`) flag.
-
-* xref:maintenance/commands/commands.adoc#revisions-cleanup[Revisions Cleanup] +
-The `ocis revisions purge` command allows removing revisions of files in the storage. Note that this command has also been backported to version 5 available with its latest release.
-
-* xref:maintenance/commands/commands.adoc#service-health[Service Health] +
-A `health` command has been added to each service: `ocis <service-name> health`.
-
-* xref:maintenance/commands/commands.adoc#trash-purge[Trash Purge]. +
-The `ocis trash purge-empty-dirs` command allows removing empty folders from the trashbin.
-
-* The `ocis graph list-unified-roles` command simplifies the process of finding out which UID belongs to which role. Note that this command is described in the https://github.com/owncloud/ocis/tree/master/ocis#list-unified-roles[ocis repository, window=_blank] and has been added for completeness only.

--- a/modules/ROOT/pages/maintenance/commands/commands.adoc
+++ b/modules/ROOT/pages/maintenance/commands/commands.adoc
@@ -111,3 +111,7 @@ If post-processing fails in one step due to an unforeseen error, current uploads
 A xref:maintenance/commands/rolling-back-and-forward.adoc[CLI command] is provided to roll back or roll forward a decomposedfs migration.
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
+
+=== Sending Grouped Emails
+
+This command is about sending emails based on events stored in a named group bucket. See the xref:{s-path}/notifications.adoc#sending-grouped-emails[Sending Grouped Emails] section in the _notification_ service for details.

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -19,6 +19,20 @@ IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrad
 
 IMPORTANT: When upgrading from an older release to the desired one, mandatory configuration settings may have been added or removed. To see the changes required, you can run `ocis init --diff` after upgrading but before finally starting. For more details, see the xref:deployment/general/ocis-init.adoc[ocis init command] description.
 
+== Version 7.0.0 to 7.1.0
+
+=== Notable Changes Requiring Manual Intervention
+
+There are no notable changes requiring manual intervention in Infinite Scale 7.1
+
+=== Breaking Changes Requiring Manual Intervention
+
+There are no breaking changes in Infinite Scale 7.1
+
+=== Upgrade Steps
+
+For a detailed description of the steps to upgrade, see the xref:migration/upgrading_7.0.0_7.1.0.adoc[Upgrading from 7.0.0 to 7.1.0] documentation. Note that this document also contains references to added/changed/removed CLI commands and environment variables.
+
 == Version 5.0.x to 7.0.0
 
 === Notable Changes Requiring Manual Intervention

--- a/modules/ROOT/pages/migration/upgrading_7.0.0_7.1.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.0.0_7.1.0.adoc
@@ -1,0 +1,104 @@
+= Upgrading from 7.0.0 to 7.1.0
+:toc: right
+:description: This document describes the necessary steps when upgrading Infinite Scale from release 7.0.0 to 7.1.0.
+
+:actual_seven_version: 7.1.0
+
+include::partial$multi-location/compose-version.adoc[]
+
+== Introduction
+
+{description}
+
+IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#introduction[Upgrading Infinite Scale] documentation before you start.
+
+IMPORTANT: Check below, if you are affected by breaking changes and prepare all steps mentioned before you start the upgrade.
+
+== Upgrade Steps
+
+. Download and install Infinite Scale +
+*Do not start it after downloading the binary or image*!
+. Shut down the Infinite Scale instance
+. We strongly recommend doing a backup
+. Reconfigure the deployment
+. Manage Breaking Changes
+. Start Infinite Scale
+
+:sectnums:
+
+== Download and Install Infinite Scale
+
+Download and install Infinite Scale via:
+
+=== Binary
+
+Follow the xref:depl-examples/minimal-bare-metal.adoc#installation[Installation] section of the bare metal deployment example.
+
+=== Image Based Deployments
+
+* Issue the following command to download the new image:
++
+[source,bash,subs="attributes+"]
+----
+docker pull owncloud/ocis:{actual_seven_version}
+----
+
+== Shut Down the Infinite Scale Instance
+
+Depending how you deployed Infinite Scale, you need to shut it down differently.
+
+* *Binary* +
+For binary deployments, do a graceful shutdown as described in xref:depl-examples/minimal-bare-metal.adoc#stopping-infinite-scale[Stopping Infinite Scale].
+
+* *docker run* +
+For depoyments using `docker run` do a graceful shutdown as described in xref:depl-examples/container-setup.adoc#stop-a-running-container[Stop a Running Container].
+
+* *docker compose* +
+For deployments using `docker compose` do a graceful shutdown as described in xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#stop-the-deployment[Stop the Deployment].
+
+* *Any other image based deployment* +
+For any other image based deployment, shut down Infinite Scale according the vendors deployment description.
+
+== Backup of Infinite Scale
+
+See the xref:maintenance/b-r/backup_considerations.adoc[Backup Considerations] and the xref:maintenance/b-r/backup.adoc[Backup] documentation for more details.
+
+== Reconfigure the Deployment
+
+Reconfigure the deployment to use the new image:
+
+* For binary, nothing extra needs to be done
+
+* When using `docker run`
+** Update the image version used in the docker run command.
+
+* When using `docker compose`
+** Update _every_ compose file where the `ocis image` is referenced accordingly.
+** If you have used the deployment examples either for xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] or xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner], read the *Updating and Upgrading* section of those pages carefully. 
+
+== Manage Breaking Changes
+
+* There are no breaking changes in Infinite Scale 7.1
+
+== Reconfigure web Office Document Deployments
+
+The following steps are based on the xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] deployment example. The steps are identical for the xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner].
+
+* Backup the the base folder containing the existing deployment example by renaming it. +
+You will need your configuration details with the new example.
+
+* Follow the xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#download-and-transfer-the-example[Download and Transfer Example] to get the new deployment and extract it as described in the following section of the guide.
+
+* Reconfigure the new `.env` file based on settings made in the `.env` file of the backup.
+
+== Start Infinite Scale
+
+When you have finished upgrading, you now can start Infinite Scale as ususal.
+
+For any deployment used, you now can delete/remove old binaries or images/containers.
+
+:sectnums!:
+
+== Changed or Added CLI Commands
+
+See the xref:maintenance/commands/changed-cli.adoc[Changed or Added CLI Commands] document for details.

--- a/modules/ROOT/pages/migration/upgrading_7.0.0_7.1.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.0.0_7.1.0.adoc
@@ -93,7 +93,7 @@ You will need your configuration details with the new example.
 
 == Start Infinite Scale
 
-When you have finished upgrading, you now can start Infinite Scale as ususal.
+When you have finished upgrading, you now can start Infinite Scale as usual.
 
 For any deployment used, you now can delete/remove old binaries or images/containers.
 


### PR DESCRIPTION
Fixes: #1111 (Notification Service gets a store and a CLI command)
Fixes: #1104 (Settings Service gets Translations)
References: https://github.com/owncloud/docs/pull/5007 (Enable ocis 7.1)

* Add new CLI in maintenance section
* Add notification service changes
* Add settings service changes
* Update Migration and Upgrade guide
(Note that the release notes will point to them)

A local build runs fine.

Language review welcomed.

Backport to 7.1