### PR TITLE
Tip for adding notification service

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -15,7 +15,7 @@
 
 * The reason for excluding the {service_name} service from autostart is, that the service will block starting up all other services if the `NOTIFICATIONS_SMTP_SENDER` environment variable is not set. The value can be the real or a placeholder email address for startup testing purposes.
 
-* Once the notification service is configured, it can be added to startup using the (xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[`OCIS_ADD_RUN_SERVICES`] environmental variable.
+* Once the notification service is configured, it can be added to startup using the xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[`OCIS_ADD_RUN_SERVICES`] environmental variable.
 ====
 
 == Default Values

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -15,7 +15,7 @@
 
 * The reason for excluding the {service_name} service from autostart is, that the service will block starting up all other services if the `NOTIFICATIONS_SMTP_SENDER` environment variable is not set. The value can be the real or a placeholder email address for startup testing purposes.
 
-* Once the notification service is configured, it can be added to startup using the xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[`OCIS_ADD_RUN_SERVICES`] environmental variable.
+* Once the {service_name} service is configured, it can be added to startup using the xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[`OCIS_ADD_RUN_SERVICES`] environmental variable.
 ====
 
 == Default Values

--- a/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/notifications.adoc
@@ -13,7 +13,9 @@
 ====
 * The {service_name} service does not start automatically and must be started manually. For more details see the xref:deployment/general/general-info.adoc#start-infinite-scale[Start Infinite Scale] section.
 
-* The reason for excluding the {service_name} service from autostart is, that the service will block starting up all other services if the `NOTIFICATIONS_SMTP_SENDER` environment variable is not set. The value can be the real or a placeholder email address for startup testing purposes. 
+* The reason for excluding the {service_name} service from autostart is, that the service will block starting up all other services if the `NOTIFICATIONS_SMTP_SENDER` environment variable is not set. The value can be the real or a placeholder email address for startup testing purposes.
+
+* Once the notification service is configured, it can be added to startup using the (xref:deployment/services/env-vars-special-scope.adoc#special-environment-variables[`OCIS_ADD_RUN_SERVICES`] environmental variable.
 ====
 
 == Default Values


### PR DESCRIPTION
Follow on to #925 - add a note about using `OCIS_ADD_RUN_SERVICES` to enable the notification service.