### PR TITLE
Simplify attribute usage and paths

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -22,35 +22,37 @@ asciidoc:
     # https://github.com/owncloud/ocis-charts/tree/master/charts/ocis/docs
     s-path: 'deployment/services/s-list'
 
-    # the name of the sub directory that defines the sources used in the compose deployment examples
+    # the name of the sub directory that defines the sources folder used in the compose deployment examples
     ocis_wopi: ocis_full
 
     # note that service_url_component is used for services ONLY
-    # service_url_component will be used to assemble the url for services to include content (tables) sourced from the ocis repo.
-    service_url_component: 'docs' # docs for master or for stable, like docs-stable-5.0
+    # service_url_component will be used to assemble the url for services to include content (tables)
+    # sourced from the ocis repo.
+    # 'docs' for the next branch or 'docs-stable-7.0' for a production branch
+    service_url_component: 'docs'
 
-    # defines the url path component when accessing the ocis repo for versioned data includes 
-    ocis_repo_url_component: 'master' # master for master or for stable, like stable-5.0
+    # defines the url path component when accessing the ocis repo for versioned data includes or examples
+    # 'master' for the next branch or 'stable-7.0' for a production branch
+    ocis_repo_url_component: 'master'
 
     # service_tab_text will be used as tab text shown for the tables in services only
     # note when literally changing the word 'master' to something else, you also must adapt 'env-and-yaml.adoc'.
     # this does not apply to branched releases using semver, only to the master branch! 
-    service_tab_text: 'master' # latest stable including patch releases like 5.0.0
+    # 'master' for the next branch or '7.0.0' for a production branch including patch releases like `7.0.1'
+    service_tab_text: 'master'
 
     # note that compose_url_component is used for compose examples and for the EULA ONLY
     # compose_url_component will be used to assemble the url (tag) accessing the link for the services (tag)
-    compose_url_component: 'master' # latest stable including patch releases like v5.0.0 (note the v ! as it is tagged)
+    # 'master' for the next branch or 'v7.0.0' for a production branch including patch releases like `v7.0.1'
+    # note the v ! as it is tagged
+    compose_url_component: 'master'
 
     # compose_tab_text will be used as tab text for examples and all other stuff but not services
-    compose_tab_text: 'master' # latest stable including patch releases like 5.0.0
-
-    # use this attribute to define the branch name for git clone
-    # the value is usually identical to compose_tab_text, but it should be separable to be independent
-    # note that you must define a value and not an attribute from above 
-    compose_git_name: 'master' # latest stable including patch releases like 5.0.0 (must be without v !)
+    # 'master' for the next branch or '7.0.0' for a production branch including patch releases like `7.0.1'
+    compose_tab_text: 'master'
 
     # this is the first part of the name for envvars between major versions that will be added or removed
-    # example for full name: 4.0.0-5.0.0-added.adoc or 4.0.0-5.0.0-removed.adoc
+    # example for full name: 7.0.0-7.1.0-added.adoc or 7.0.0-7.1.0-removed.adoc
     env_var_delta_name: '7.0.0-7.1.0'
 
     # set attributes defining path components which will be assembled in the document

--- a/modules/ROOT/pages/additional-information/knowledge-base.adoc
+++ b/modules/ROOT/pages/additional-information/knowledge-base.adoc
@@ -21,7 +21,7 @@ Implementing a brute force protection against failing login attempts is somethin
 
 == CORS Settings with Keycloak
 
-When looking at the {download-gh-directory-url}?url={compose_url}v{compose_version}{compose_final_path}/ocis_keycloak[ocis_keycloak,window=_blank] deployment example on github, in particular the file `ocis_keycloak/config/keycloak/ocis-realm.dist.json`, you will find the following setting responsible for CORS inside Infnite Scale:
+When looking at the {download-gh-directory-url}?url={compose_url}{compose_version}{compose_final_path}/ocis_keycloak[ocis_keycloak,window=_blank] deployment example on github, in particular the file `ocis_keycloak/config/keycloak/ocis-realm.dist.json`, you will find the following setting responsible for CORS inside Infnite Scale:
 
 [source,yaml]
 ----

--- a/modules/ROOT/pages/deployment/general/general-info.adoc
+++ b/modules/ROOT/pages/deployment/general/general-info.adoc
@@ -2,8 +2,6 @@
 :toc: right
 :description: This document covers general aspects of Infinite Scale like start modes, services, important minimum configuration etc. for a common understanding.
 
-include::partial$multi-location/compose-version.adoc[]
-
 == Introduction
 
 {description}
@@ -632,7 +630,7 @@ This is the local path the where Infinite Scale stores all data except the confi
 This is the local path where the Infinite Scale configuration is stored. When listing the content, you must see the file `ocis.yaml`. See the important information when using xref:docker-volumes[Docker Volumes].
 
 * `<ocis-version>` +
-The Infinite Scale version used like `latest` or `{compose_version}` or ... .
+The Infinite Scale version used like `latest` or `{ocis-actual-version}` or ... .
 +
 --
 [source,bash]

--- a/modules/ROOT/pages/deployment/services/s-list/graph.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/graph.adoc
@@ -66,7 +66,7 @@ To use the graph service for managing (create, update, delete) users and groups,
 
 * The LDAP server must provide the `inetOrgPerson` object class for users and the `groupOfNames` object class for groups.
 
-* The graph service maintains a few additional attributes for users and groups that are not available in the standard LDAP schema. A schema file (ldif), ready to use with OpenLDAP defining those additional attributes, is available: {compose_url}v{compose_version}{compose_final_path}/ocis_ldap/config/ldap/schemas/[here,window=_blank].
+* The graph service maintains a few additional attributes for users and groups that are not available in the standard LDAP schema. A schema file (ldif), ready to use with OpenLDAP defining those additional attributes, is available: {compose_url}{compose_version}{compose_final_path}/ocis_ldap/config/ldap/schemas/[here,window=_blank].
 
 == Query Filters Provided by the Graph API
 

--- a/modules/ROOT/pages/deployment/services/s-list/idp.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/idp.adoc
@@ -10,7 +10,7 @@ include::partial$multi-location/compose-version.adoc[]
 
 {description}
 
-The IDP service is mainly suitable for smaller installations. The recommendation for larger setups is to replace IDP with and external OpenID Connect Provider. See the {download-gh-directory-url}?url={compose_url}v{compose_version}{compose_final_path}/ocis_keycloak[ocis_keycloak,window=_blank] deployment example on github for more details.
+The IDP service is mainly suitable for smaller installations. The recommendation for larger setups is to replace IDP with and external OpenID Connect Provider. See the {download-gh-directory-url}?url={compose_url}{compose_version}{compose_final_path}/ocis_keycloak[ocis_keycloak,window=_blank] deployment example on github for more details.
 
 By default, the IDP service is configured to use the Infinite Scale xref:{s-path}/idm.adoc[IDM service] as its LDAP backend for looking up and authenticating users. Other backends like an external LDAP server can be configured via a set of environment variables. For details see below.
 

--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -188,7 +188,7 @@ For Infinite Scale, external resources like an IDP (e.g. Keycloak) or when using
 
 To create a Content Security Policy (CSP), you need to create a yaml file containing the CSP definitions. To activate the settings, reference the file as value in the `PROXY_CSP_CONFIG_FILE_LOCATION` environment variable. For each change, a restart of the Infinite Scale deployment or the proxy service is required.
 
-A working example for a CSP can be found in a sub path of the `config` directory of the {compose_url}v{compose_version}{compose_final_path}/{ocis_wopi}[{ocis_wopi},window=_blank] deployment example which is the base for our xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] and the xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner].
+A working example for a CSP can be found in a sub path of the `config` directory of the {compose_url}{compose_version}{compose_final_path}/{ocis_wopi}[{ocis_wopi},window=_blank] deployment example which is the base for our xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] and the xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner].
 
 See the https://content-security-policy.com[Content Security Policy (CSP) Quick Reference Guide,window=_blank] for a description of directives.
 

--- a/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
+++ b/modules/ROOT/partials/depl-examples/ubuntu-compose/shared-setup.adoc
@@ -246,7 +246,7 @@ NOTE: The client to download the example is not the server you upload to. The se
 
 NOTE: The client from where you download the example via a browser and upload it using `scp` must have granted access to the server and have the `scp` app installed.
 
-To download and extract the necessary deployment example footnote:[Derived from the {compose_url}v{compose_version}{compose_final_path}/{ocis_wopi}/[{ocis_wopi}, window=_blank] developer example], *open a browser* and enter the following URL:
+To download and extract the necessary deployment example footnote:[Derived from the {compose_url}{compose_version}{compose_final_path}/{ocis_wopi}/[{ocis_wopi}, window=_blank] developer example], *open a browser* and enter the following URL:
 
 //[source,url,subs="attributes+,+macros"]
 //----
@@ -254,7 +254,7 @@ To download and extract the necessary deployment example footnote:[Derived from 
 
 [.gray-light-background]
 ****
-{download-gh-directory-url}?url={compose_url}v{compose_version}{compose_final_path}/{ocis_wopi}[,window=_blank]
+{download-gh-directory-url}?url={compose_url}{compose_version}{compose_final_path}/{ocis_wopi}[,window=_blank]
 ****
 
 The `.zip` file will be downloaded into your local `Download` directory.
@@ -263,7 +263,7 @@ Transfer the `.zip` file created to the server by issuing the following command,
 
 [source,bash,subs="attributes+"]
 ----
-scp ~/Downloads/'owncloud ocis v{compose_version} deployments-examples_{ocis_wopi}.zip' root@182.83.2.94:/opt
+scp ~/Downloads/'owncloud ocis {compose_version} deployments-examples_{ocis_wopi}.zip' root@182.83.2.94:/opt
 ----
 
 Note that the command differs a bit on Windows due to way how the home directory and the path separator is defined.
@@ -286,7 +286,7 @@ mkdir -p /opt/compose/ocis/{ocis_wopi}
 [source,bash,subs="attributes+"]
 ----
 unzip -d /opt/compose/ocis/{ocis_wopi} \
-  /opt/'owncloud ocis v{compose_version} deployments-examples_{ocis_wopi}.zip'
+  /opt/'owncloud ocis {compose_version} deployments-examples_{ocis_wopi}.zip'
 ----
 
 * When files have been extracted, list the directory with:

--- a/modules/ROOT/partials/multi-location/compose-version.adoc
+++ b/modules/ROOT/partials/multi-location/compose-version.adoc
@@ -9,14 +9,16 @@ compose_tab_text:         is either master or a stable version defined in antora
 ////
 
 // production (because it is an own branch)
-:compose_version: {compose_tab_text}
+// antora.yml: like master or stable-7.1
+:compose_version: {ocis_repo_url_component}
 :version-type: production
 :download-type: stable
 
 ifeval::["{antora-component-version}" == "next"]
 
 // rolling (it is in the master branch which is next)
-:compose_version: {ocis-rolling-version}
+// global-attrtibutes.yml: like v6.6.1
+:compose_version: v{ocis-rolling-version}
 :version-type: rolling
 :download-type: rolling
 endif::[]


### PR DESCRIPTION
References: #1140 (For 7.1, use the real 7.1 related branches in antora.yml)

This PR simplifies respectively removes unused attributes including paths when these attributes are used.

Needs a _careful_ backport to 7.1 ONLY 