### PR TITLE
Prepare content update for 7.2

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -51,7 +51,7 @@ asciidoc:
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 7.0.0-7.1.0-added.adoc or 7.0.0-7.1.0-removed.adoc
     # note that the name must be exactly how it is defined in the ocis repo to access the source files!
-    env_var_delta_name: '7.0.0-7.1.0'
+    env_var_delta_name: '7.1.0-7.2.0'
 
     # set attributes defining path components which will be assembled in the document
     compose_url: 'https://github.com/owncloud/ocis/tree/'

--- a/modules/ROOT/pages/deployment/services/env-var-changes.adoc
+++ b/modules/ROOT/pages/deployment/services/env-var-changes.adoc
@@ -1,9 +1,14 @@
 # Changed Environment Variables in Versions
 :toc: right
-:description: This page contains tables with added and removed environment variables between Infinite Scale version 7.0.0 and 7.1.0.
+:description: This page contains tables with added and removed environment variables between Infinite Scale version 7.1.0 and 7.2.0.
 
 :source_path: {ocis_services_raw_url}{service_url_component}{ocis_services_final_path}adoc/env-var-deltas/
-// https://raw.githubusercontent.com/owncloud/ocis/docs-stable-7.0/services/_includes/adoc/env-var-deltas/
+////
+ocis_services_raw_url:    https://raw.githubusercontent.com/owncloud/ocis/
+service_url_component:    docs || docs-stable-7.2
+ocis_services_final_path: /services/_includes/
+env_var_delta_name:       7.1.0-7.2.0
+////
 
 == Introduction
 

--- a/modules/ROOT/pages/maintenance/commands/changed-cli.adoc
+++ b/modules/ROOT/pages/maintenance/commands/changed-cli.adoc
@@ -1,6 +1,6 @@
 = Changed or Added CLI Commands
 :toc: right
-:description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 7.0.0 and 7.1.0.
+:description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 7.1.0 and 7.2.0.
 
 == Introduction
 
@@ -10,5 +10,5 @@
 
 See the link for a detailed description of the respective CLI command if available.
 
-* xref:maintenance/commands/commands.adoc#sending-grouped-emails[Sending Grouped Emails] +
-The `ocis auth-app create` command allows creating tokens to authenticate 3rd party access.
+* xref:maintenance/commands/commands.adoc#manage-expired-or-stale-uploads[Manage Expired or Stale Uploads] +
+The `ocis storage-users uploads delete-stale-nodes` command deletes all nodes that are in processing state and not referenced by an upload session.

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -19,6 +19,20 @@ IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrad
 
 IMPORTANT: When upgrading from an older release to the desired one, mandatory configuration settings may have been added or removed. To see the changes required, you can run `ocis init --diff` after upgrading but before finally starting. For more details, see the xref:deployment/general/ocis-init.adoc[ocis init command] description.
 
+== Version 7.1.0 to 7.2.0
+
+=== Notable Changes Requiring Manual Intervention
+
+There are no notable changes requiring manual intervention in Infinite Scale 7.2
+
+=== Breaking Changes Requiring Manual Intervention
+
+There are no breaking changes in Infinite Scale 7.2
+
+=== Upgrade Steps
+
+For a detailed description of the steps to upgrade, see the xref:migration/upgrading_7.1.0_7.2.0.adoc[Upgrading from 7.1.0 to 7.2.0] documentation. Note that this document also contains references to added/changed/removed CLI commands and environment variables.
+
 == Version 7.0.0 to 7.1.0
 
 === Notable Changes Requiring Manual Intervention

--- a/modules/ROOT/pages/migration/upgrading_7.1.0_7.2.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.1.0_7.2.0.adoc
@@ -1,0 +1,95 @@
+= Upgrading from 7.1.0 to 7.2.0
+:toc: right
+:description: This document describes the necessary steps when upgrading Infinite Scale from release 7.1.0 to 7.2.0.
+
+:actual_seven_version: 7.2.0
+
+include::partial$multi-location/compose-version.adoc[]
+
+== Introduction
+
+{description}
+
+IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#introduction[Upgrading Infinite Scale] documentation before you start.
+
+IMPORTANT: Check below, if you are affected by breaking changes and prepare all steps mentioned before you start the upgrade.
+
+== Upgrade Steps
+
+. Download and install Infinite Scale +
+*Do not start it after downloading the image*!
+. Shut down the Infinite Scale instance
+. We strongly recommend doing a backup
+. Reconfigure the deployment
+. Manage Breaking Changes
+. Manage Added/Removed/Deprecated environment variables
+. Start Infinite Scale
+
+:sectnums:
+
+== Download and Install Infinite Scale
+
+Download and install Infinite Scale:
+
+* Issue the following command to download the new image:
++
+[source,bash,subs="attributes+"]
+----
+docker pull owncloud/ocis:{actual_seven_version}
+----
+
+== Shut Down the Infinite Scale Instance
+
+Depending how you deployed Infinite Scale, you need to shut it down differently.
+
+* *docker compose* +
+For deployments using `docker compose` do a graceful shutdown as described in xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#stop-the-deployment[Stop the Deployment].
+
+* *Any other image based deployment* +
+For any other image based deployment, shut down Infinite Scale according the vendors deployment description.
+
+== Backup of Infinite Scale
+
+See the xref:maintenance/b-r/backup_considerations.adoc[Backup Considerations] and the xref:maintenance/b-r/backup.adoc[Backup] documentation for more details.
+
+== Reconfigure the Deployment
+
+Reconfigure the deployment to use the new image:
+
+* For binary, nothing extra needs to be done
+
+* When using `docker compose`
+** Update _every_ compose file where the `ocis image` is referenced accordingly.
+** If you have used the deployment examples either for xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] or xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner], read the *Updating and Upgrading* section of those pages carefully. 
+
+== Manage Breaking Changes
+
+* There are no breaking changes in Infinite Scale 7.2
+
+== Added-Removed-Deprecated Environment Variables
+
+* See the xref:deployment/services/env-var-changes.adoc[Changed Environment Variables in Versions] for more details.
+
+== Reconfigure web Office Document Deployments
+
+The following steps are based on the xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] deployment example. The steps are identical for the xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner].
+
+* Backup the the base folder containing the existing deployment example by renaming it. +
+You will need your configuration details with the new example.
+
+* Follow the xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#download-and-transfer-the-example[Download and Transfer Example] to get the new deployment and extract it as described in the following section of the guide.
+
+* Reconfigure the new `.env` file based on settings made in the `.env` file of the backup. +
+Note that the `WOPISERVER_DOMAIN` is no longer required since all collaboration traffic is now handled via the internal Docker network. While it does no harm if the DNS configuration and certificate continues to exist, it should be removed for consistency reasons.
+
+== Start Infinite Scale
+
+When you have finished upgrading, you now can start Infinite Scale as usual.
+
+For any deployment used, you now can delete/remove old binaries or images/containers.
+
+:sectnums!:
+
+== Changed or Added CLI Commands
+
+See the xref:maintenance/commands/changed-cli.adoc[Changed or Added CLI Commands] document for details.


### PR DESCRIPTION
This PR prepares the content update for 7.2.

No backport, 7.2.0 will derive from master.

Tested locally, renders fine.