### PR TITLE
Add changed envvar link to migration document

### DIFF
--- a/modules/ROOT/pages/migration/upgrading_7.1.0_7.2.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.1.0_7.2.0.adoc
@@ -93,3 +93,7 @@ For any deployment used, you now can delete/remove old binaries or images/contai
 == Changed or Added CLI Commands
 
 See the xref:maintenance/commands/changed-cli.adoc[Changed or Added CLI Commands] document for details.
+
+== Changed Environment Variables
+
+See the xref:deployment/services/env-var-changes.adoc[Changed Environment Variables in Versions] document for details.


### PR DESCRIPTION
Add link for completeness and ease of finding

Backport to 7.2
7.1 needs an own PR but no backport because it is a different file