### PR TITLE
[7.1] [PR 1176] Add changed envvar link

### DIFF
--- a/modules/ROOT/pages/migration/upgrading_7.0.0_7.1.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.0.0_7.1.0.adoc
@@ -87,3 +87,7 @@ For any deployment used, you now can delete/remove old binaries or images/contai
 == Changed or Added CLI Commands
 
 See the xref:maintenance/commands/changed-cli.adoc[Changed or Added CLI Commands] document for details.
+
+== Changed Environment Variables
+
+See the xref:deployment/services/env-var-changes.adoc[Changed Environment Variables in Versions] document for details.


### PR DESCRIPTION
Refernces: #1176 (Add changed envvar link to migration document)(master)

This is a kind of backport of the change made in master but to the correct document which is different in 7.1
