### PR TITLE
Fix storage-users command for resume non virus infected

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-users.adoc
@@ -199,7 +199,7 @@ ocis storage-users uploads sessions \
 [source,bash]
 ----
 ocis storage-users uploads sessions \
-     --processing=false \
+     --processing=true \
      --has-virus=false \
      --resume
 ----


### PR DESCRIPTION
Fixes: #1180 (Update Storage-Users docs)

`--processing=false` --> `--processing=true`

Backport to 7.2 and 7.1