### PR TITLE
Add proxy - Strict Transport Security Header

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/proxy.adoc
@@ -344,7 +344,7 @@ Infinite Scale cannot always determine whether the entire communication chain be
                  Termination                Unsecured               Unsecured
 ----
 
-As you can see in Figure 2, the entire chain is secured by HTTPS, and the headers will be sent accordingly. The other figures illustrate that, although the client has a secure connection, the subsequent connection is insecure. The Infinite Scale proxy service detects this and sends back headers for an insecure connection.
+As you can see in Figure 2, the entire chain is secured by HTTPS, and the headers will be sent accordingly. The other figures illustrate that, although the client has a secure connection, the subsequent connection is insecure. Because the Infinite Scale proxy service can only detect his connection, it sends back headers for an insecure connection.
 
 To mitigate this issue, set the environment variable `PROXY_FORCE_STRICT_TRANSPORT_SECURITY` to true. This forces the sending of Strict-Transport-Security headers on all responses.
 


### PR DESCRIPTION
Fixes: #1208 (Proxy: Strict-Transport-Security via proxy)

Adding a description for the new envvar `PROXY_FORCE_STRICT_TRANSPORT_SECURITY`.

Note that the text based images finally render as svg such as:
<img width="624" height="183" alt="image" src="https://github.com/user-attachments/assets/bf5eafd7-d41e-496e-a5bd-fb6162b35e8b" />
