### PR TITLE
Prepare for ocis 8.0

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -50,7 +50,7 @@ asciidoc:
     # this is the first part of the name for envvars between major versions that will be added or removed
     # example for full name: 7.0.0-7.1.0-added.adoc or 7.0.0-7.1.0-removed.adoc
     # note that the name must be exactly how it is defined in the ocis repo to access the source files!
-    env_var_delta_name: '7.2.0-7.3.0'
+    env_var_delta_name: '7.3.0-8.0.0'
 
     # set attributes defining path components which will be assembled in the document
     compose_url: 'https://github.com/owncloud/ocis/tree/'

--- a/modules/ROOT/pages/deployment/services/env-var-changes.adoc
+++ b/modules/ROOT/pages/deployment/services/env-var-changes.adoc
@@ -1,14 +1,16 @@
 # Changed Environment Variables in Versions
 :toc: right
-:description: This page contains tables with added and removed environment variables between Infinite Scale version 7.2.0 and 7.3.0.
+:description: This page contains tables with added and removed environment variables between Infinite Scale version 7.3.0 and 8.0.0.
 
 :source_path: {ocis_services_raw_url}{service_url_component}{ocis_services_env_var_deltas_path}
 
 ////
+to be set in antora.yml
+
 ocis_services_raw_url:             https://raw.githubusercontent.com/owncloud/ocis/
-service_url_component:             docs || docs-stable-7.3
+service_url_component:             docs || docs-stable-8.0
 ocis_services_env_var_deltas_path: /services/general-info/envvars/env-var-deltas/
-env_var_delta_name:                7.2.0-7.3.0
+env_var_delta_name:                7.3.0-8.0.0
 ////
 
 == Introduction

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -19,6 +19,21 @@ IMPORTANT: When upgrading from an older release to the desired one, *ALL* upgrad
 
 IMPORTANT: When upgrading from an older release to the desired one, mandatory configuration settings may have been added or removed. To see the changes required, you can run `ocis init --diff` after upgrading but before finally starting. For more details, see the xref:deployment/general/ocis-init.adoc[ocis init command] description.
 
+== Version 7.3.0 to 8.0.0
+
+=== Notable Changes Requiring Manual Intervention
+
+There are no notable changes requiring manual intervention in Infinite Scale 8.0
+
+=== Breaking Changes Requiring Manual Intervention
+
+There are breaking changes in Infinite Scale 8.0
+
+=== Upgrade Steps
+
+For a detailed description of the steps to upgrade, see the xref:migration/upgrading_7.3.0_8.0.0.adoc[Upgrading from 7.3.0 to 8.0.0] documentation. Note that this document also contains references to added/changed/removed CLI commands and environment variables.
+
+
 == Version 7.2.0 to 7.3.0
 
 === Notable Changes Requiring Manual Intervention

--- a/modules/ROOT/pages/migration/upgrading_7.3.0_8.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.3.0_8.0.0.adoc
@@ -1,0 +1,106 @@
+= Upgrading from 7.3.0 to 8.0.0
+:toc: right
+:description: This document describes the necessary steps when upgrading Infinite Scale from release 7.3.0 to 8.0.0.
+
+:actual_seven_version: 8.0.0
+
+include::partial$multi-location/compose-version.adoc[]
+
+== Introduction
+
+{description}
+
+IMPORTANT: Read the important notes in the xref:migration/upgrading-ocis.adoc#introduction[Upgrading Infinite Scale] documentation before you start.
+
+IMPORTANT: Check below, if you are affected by breaking changes and prepare all steps mentioned before you start the upgrade.
+
+== Upgrade Steps
+
+. Download and install Infinite Scale +
+*Do not start it after downloading the image*!
+. Shut down the Infinite Scale instance
+. We strongly recommend doing a backup
+. Reconfigure the deployment
+. Manage Breaking Changes
+. Manage Added/Removed/Deprecated environment variables
+. Start Infinite Scale
+
+:sectnums:
+
+== Download and Install Infinite Scale
+
+Download and install Infinite Scale:
+
+* Issue the following command to download the new image:
++
+[source,bash,subs="attributes+"]
+----
+docker pull owncloud/ocis:{actual_seven_version}
+----
+
+== Shut Down the Infinite Scale Instance
+
+Depending how you deployed Infinite Scale, you need to shut it down differently.
+
+* *docker compose* +
+For deployments using `docker compose` do a graceful shutdown as described in xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#stop-the-deployment[Stop the Deployment].
+
+* *Any other image based deployment* +
+For any other image based deployment, shut down Infinite Scale according the vendors deployment description.
+
+== Backup of Infinite Scale
+
+See the xref:maintenance/b-r/backup_considerations.adoc[Backup Considerations] and the xref:maintenance/b-r/backup.adoc[Backup] documentation for more details.
+
+== Reconfigure the Deployment
+
+Reconfigure the deployment to use the new image:
+
+* For `docker compose`
+** Update _every_ compose file where the `ocis image` is referenced accordingly.
+** If you have used the deployment examples either for xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] or xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner], read the *Updating and Upgrading* section of those pages carefully. 
+
+== Manage Breaking Changes
+
+There are breaking changes in Infinite Scale 8.0
+
+== Added-Removed-Deprecated Environment Variables
+
+* See the xref:deployment/services/env-var-changes.adoc[Changed Environment Variables in Versions] for more details.
+
+== Reconfigure Deployment Examples
+
+The following steps are based on the xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc[Local Production Setup] deployment example. The steps are identical for the xref:depl-examples/ubuntu-compose/ubuntu-compose-hetzner.adoc[Deployment on Hetzner].
+
+* Stop the deployment example
+
+* Backup the the base folder containing the existing deployment example by renaming it. +
+You will need your configuration details with the new example.
+
+* Follow the xref:depl-examples/ubuntu-compose/ubuntu-compose-prod.adoc#download-and-transfer-the-example[Download and Transfer Example] link to get the new deployment and extract it as described in the following section of the guide.
+
+* Reconfigure the new `.env` file based on settings made in the `.env` file of the backup.
+** Note that defined image versions have changed for: +
+`Traefik`, `Collabora` and `OnlyOffice`. +
+The provided versions have been tested. Update at your own risk. Note that this applies in particular when using `latest`. The image versions are subject to change if a new deployment example is provided.
+
+** The version of other images using the `latest` tag may also have changed.
+** Pull the new image versions with `docker compose pull`.
+
+* Start the deployment example.
+
+== Start Infinite Scale
+
+When you have finished upgrading, you now can start Infinite Scale as usual.
+
+For any deployment used, you now can delete/remove old binaries or images/containers.
+
+:sectnums!:
+
+== Changed or Added CLI Commands
+
+See the xref:maintenance/commands/changed-cli.adoc[Changed or Added CLI Commands] document for details.
+
+== Changed Environment Variables
+
+See the xref:deployment/services/env-var-changes.adoc[Changed Environment Variables in Versions] document for details.


### PR DESCRIPTION
This PR prepares for the new ocis release 8.0.0 (curie).

Works, renders fine locally.
Any text changes can go as independent PR's.
Any envvar changes are done anyways in the ocis repo and referenced automatically.
This PR can safely be merged.

**IMPORTANT**
`antora.yml` will be adapted in the upcoming 8.0 branch here after merging this one. But merging the 8.0 branch must be done after all branches (stable-8.0, docs-stable-8.0) are available in the ocis repo.