### PR TITLE
missing stuff for ocis 8.0

### DIFF
--- a/modules/ROOT/pages/deployment/services/s-list/storage-publiclink.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/storage-publiclink.adoc
@@ -14,6 +14,44 @@
 
 * Storage-Publiclink listens on port 9175 by default.
 
+== Brute Force Protection
+
+Brute force protection prevents access to public links if incorrect passwords are entered. Its implementation is very similar to that of a rate limiter, but it takes into account only incorrect password attempts.
+
+[NOTE]
+====
+This feature:
+
+* Is enabled by default with the standard settings. +
+To disable the feature, set the relevant configuration values to 0.
+* If enabled, brute force protection uses a configurable store, see section xref:#storing[Storing]. No additional configuration is required if the global configuration (OCIS_) is used alongside the other default store settings.
+====
+
+By default, you're allowed a maximum of 5 failed attempts in 1 hour:
+
+* `STORAGE_PUBLICLINK_BRUTEFORCE_TIMEGAP=1h`
+* `STORAGE_PUBLICLINK_BRUTEFORCE_MAXATTEMPTS=5`
+
+You can adjust these values as you wish to define the failure rate threshold.
+
+[IMPORTANT]
+====
+* If a public link is blocked by brute force protection, it will be blocked for all users, regardless of whether an attempt has been successful in the meantime.
+* If the failure rate threshold is exceeded, the public link will be blocked until such rate goes below the threshold.
+** This means that it will remain blocked for an undefined time: a couple of seconds in the best case, or up to the setting of `STORAGE_PUBLICLINK_BRUTEFORCE_TIMEGAP` in the worst case.
+** After blocking, each new unsuccessful attempt retriggers the timer.
+====
+
+== Storing
+
+// renders dependent on is_cache or is_store
+:is_store: true
+// add a manual anchor + text because the service does not use the event bus
+:no_event_bus: true
+
+// get the complete .adoc page but do not render any contained tag directive when found in the middle
+include::partial$multi-location/cache-store.adoc[tag=**]
+
 == Configuration
 
 include::partial$deployment/services/env-and-yaml.adoc[tag=envvars-yaml]

--- a/modules/ROOT/pages/maintenance/commands/changed-cli.adoc
+++ b/modules/ROOT/pages/maintenance/commands/changed-cli.adoc
@@ -1,6 +1,6 @@
 = Changed or Added CLI Commands
 :toc: right
-:description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 7.3.0 and 7.4.0.
+:description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 7.3.0 and 8.0.0.
 
 == Introduction
 

--- a/modules/ROOT/pages/migration/upgrading-ocis.adoc
+++ b/modules/ROOT/pages/migration/upgrading-ocis.adoc
@@ -23,11 +23,11 @@ IMPORTANT: When upgrading from an older release to the desired one, mandatory co
 
 === Notable Changes Requiring Manual Intervention
 
-There are no notable changes requiring manual intervention in Infinite Scale 8.0
+There are no changes in Infinite Scale 8.0 that require manual intervention, but other notable changes have been implemented.
 
 === Breaking Changes Requiring Manual Intervention
 
-There are breaking changes in Infinite Scale 8.0
+There are breaking changes in Infinite Scale 8.0 that only apply when using the OCM service.
 
 === Upgrade Steps
 

--- a/modules/ROOT/pages/migration/upgrading_7.3.0_8.0.0.adoc
+++ b/modules/ROOT/pages/migration/upgrading_7.3.0_8.0.0.adoc
@@ -22,6 +22,7 @@ IMPORTANT: Check below, if you are affected by breaking changes and prepare all 
 . We strongly recommend doing a backup
 . Reconfigure the deployment
 . Manage Breaking Changes
+. Notabale Changes
 . Manage Added/Removed/Deprecated environment variables
 . Start Infinite Scale
 
@@ -62,11 +63,14 @@ Reconfigure the deployment to use the new image:
 
 == Manage Breaking Changes
 
-There are breaking changes in Infinite Scale 8.0
+Breaking changes only apply when using OCM. +
+These changes mean, that OCM is now fully compatible with other Open Cloud Mesh services and can be federated with them. As drawback, all OCM invitations and shares no longer work and must be resetup.
 
-== Added-Removed-Deprecated Environment Variables
+== Notabale Changes
 
-* See the xref:deployment/services/env-var-changes.adoc[Changed Environment Variables in Versions] for more details.
+* A new feature has been implemented to protect against brute-force password attacks when using public links. This feature is enabled by default. See the xref:{s-path}/storage-publiclink.adoc#brute-force-protection[Storage-Publiclink] service for more details.
+
+* Some deprecated environment variables have finally been removed. If you are using them, you can remove them from your config. For details see the xref:#changed-environment-variables[Changed Environment Variables] section below.
 
 == Reconfigure Deployment Examples
 


### PR DESCRIPTION
This is missing content for ocis 8.0 - as far I know it...

**IMPORTANT:** This PR does not change internal variables in `antora.yml` required to be present in the 8.0 docs branch. This will be made with an independent PR because some changes require branches in the ocis repo that are currently not present and will be created when the final release is made.

The PR is safe to merge, I can afterwards create the 8.0 branch and **prepare** the docs branch using it. Any upcoming changes then just need to be backported to the 8.0 branch.