### PR TITLE
Changes nexessary for 8.0

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -6,7 +6,7 @@ def main(ctx):
     # Version shown as latest in generated documentations
     # It's fine that this is out of date in version branches, usually just needs
     # adjustment in master/deployment_branch when a new version is added to site.yml
-    latest_version = "7.3"
+    latest_version = "8.0"
     default_branch = "master"
 
     # Current version branch (used to determine when changes are supposed to be pushed)

--- a/antora.yml
+++ b/antora.yml
@@ -39,7 +39,7 @@ asciidoc:
     # this always points to the latest stable branch such as 'stable-7.2'
     # this branch also includes patches if any
     # used for links where you would else download from master but the content better comes from stable
-    ocis_repo_url_stable: 'stable-7.3'
+    ocis_repo_url_stable: 'stable-8.0'
 
     # service_tab_text will be used as tab text shown for the tables in services only
     # note when literally changing the word 'master' to something else, you also must adapt 'env-and-yaml.adoc'.

--- a/docs/new-version-branch.md
+++ b/docs/new-version-branch.md
@@ -20,7 +20,8 @@ This step creates the branch locally, necessary for content changes and for the 
 1.  Check in `site.yml` in section `content.sources` that the following value is set: `- url: .` and in `content.sources.url` the following value is set: `- HEAD`.
 1.  In `antora.yml`, set the `version:` key on top to the same as the branch name like `x.y`. Each branch must have it's unique version!
 1.  In `antora.yml`, in section `asciidoc.attributes`, DO NOT adjust relevant `xxx-ocis-version` keys. They are required for local building.
-1.  In `antora.yml`, in section `asciidoc.attributes`, adjust all other keys if required. They are used to set targets and define variable data for this version.
+1.  In `antora.yml`, in section `asciidoc.attributes`, adjust all other keys if required. They are used to set targets and define variable data for this version. +
+Note that the docs-stablex.y branch may currently not exist in ocis. The setting needs to be changed when available in the respective x.y branch.
 1.  In `site.yml`, in section `asciidoc.attributes`, DO NOT adjust relevant `-version` keys. They are used for local building and will be correctly set in the docs repo when doing a full build. NOTE: any attribute values defined here overwrites any attributes included via the `load-global-site-attributes.js` extension. 
 1.  Run a build by entering `npm run antora-local`. No build errors should occur.
 1.  Commit the changes and push the new `x.y` branch. This makes the branch available for futher processing. DO NOT CREATE A PR!


### PR DESCRIPTION
These are the changes necessary to finalize the creation of the 8.0 branch.

* The 8.0 branch is already pushed, prepared and is included in the branch protection rules.

* Note that this PR can be merged at any time but:
  * must be merged **before** applying content changes and
  * **before** merging the docs PR to include this version.

* Post merging this, we need to backport all relevant changes created in master to 8.0

Note that the referenced branch in ocis gathering docs content is still on 7.3 because the docs-stable-8.0 branch does not exist. This needs an extra PR when the branch is available that requires backporting to 8.0
 
@mmattel @kobergj 