### PR TITLE
fix: add missing page-aliases

### DIFF
--- a/modules/admin/pages/maintenance/commands/backup-consistency.adoc
+++ b/modules/admin/pages/maintenance/commands/backup-consistency.adoc
@@ -1,4 +1,5 @@
 = Backup Consistency
+:page-aliases: ROOT:maintenance/b-r/backup-consistency.adoc
 
 The backup consistency command allows inspecting the consistency of an Infinite Scale storage:
 

--- a/modules/admin/pages/maintenance/commands/changed-cli.adoc
+++ b/modules/admin/pages/maintenance/commands/changed-cli.adoc
@@ -1,6 +1,7 @@
 = Changed or Added CLI Commands
 :toc: right
 :description: This page contains a list with added, changed or removed CLI commands between Infinite Scale version 7.3.0 and 8.0.0.
+:page-aliases: ROOT:maintenance/b-r/changed-cli.adoc
 
 == Introduction
 

--- a/modules/admin/pages/maintenance/commands/cleanup-orphaned-grants.adoc
+++ b/modules/admin/pages/maintenance/commands/cleanup-orphaned-grants.adoc
@@ -1,5 +1,6 @@
 = Cleanup Orphaned Grants
-:toc:
+:toc: right
+:page-aliases: ROOT:maintenance/b-r/cleanup-orphaned-grants.adoc
 
 Detect and optionally delete storage grants that have no corresponding share-manager entry.
 

--- a/modules/admin/pages/maintenance/commands/cleanup-orphaned-shares.adoc
+++ b/modules/admin/pages/maintenance/commands/cleanup-orphaned-shares.adoc
@@ -1,6 +1,6 @@
 = Cleanup Orphaned Shares
-:page-aliases: shares-cleanup.adoc
-:toc:
+:toc: right
+:page-aliases: ROOT:maintenance/b-r/cleanup-orphaned-shares.adoc
 
 Use this CLI command to clean up shared space or directory orphans when a shared space or directory is deleted. This cannot be done automatically at the moment.
 

--- a/modules/admin/pages/maintenance/commands/move-stuck-uploads.adoc
+++ b/modules/admin/pages/maintenance/commands/move-stuck-uploads.adoc
@@ -1,4 +1,6 @@
 = Move Stuck Uploads
+:toc: right
+:page-aliases: ROOT:maintenance/b-r/move-stuck-uploads.adoc
 
 Detect and optionally move stuck uploads.
 

--- a/modules/admin/pages/maintenance/commands/node-metadata.adoc
+++ b/modules/admin/pages/maintenance/commands/node-metadata.adoc
@@ -1,4 +1,5 @@
 = Inspect and Manipulate Node Metadata
+:page-aliases: ROOT:maintenance/b-r/node-metadata.adoc
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 

--- a/modules/admin/pages/maintenance/commands/node-tree-size.adoc
+++ b/modules/admin/pages/maintenance/commands/node-tree-size.adoc
@@ -1,4 +1,5 @@
 = Inspect and Repair Node Tree Sizes
+:page-aliases: ROOT:maintenance/b-r/node-tree-size.adoc
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 

--- a/modules/admin/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
+++ b/modules/admin/pages/maintenance/commands/rebuild-jsoncs3-indexes.adoc
@@ -1,4 +1,5 @@
 = Rebuild jsoncs3 Indexes
+:page-aliases: ROOT:maintenance/b-r/rebuild-jsoncs3-indexes.adoc
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support.
 

--- a/modules/admin/pages/maintenance/commands/revisions-cleanup.adoc
+++ b/modules/admin/pages/maintenance/commands/revisions-cleanup.adoc
@@ -1,4 +1,5 @@
 = Revisions Cleanup
+:page-aliases: ROOT:maintenance/b-r/revisions-cleanup.adoc
 
 The revisions command allows removing the revisions of files in the storage.
 

--- a/modules/admin/pages/maintenance/commands/rolling-back-and-forward.adoc
+++ b/modules/admin/pages/maintenance/commands/rolling-back-and-forward.adoc
@@ -1,4 +1,5 @@
 = Roll Back / Roll Forward Decomposedfs Migrations
+:page-aliases: ROOT:maintenance/b-r/rolling-back-and-forward.adoc
 
 WARNING: Use this command with absolute care. It is not intended to play around and should only be used on request and under supervision of ownCloud support. 
 

--- a/modules/admin/pages/maintenance/commands/service-health.adoc
+++ b/modules/admin/pages/maintenance/commands/service-health.adoc
@@ -1,4 +1,5 @@
 = Service Health
+:page-aliases: ROOT:maintenance/b-r/service-health.adoc
 
 The service health CLI command allows checking the health status of a service. If there are no issues found, nothing health related will get printed.
 

--- a/modules/admin/pages/maintenance/commands/trash.adoc
+++ b/modules/admin/pages/maintenance/commands/trash.adoc
@@ -1,4 +1,5 @@
 = Trash CLI
+:page-aliases: ROOT:maintenance/b-r/trash.adoc
 
 The trash CLI command allows removing empty folders from the trashbin. This should be used to speed up trash bin operations.
 


### PR DESCRIPTION
This PR adds page-aliases that were missed to add before because those pages are not part of the navigation but referenced thru other pages.

Backport to 8.0