### PR TITLE
docs: normalize legacy server product name to "ownCloud Classic" (7.3)

### DIFF
--- a/modules/ROOT/pages/architecture/architecture.adoc
+++ b/modules/ROOT/pages/architecture/architecture.adoc
@@ -73,7 +73,7 @@ For detailed information on the implementation of spaces, check out the https://
 
 ==== Federated Storage
 
-To create a truly federated storage architecture, Infinite Scale breaks down the ownCloud 10 user-specific namespace, which is assembled on the server side, and makes the individual parts accessible to clients as storage spaces and storage space registries.
+To create a truly federated storage architecture, Infinite Scale breaks down the ownCloud Classic user-specific namespace, which is assembled on the server side, and makes the individual parts accessible to clients as storage spaces and storage space registries.
 
 The diagram below shows the core concepts of the new architecture:
 

--- a/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/frontend.adoc
@@ -36,7 +36,7 @@ The datagateway endpoint, by default `/data`, forwards file up- and download req
 
 === ocs
 
-The ocs endpoint, by default `/ocs`, implements the ownCloud 10 Open Collaboration Services API by translating it into CS3 API requests. It can handle users, groups, capabilities and also implements the file sharing functionality on top of CS3. The `/ocs/v[12].php/cloud/user/signing-key` is currently handled by the dedicated xref:{s-path}/ocs.adoc[ocs] service.
+The ocs endpoint, by default `/ocs`, implements the ownCloud Classic Open Collaboration Services API by translating it into CS3 API requests. It can handle users, groups, capabilities and also implements the file sharing functionality on top of CS3. The `/ocs/v[12].php/cloud/user/signing-key` is currently handled by the dedicated xref:{s-path}/ocs.adoc[ocs] service.
 
 ==== Event Handler
 

--- a/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
+++ b/modules/ROOT/pages/deployment/services/s-list/userlog.adoc
@@ -26,7 +26,7 @@ Currently, the configuration which user-related events are of interest is hard-c
 
 == Retrieving
 
-The `userlog` service provides an API to retrieve configured events. For now, this API is mostly following the {oc10-api-url}[ownCloud Server notification GET API, window=_blank].
+The `userlog` service provides an API to retrieve configured events. For now, this API is mostly following the {oc10-api-url}[ownCloud Classic notification GET API, window=_blank].
 
 == Subscribing
 

--- a/modules/ROOT/pages/security/security.adoc
+++ b/modules/ROOT/pages/security/security.adoc
@@ -32,7 +32,7 @@ Infinite Scale provides a flexible role system, which allows the permissions of 
 
 === Extension System
 
-Compared to the apps/extensions in ownCloud 10, the Infinite Scale extensions/services are more secure because they are developed and deployed as standalone services. They communicate via APIs with the core services and therefore can only use specific interfaces instead of having direct access to storages and data. A single extension which behaves incorrectly cannot corrupt the whole system.
+Compared to the apps/extensions in ownCloud Classic, the Infinite Scale extensions/services are more secure because they are developed and deployed as standalone services. They communicate via APIs with the core services and therefore can only use specific interfaces instead of having direct access to storages and data. A single extension which behaves incorrectly cannot corrupt the whole system.
 
 === File-based storage
 

--- a/modules/ROOT/partials/nav.adoc
+++ b/modules/ROOT/partials/nav.adoc
@@ -101,5 +101,5 @@
 
 ////
 * Migration
-** xref:migration/index.adoc[Migrating from ownCloud 10 to ownCloud Infinite Scale]
+** xref:migration/index.adoc[Migrating from ownCloud Classic to ownCloud Infinite Scale]
 ////


### PR DESCRIPTION
## What

Normalizes the legacy ownCloud server product to its canonical name **ownCloud Classic** across all user-facing documentation in this repo. Version (10/11) is retained only as trailing information where relevant (e.g. "ownCloud Classic 10").

Normalized: `ownCloud Server`, `owncloud Server`, `ownCloud Classic Server`, and bare `ownCloud 10/11`.

## Why

Part of owncloud/docs#5111 — a coordinated, docs-only rebranding so the legacy product is consistently named **ownCloud Classic** across the `owncloud` / `owncloud-docker` orgs. Reference implementation: owncloud/docs-main#187.

## Out of scope (intentionally untouched)

- `xref:`/`include::` targets, module slugs (`classic_ui`, `oc10-app`), URLs, attribute names (e.g. `oc10-api-url`), image paths, anchors
- The new product names: **ownCloud Infinite Scale** / **oCIS**

## Verification

- All target variants normalized; only prose / headings / link display text changed.
- Every `xref`/`include`/URL **target** byte-for-byte identical before/after.
- `oCIS` / `Infinite Scale` occurrence count unchanged.
- No internal xref depends on any heading whose auto-generated anchor changes.

## Reviewer checklist

- [ ] No xref targets / module slugs / URLs altered
- [ ] oCIS / Infinite Scale untouched
- [ ] Version shown only as additional info ("ownCloud Classic 10")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
